### PR TITLE
fix(security): P1 backend security hardening

### DIFF
--- a/apps/backend/src/graphql/resolvers/__tests__/subscriptions.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/subscriptions.test.ts
@@ -124,19 +124,22 @@ describe('Subscription Resolvers', () => {
       ];
 
       vi.mocked(chargebeeService.getAvailablePlans).mockResolvedValue(mockPlans);
+      vi.mocked(betterAuthMiddleware.requireAuth).mockReturnValue(mockContext.auth as any);
 
-      const result = await subscriptionResolvers.Query.availablePlans();
+      const result = await subscriptionResolvers.Query.availablePlans({}, {}, mockContext);
 
       expect(result).toEqual(mockPlans);
       expect(chargebeeService.getAvailablePlans).toHaveBeenCalledTimes(1);
+      expect(betterAuthMiddleware.requireAuth).toHaveBeenCalledWith(mockContext.auth);
     });
 
     it('should handle errors from Chargebee service', async () => {
       vi.mocked(chargebeeService.getAvailablePlans).mockRejectedValue(
         new Error('Chargebee API error')
       );
+      vi.mocked(betterAuthMiddleware.requireAuth).mockReturnValue(mockContext.auth as any);
 
-      await expect(subscriptionResolvers.Query.availablePlans()).rejects.toThrow(
+      await expect(subscriptionResolvers.Query.availablePlans({}, {}, mockContext)).rejects.toThrow(
         'Chargebee API error'
       );
     });

--- a/apps/backend/src/graphql/resolvers/analytics.ts
+++ b/apps/backend/src/graphql/resolvers/analytics.ts
@@ -141,6 +141,8 @@ export const analyticsResolvers = {
 
     trackFormSubmission: async (_: any, { input }: { input: TrackFormSubmissionInput }, context: any) => {
       try {
+        validatePublicAnalyticsInput(input.sessionId, input.userAgent);
+
         // Get client IP from request
         const clientIP = context.req?.ip ||
           context.req?.connection?.remoteAddress ||

--- a/apps/backend/src/graphql/resolvers/formSharing.ts
+++ b/apps/backend/src/graphql/resolvers/formSharing.ts
@@ -102,8 +102,8 @@ export const formSharingResolvers = {
     formPermissions: async (_: any, { formId }: { formId: string }, context: { auth: BetterAuthContext }) => {
       requireAuth(context.auth);
 
-      // Check if user has access to manage permissions (must be owner or editor)
-      const accessCheck = await checkFormAccess(context.auth.user!.id, formId, PermissionLevel.EDITOR);
+      // Check if user has access to manage permissions (must be owner)
+      const accessCheck = await checkFormAccess(context.auth.user!.id, formId, PermissionLevel.OWNER);
       if (!accessCheck.hasAccess) {
         throw createGraphQLError('Access denied: Insufficient permissions', GRAPHQL_ERROR_CODES.NO_ACCESS);
       }

--- a/apps/backend/src/graphql/resolvers/subscriptions.ts
+++ b/apps/backend/src/graphql/resolvers/subscriptions.ts
@@ -22,7 +22,8 @@ export const subscriptionResolvers = {
      * Get available subscription plans with pricing
      * Fetches from Chargebee dynamically
      */
-    availablePlans: async () => {
+    availablePlans: async (_: any, __: any, context: { auth: BetterAuthContext }) => {
+      requireAuth(context.auth);
       return await getAvailablePlans();
     },
   },

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -317,6 +317,7 @@ async function startServer() {
 }
 
 startServer().catch((error) => {
+  Sentry.captureException(error);
   logger.error('Failed to start server:', error);
   process.exit(1);
 });

--- a/apps/backend/src/plugins/executor.ts
+++ b/apps/backend/src/plugins/executor.ts
@@ -3,6 +3,7 @@ import { getPluginHandler } from './registry.js';
 import { createPluginContext } from './context.js';
 import type { PluginEvent, PluginConfig } from './types.js';
 import { generateId } from '@dculus/utils';
+import * as Sentry from '@sentry/node';
 
 /**
  * Execute a single plugin
@@ -73,6 +74,7 @@ export const executePlugin = async (
 
     return { success: true };
   } catch (error: any) {
+    Sentry.captureException(error);
     context.logger.error(`Plugin execution failed: ${pluginId}`, error);
 
     // Record failed delivery
@@ -156,6 +158,7 @@ export const executePluginsForForm = async (
 
     return { total: plugins.length, succeeded, failed };
   } catch (error: any) {
+    Sentry.captureException(error);
     context.logger.error('Error executing plugins for form', error);
     throw error;
   }

--- a/apps/backend/src/routes/__tests__/upload.test.ts
+++ b/apps/backend/src/routes/__tests__/upload.test.ts
@@ -6,6 +6,7 @@ import { uploadFile } from '../../services/fileUploadService.js';
 import { prisma } from '../../lib/prisma.js';
 import { logger } from '../../lib/logger.js';
 import { auth } from '../../lib/better-auth.js';
+import * as formSharing from '../../graphql/resolvers/formSharing.js';
 
 // Mock dependencies
 vi.mock('../../services/fileUploadService.js');
@@ -42,6 +43,15 @@ vi.mock('../../lib/logger.js', () => ({
     warn: vi.fn(),
   },
 }));
+vi.mock('../../graphql/resolvers/formSharing.js', () => ({
+  checkFormAccess: vi.fn(),
+  PermissionLevel: {
+    OWNER: 'OWNER',
+    EDITOR: 'EDITOR',
+    VIEWER: 'VIEWER',
+    NO_ACCESS: 'NO_ACCESS',
+  },
+}));
 
 const mockUser = { id: 'user-123', email: 'test@example.com', role: 'user' };
 const mockForm = { id: 'form-123', createdById: 'user-123', organizationId: 'org-123' };
@@ -60,6 +70,8 @@ describe('Upload Routes', () => {
     vi.mocked(prisma.form.findUnique).mockResolvedValue(mockForm as any);
     vi.mocked(prisma.formPermission.findUnique).mockResolvedValue(null);
     vi.mocked(prisma.member.findFirst).mockResolvedValue({ role: 'owner' } as any);
+    // Default: checkFormAccess grants editor access for FormBackground uploads
+    vi.mocked(formSharing.checkFormAccess).mockResolvedValue({ hasAccess: true, permission: 'EDITOR', form: mockForm } as any);
   });
 
   afterEach(() => {

--- a/apps/backend/src/routes/upload.ts
+++ b/apps/backend/src/routes/upload.ts
@@ -12,6 +12,7 @@ import { randomUUID } from 'crypto';
 import { logger } from '../lib/logger.js';
 import { auth } from '../lib/better-auth.js';
 import { fromNodeHeaders } from 'better-auth/node';
+import { checkFormAccess, PermissionLevel } from '../graphql/resolvers/formSharing.js';
 
 // Allowed upload type values — prevents arbitrary path injection via type param
 const ALLOWED_UPLOAD_TYPES = new Set([
@@ -84,31 +85,9 @@ router.post('/upload', upload.single('file'), async (req, res) => {
       if (!callerUser) {
         return res.status(401).json({ error: 'Authentication required', code: 'UNAUTHENTICATED' });
       }
-      const bgForm = await prisma.form.findUnique({
-        where: { id: formId },
-        select: { id: true, createdById: true, organizationId: true },
-      });
-      if (!bgForm) {
-        return res.status(404).json({ error: 'Form not found', code: 'NOT_FOUND' });
-      }
-      const isOwner = bgForm.createdById === callerUser.id;
-      if (!isOwner) {
-        const explicitPermission = await prisma.formPermission.findUnique({
-          where: { formId_userId: { formId: bgForm.id, userId: callerUser.id } },
-          select: { permission: true },
-        });
-        const hasEditorPermission =
-          explicitPermission?.permission === 'EDITOR' ||
-          explicitPermission?.permission === 'OWNER';
-        const orgMembership = !hasEditorPermission
-          ? await prisma.member.findFirst({
-              where: { organizationId: bgForm.organizationId, userId: callerUser.id },
-              select: { role: true },
-            })
-          : null;
-        if (!hasEditorPermission && orgMembership?.role !== 'owner') {
-          return res.status(403).json({ error: 'EDITOR access required', code: 'FORBIDDEN' });
-        }
+      const accessCheck = await checkFormAccess(callerUser.id, formId, PermissionLevel.EDITOR);
+      if (!accessCheck.hasAccess) {
+        return res.status(403).json({ error: 'EDITOR access required for form background uploads', code: 'FORBIDDEN' });
       }
     } else if (type === 'UserAvatar') {
       if (!callerUser) {

--- a/apps/backend/src/services/chargebeeService.ts
+++ b/apps/backend/src/services/chargebeeService.ts
@@ -4,6 +4,7 @@ import { subscriptionRepository } from '../repositories/index.js';
 import { logger } from '../lib/logger.js';
 import { prisma } from '../lib/prisma.js';
 import { sendEmail } from './emailService.js';
+import * as Sentry from '@sentry/node';
 
 /**
  * Chargebee Service
@@ -344,6 +345,7 @@ export const handlePaymentFailed = async (event: any): Promise<void> => {
 
     logger.warn('[Chargebee Service] Payment failed — subscription marked past_due for org:', organizationId);
   } catch (error: any) {
+    Sentry.captureException(error);
     logger.error('[Chargebee Service] Error handling payment failure:', error);
     throw error;
   }

--- a/apps/backend/src/services/temporaryFileService.ts
+++ b/apps/backend/src/services/temporaryFileService.ts
@@ -3,6 +3,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { randomUUID } from 'crypto';
 import { s3Config } from '../lib/env.js';
 import { logger } from '../lib/logger.js';
+import * as Sentry from '@sentry/node';
 
 // Initialize S3 client for Cloudflare R2
 const s3Client = new S3Client({
@@ -145,6 +146,7 @@ export async function cleanupExpiredFiles(): Promise<{ deleted: number; errors: 
 
     logger.info(`Temp-file cleanup complete: ${deleted} deleted, ${errors} errors`);
   } catch (error) {
+    Sentry.captureException(error);
     logger.error('Error during temp-file cleanup:', error);
   }
 


### PR DESCRIPTION
## Summary

Implements P1-02, P1-03, P1-04, P1-05, P1-15 from the production readiness audit.

- **P1-02**: Add `validatePublicAnalyticsInput(sessionId, userAgent)` to `trackFormSubmission` resolver — was the only public analytics mutation missing this guard
- **P1-03**: Gate `availablePlans` resolver with `requireAuth` — previously unauthenticated, making live Chargebee API calls for anyone
- **P1-04**: Tighten `formPermissions` query to require `OWNER` permission (was `EDITOR`) — listing all collaborators with email addresses is an owner-only administrative action
- **P1-05**: Replace custom permission block in `FormBackground` upload route with `checkFormAccess(EDITOR)` — the old code missed the `ALL_ORG_MEMBERS + defaultPermission >= EDITOR` sharing-scope case
- **P1-15**: Add `Sentry.captureException` to critical error paths: `temporaryFileService.cleanupExpiredFiles`, `plugins/executor.ts` (both `executePlugin` and `executePluginsForForm`), `chargebeeService.handlePaymentFailed`, and `index.ts` `startServer().catch()`

## Test plan

- [x] `pnpm --filter backend type-check` passes (0 errors)
- [x] `pnpm test:unit` — all 1890 tests pass (upload and subscriptions test files updated to match new signatures)
- [x] No lint errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)