### PR TITLE
perf: P1 database indexes and query optimization

### DIFF
--- a/apps/backend/prisma/migrations/20250521000000_add_performance_indexes/migration.sql
+++ b/apps/backend/prisma/migrations/20250521000000_add_performance_indexes/migration.sql
@@ -1,0 +1,43 @@
+-- ============================================================
+-- P1-14: Add missing performance indexes
+--
+-- Rationale:
+--
+-- form_view_analytics / form_submission_analytics — sessionId composite:
+--   Analytics deduplication queries join or group by (formId, sessionId)
+--   to count unique visitors.  Without a covering index the planner
+--   must scan all rows for a given formId and then sort by sessionId
+--   in memory.  Adding (formId, sessionId) lets these lookups be served
+--   entirely from the index.
+--
+-- form — (organizationId, createdById) composite:
+--   The responses resolver fetches all forms for an org scoped to a
+--   specific creator (WHERE organizationId = ? AND createdById = ?).
+--   The existing single-column organizationId index is used for the
+--   first predicate but then requires a heap fetch + filter for
+--   createdById.  The composite index covers both predicates in one seek.
+--
+-- response — GIN index on data (jsonb_path_ops):
+--   Field-level filter queries on response.data use JSON path expressions
+--   (e.g.  data @> '{"fieldId": "value"}').  jsonb_path_ops is the
+--   narrow operator class that covers @> and @? operators, making it
+--   smaller and faster than the default jsonb_ops for path-containment
+--   queries.  Cannot be expressed in Prisma schema DSL so it is added
+--   here as raw SQL.
+-- ============================================================
+
+-- Composite index for analytics deduplication by session within a form
+CREATE INDEX IF NOT EXISTS "form_view_analytics_formId_sessionId_idx"
+  ON "form_view_analytics"("formId", "sessionId");
+
+CREATE INDEX IF NOT EXISTS "form_submission_analytics_formId_sessionId_idx"
+  ON "form_submission_analytics"("formId", "sessionId");
+
+-- Composite index for form queries filtered by org and creator
+CREATE INDEX IF NOT EXISTS "form_organizationId_createdById_idx"
+  ON "form"("organizationId", "createdById");
+
+-- GIN index on response.data for JSON path-containment queries
+-- Uses jsonb_path_ops (smaller, faster for @> and @? operators)
+CREATE INDEX IF NOT EXISTS "response_data_gin_idx"
+  ON "response" USING GIN (data jsonb_path_ops);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -156,6 +156,7 @@ model Form {
   plugins             FormPlugin[]
 
   @@index([organizationId])
+  @@index([organizationId, createdById])
   @@map("form")
 }
 
@@ -267,6 +268,7 @@ model FormViewAnalytics {
   form Form @relation(fields: [formId], references: [id], onDelete: Cascade)
 
   @@index([formId, viewedAt])
+  @@index([formId, sessionId])
   @@map("form_view_analytics")
 }
 
@@ -295,6 +297,7 @@ model FormSubmissionAnalytics {
   response Response @relation(fields: [responseId], references: [id], onDelete: Cascade)
 
   @@index([formId, submittedAt])
+  @@index([formId, sessionId])
   @@map("form_submission_analytics")
 }
 

--- a/apps/backend/src/services/__tests__/responseService.test.ts
+++ b/apps/backend/src/services/__tests__/responseService.test.ts
@@ -56,7 +56,7 @@ describe('Response Service', () => {
   });
 
   describe('getAllResponses', () => {
-    it('should return all responses for an organization', async () => {
+    it('should return all responses for an organization (capped at 10k)', async () => {
       const mockResponses = [mockResponse, { ...mockResponse, id: 'response-456' }];
       vi.mocked(responseRepository.findMany).mockResolvedValue(mockResponses as any);
 
@@ -65,13 +65,14 @@ describe('Response Service', () => {
       expect(responseRepository.findMany).toHaveBeenCalledWith({
         where: { form: { organizationId: 'org-123' } },
         orderBy: { submittedAt: 'desc' },
+        take: 10_000,
         include: { form: true },
       });
       expect(result).toHaveLength(2);
       expect(result[0].id).toBe('response-123');
     });
 
-    it('should return all responses when no organizationId provided', async () => {
+    it('should return all responses when no organizationId provided (capped at 10k)', async () => {
       vi.mocked(responseRepository.findMany).mockResolvedValue([mockResponse] as any);
 
       const result = await getAllResponses();
@@ -79,6 +80,7 @@ describe('Response Service', () => {
       expect(responseRepository.findMany).toHaveBeenCalledWith({
         where: {},
         orderBy: { submittedAt: 'desc' },
+        take: 10_000,
         include: { form: true },
       });
       expect(result).toHaveLength(1);

--- a/apps/backend/src/services/fieldAnalyticsService.ts
+++ b/apps/backend/src/services/fieldAnalyticsService.ts
@@ -850,24 +850,20 @@ export const processEmailFieldAnalytics = (
 };
 
 /**
- * Main function to get field analytics for any field type
+ * Private helper: compute analytics for a single field from a pre-fetched response set.
+ * Used by getAllFieldsAnalytics to avoid re-querying the DB for every field (N+1 fix).
  */
-export const getFieldAnalytics = async (
-  formId: string,
+const getFieldAnalyticsFromResponses = (
+  responses: Array<{ responseId: string; data: Record<string, any>; submittedAt: Date }>,
   fieldId: string,
   fieldType: FieldType,
   fieldLabel: string
-): Promise<FieldAnalytics> => {
-  // Get all form responses
-  const responses = await getFormResponses(formId);
+): FieldAnalytics => {
   const totalFormResponses = responses.length;
-
-  // Extract field values
   const fieldResponses = extractFieldValues(responses, fieldId);
 
   let result: FieldAnalytics;
 
-  // Process based on field type
   switch (fieldType) {
     case FieldType.TEXT_INPUT_FIELD:
     case FieldType.TEXT_AREA_FIELD:
@@ -906,6 +902,23 @@ export const getFieldAnalytics = async (
   }
 
   return result;
+};
+
+/**
+ * Main function to get field analytics for any field type.
+ * Fetches form responses from the DB once and delegates to getFieldAnalyticsFromResponses.
+ * Use getAllFieldsAnalytics when computing analytics for many fields — it fetches responses
+ * a single time for the entire form, avoiding the N+1 query problem.
+ */
+export const getFieldAnalytics = async (
+  formId: string,
+  fieldId: string,
+  fieldType: FieldType,
+  fieldLabel: string
+): Promise<FieldAnalytics> => {
+  // Get all form responses (single DB fetch)
+  const responses = await getFormResponses(formId);
+  return getFieldAnalyticsFromResponses(responses, fieldId, fieldType, fieldLabel);
 };
 
 /**
@@ -972,19 +985,14 @@ export const getAllFieldsAnalytics = async (formId: string): Promise<{
     });
   }
 
-  // Process fields in batches to avoid overwhelming the system
-  const batchSize = 5;
-  const fieldAnalytics: FieldAnalytics[] = [];
-
-  for (let i = 0; i < allFields.length; i += batchSize) {
-    const batch = allFields.slice(i, i + batchSize);
-    const batchResults = await Promise.all(
-      batch.map(field =>
-        getFieldAnalytics(formId, field.id, field.type, field.label)
-      )
-    );
-    fieldAnalytics.push(...batchResults);
-  }
+  // P1-12: Process all fields using the already-fetched responses.
+  // Previously each getFieldAnalytics call re-fetched responses from the DB
+  // (N+1: 20 fields × 10k responses = 20 full table scans). Now we pass the
+  // pre-loaded response set to getFieldAnalyticsFromResponses, reducing it to
+  // a single DB round-trip regardless of field count.
+  const fieldAnalytics: FieldAnalytics[] = allFields.map(field =>
+    getFieldAnalyticsFromResponses(responses, field.id, field.type, field.label)
+  );
 
   return {
     formId,

--- a/apps/backend/src/services/responseService.ts
+++ b/apps/backend/src/services/responseService.ts
@@ -10,7 +10,17 @@ import { prisma } from '../lib/prisma.js';
 import type { Prisma } from '@prisma/client';
 
 
+/**
+ * Fetch recent responses across an organization (or all orgs when omitted).
+ *
+ * P1-13: Hard-capped at 10,000 rows to prevent full-table scans at high volume.
+ * The cap is intentional — this endpoint is used for org-wide response listing
+ * in the UI, which is inherently paginated. For full exports use
+ * getAllResponsesByFormId; for paginated access use getResponsesByFormId.
+ */
 export const getAllResponses = async (organizationId?: string): Promise<FormResponse[]> => {
+  const HARD_CAP = 10_000;
+
   const responses = await responseRepository.findMany({
     where: organizationId ? {
       form: {
@@ -18,6 +28,7 @@ export const getAllResponses = async (organizationId?: string): Promise<FormResp
       }
     } : {},
     orderBy: { submittedAt: 'desc' },
+    take: HARD_CAP,
     include: {
       form: true,
     },
@@ -244,6 +255,16 @@ export async function getResponsesByFormId(
   };
 }
 
+/**
+ * Fetch every response for a specific form.
+ * Used by the export pipeline (unifiedExportService) and field analytics.
+ *
+ * P1-11 / P1-13: The export resolver enforces a 50,000-row cap before calling
+ * this function. The function itself imposes no additional DB-level limit so
+ * that the resolver's post-filter check (applied after optional filter
+ * narrowing) can still work correctly. If you add a new call site, make sure
+ * to guard against loading unbounded data into memory.
+ */
 export const getAllResponsesByFormId = async (formId: string): Promise<FormResponse[]> => {
   try {
     logger.info(`Fetching ALL responses for form: ${formId}`);

--- a/apps/backend/src/services/unifiedExportService.ts
+++ b/apps/backend/src/services/unifiedExportService.ts
@@ -195,8 +195,11 @@ const generateCsvContent = (data: UnifiedExportData): string => {
     headers.push(escapeCsvFieldName(fieldInfo[fieldId]));
   });
 
-  // Start CSV content with header row
-  let csvContent = headers.join(',') + '\n';
+  // P1-11: Accumulate rows in an array and join once at the end.
+  // The previous pattern used string concatenation inside a loop which
+  // caused O(n²) memory allocation behaviour at large response counts
+  // because every `csvContent += ...` copies the entire accumulated string.
+  const rows: string[] = [headers.join(',')];
 
   // Add data rows
   responses.forEach((response) => {
@@ -258,7 +261,7 @@ const generateCsvContent = (data: UnifiedExportData): string => {
       row.push(formatFieldValue(value, fieldType, 'csv'));
     });
 
-    csvContent += row.join(',') + '\n';
+    rows.push(row.join(','));
   });
 
   // Calculate plugin column count for logging
@@ -270,7 +273,7 @@ const generateCsvContent = (data: UnifiedExportData): string => {
   logger.info(
     `Unified Export - Generated CSV with ${responses.length} rows and ${headers.length} columns (${pluginColumnCount} plugin columns)`
   );
-  return csvContent;
+  return rows.join('\n');
 };
 
 // Generate Excel content using exceljs


### PR DESCRIPTION
## Summary

Implements P1-11, P1-12, P1-13, P1-14 from the production readiness audit.

- **P1-12**: Fix N+1 in `getAllFieldsAnalytics` — introduces a private `getFieldAnalyticsFromResponses` helper so responses are fetched from the DB exactly once per request, then passed to each field processor. Previously a 20-field form with 10k responses would issue 20 full table scans.
- **P1-13**: Add a hard 10,000-row cap to `getAllResponses` (org-wide response listing) via `take: HARD_CAP`. Prevents full-table scans at high response volumes. The cap is documented with a JSDoc comment explaining the intent and directing callers to `getResponsesByFormId` for paginated access.
- **P1-11**: Fix O(n²) CSV string concatenation in `generateCsvContent` — replace `csvContent += row + '\n'` loop with an array accumulation + single `join('\n')` at the end. The export resolver's existing 50k-row guard is documented with a JSDoc comment on `getAllResponsesByFormId`.
- **P1-14**: Add three missing composite indexes to `schema.prisma` (`FormViewAnalytics(formId, sessionId)`, `FormSubmissionAnalytics(formId, sessionId)`, `Form(organizationId, createdById)`) and a raw SQL migration that also creates a GIN index on `response.data` using `jsonb_path_ops` for JSON path-containment queries.

## Test plan

- [x] `pnpm --filter backend type-check` — passes with no errors
- [x] `pnpm test:unit` — all 1890 tests pass (including updated `getAllResponses` expectations to include `take: 10_000`)
- [x] `pnpm --filter backend lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)