### PR TITLE
feat(frontend): P2 accessibility, store reset, code splitting

### DIFF
--- a/apps/form-app/src/App.tsx
+++ b/apps/form-app/src/App.tsx
@@ -1,32 +1,46 @@
 
+import { lazy, Suspense } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext';
 import { LocaleProvider } from './contexts/LocaleContext';
-import { Toaster } from '@dculus/ui';
+import { Toaster, LoadingSpinner } from '@dculus/ui';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { PageErrorBoundary } from './components/PageErrorBoundary';
 import { Dashboard } from './components/Dashboard';
-import FormsList from './pages/FormsList';
-import Responses from './pages/Responses';
-import ResponseEdit from './pages/ResponseEdit';
-import { ResponseEditHistory } from './pages/ResponseEditHistory';
-import ResponsesAnalytics from './pages/ResponsesAnalytics';
-import ResponsesIndividual from './pages/ResponsesIndividual';
+// Auth pages — kept as static imports (small, needed immediately on page load)
 import { SignUp } from './pages/SignUp';
 import { SignIn } from './pages/SignIn';
 import { EmailVerification } from './pages/EmailVerification';
 import { ForgotPassword } from './pages/ForgotPassword';
-import Settings from './pages/Settings';
 import InviteAcceptance from './pages/InviteAcceptance';
-import FormDashboard from './pages/FormDashboard';
-import FormAnalytics from './pages/FormAnalytics';
-import FormSettings from './pages/FormSettings';
-import CollaborativeFormBuilder from './pages/CollaborativeFormBuilder';
-import Plugins from './pages/Plugins';
-import PluginConfiguration from './pages/PluginConfiguration';
 import { Pricing } from './pages/Pricing';
 import { CheckoutSuccess } from './pages/subscription/success';
 import { CheckoutCancel } from './pages/subscription/cancel';
+
+// Heavy pages — lazy-loaded to reduce initial bundle size (P2-20)
+const CollaborativeFormBuilder = lazy(() =>
+  import('./pages/CollaborativeFormBuilder')
+);
+const FormAnalytics = lazy(() => import('./pages/FormAnalytics'));
+const FormSettings = lazy(() => import('./pages/FormSettings'));
+const Plugins = lazy(() => import('./pages/Plugins'));
+const PluginConfiguration = lazy(() => import('./pages/PluginConfiguration'));
+const ResponsesAnalytics = lazy(() => import('./pages/ResponsesAnalytics'));
+const ResponsesIndividual = lazy(() => import('./pages/ResponsesIndividual'));
+const ResponseEdit = lazy(() => import('./pages/ResponseEdit'));
+const FormsList = lazy(() => import('./pages/FormsList'));
+const FormDashboard = lazy(() => import('./pages/FormDashboard'));
+const Responses = lazy(() => import('./pages/Responses'));
+const Settings = lazy(() => import('./pages/Settings'));
+const ResponseEditHistory = lazy(() =>
+  import('./pages/ResponseEditHistory').then(m => ({ default: m.ResponseEditHistory }))
+);
+
+const RouteSpinner = () => (
+  <div className="flex items-center justify-center h-screen">
+    <LoadingSpinner size="lg" />
+  </div>
+);
 
 
 function App() {
@@ -35,7 +49,7 @@ function App() {
       <AuthProvider>
         <div className="min-h-screen bg-background">
           <Routes>
-          {/* Public routes */}
+          {/* Public routes — static imports, needed immediately */}
           <Route path="/signin" element={<SignIn />} />
           <Route path="/verify-email" element={<EmailVerification />} />
           <Route path="/forgot-password" element={<ForgotPassword />} />
@@ -44,8 +58,8 @@ function App() {
           <Route path="/pricing" element={<Pricing />} />
           <Route path="/subscription/success" element={<CheckoutSuccess />} />
           <Route path="/subscription/cancel" element={<CheckoutCancel />} />
-          
-          {/* Protected routes — each wrapped in PageErrorBoundary to prevent full-page blank screens */}
+
+          {/* Protected routes — lazy-loaded heavy pages wrapped in Suspense (P2-20) */}
           <Route path="/" element={
             <ProtectedRoute><PageErrorBoundary><Dashboard /></PageErrorBoundary></ProtectedRoute>
           } />
@@ -53,52 +67,52 @@ function App() {
             <ProtectedRoute><PageErrorBoundary><Dashboard /></PageErrorBoundary></ProtectedRoute>
           } />
           <Route path="/dashboard/form/:formId" element={
-            <ProtectedRoute><PageErrorBoundary><FormDashboard /></PageErrorBoundary></ProtectedRoute>
+            <ProtectedRoute><PageErrorBoundary><Suspense fallback={<RouteSpinner />}><FormDashboard /></Suspense></PageErrorBoundary></ProtectedRoute>
           } />
           <Route path="/dashboard/form/:formId/collaborate/:tab?" element={
-            <ProtectedRoute><PageErrorBoundary><CollaborativeFormBuilder /></PageErrorBoundary></ProtectedRoute>
+            <ProtectedRoute><PageErrorBoundary><Suspense fallback={<RouteSpinner />}><CollaborativeFormBuilder /></Suspense></PageErrorBoundary></ProtectedRoute>
           } />
           <Route path="/dashboard/form/:formId/analytics" element={
-            <ProtectedRoute><PageErrorBoundary><FormAnalytics /></PageErrorBoundary></ProtectedRoute>
+            <ProtectedRoute><PageErrorBoundary><Suspense fallback={<RouteSpinner />}><FormAnalytics /></Suspense></PageErrorBoundary></ProtectedRoute>
           } />
           <Route path="/dashboard/form/:formId/settings" element={
-            <ProtectedRoute><PageErrorBoundary><FormSettings /></PageErrorBoundary></ProtectedRoute>
+            <ProtectedRoute><PageErrorBoundary><Suspense fallback={<RouteSpinner />}><FormSettings /></Suspense></PageErrorBoundary></ProtectedRoute>
           } />
           <Route path="/dashboard/form/:formId/plugins" element={
-            <ProtectedRoute><PageErrorBoundary><Plugins /></PageErrorBoundary></ProtectedRoute>
+            <ProtectedRoute><PageErrorBoundary><Suspense fallback={<RouteSpinner />}><Plugins /></Suspense></PageErrorBoundary></ProtectedRoute>
           } />
           <Route path="/dashboard/form/:formId/plugins/configure/:pluginType" element={
-            <ProtectedRoute><PageErrorBoundary><PluginConfiguration /></PageErrorBoundary></ProtectedRoute>
+            <ProtectedRoute><PageErrorBoundary><Suspense fallback={<RouteSpinner />}><PluginConfiguration /></Suspense></PageErrorBoundary></ProtectedRoute>
           } />
           <Route path="/dashboard/form/:formId/plugins/:pluginId/edit" element={
-            <ProtectedRoute><PageErrorBoundary><PluginConfiguration /></PageErrorBoundary></ProtectedRoute>
+            <ProtectedRoute><PageErrorBoundary><Suspense fallback={<RouteSpinner />}><PluginConfiguration /></Suspense></PageErrorBoundary></ProtectedRoute>
           } />
           <Route path="/settings/:tab?" element={
-            <ProtectedRoute><PageErrorBoundary><Settings /></PageErrorBoundary></ProtectedRoute>
+            <ProtectedRoute><PageErrorBoundary><Suspense fallback={<RouteSpinner />}><Settings /></Suspense></PageErrorBoundary></ProtectedRoute>
           } />
           <Route path="/forms" element={
-            <ProtectedRoute><PageErrorBoundary><FormsList /></PageErrorBoundary></ProtectedRoute>
+            <ProtectedRoute><PageErrorBoundary><Suspense fallback={<RouteSpinner />}><FormsList /></Suspense></PageErrorBoundary></ProtectedRoute>
           } />
           <Route path="/dashboard/form/:formId/responses" element={
-            <ProtectedRoute><PageErrorBoundary><Responses /></PageErrorBoundary></ProtectedRoute>
+            <ProtectedRoute><PageErrorBoundary><Suspense fallback={<RouteSpinner />}><Responses /></Suspense></PageErrorBoundary></ProtectedRoute>
           } />
           <Route path="/dashboard/form/:formId/responses/:responseId/edit" element={
-            <ProtectedRoute><PageErrorBoundary><ResponseEdit /></PageErrorBoundary></ProtectedRoute>
+            <ProtectedRoute><PageErrorBoundary><Suspense fallback={<RouteSpinner />}><ResponseEdit /></Suspense></PageErrorBoundary></ProtectedRoute>
           } />
           <Route path="/dashboard/form/:formId/responses/:responseId/history" element={
-            <ProtectedRoute><PageErrorBoundary><ResponseEditHistory /></PageErrorBoundary></ProtectedRoute>
+            <ProtectedRoute><PageErrorBoundary><Suspense fallback={<RouteSpinner />}><ResponseEditHistory /></Suspense></PageErrorBoundary></ProtectedRoute>
           } />
           <Route path="/dashboard/form/:formId/responses/analytics" element={
-            <ProtectedRoute><PageErrorBoundary><ResponsesAnalytics /></PageErrorBoundary></ProtectedRoute>
+            <ProtectedRoute><PageErrorBoundary><Suspense fallback={<RouteSpinner />}><ResponsesAnalytics /></Suspense></PageErrorBoundary></ProtectedRoute>
           } />
           <Route path="/dashboard/form/:formId/responses/individual" element={
-            <ProtectedRoute><PageErrorBoundary><ResponsesIndividual /></PageErrorBoundary></ProtectedRoute>
+            <ProtectedRoute><PageErrorBoundary><Suspense fallback={<RouteSpinner />}><ResponsesIndividual /></Suspense></PageErrorBoundary></ProtectedRoute>
           } />
           <Route path="/forms/:id/responses" element={
-            <ProtectedRoute><PageErrorBoundary><Responses /></PageErrorBoundary></ProtectedRoute>
+            <ProtectedRoute><PageErrorBoundary><Suspense fallback={<RouteSpinner />}><Responses /></Suspense></PageErrorBoundary></ProtectedRoute>
           } />
           <Route path="/responses" element={
-            <ProtectedRoute><PageErrorBoundary><Responses /></PageErrorBoundary></ProtectedRoute>
+            <ProtectedRoute><PageErrorBoundary><Suspense fallback={<RouteSpinner />}><Responses /></Suspense></PageErrorBoundary></ProtectedRoute>
           } />
           {/* Templates is now nested under Dashboard */}
           </Routes>

--- a/apps/form-app/src/pages/CollaborativeFormBuilder.tsx
+++ b/apps/form-app/src/pages/CollaborativeFormBuilder.tsx
@@ -87,6 +87,7 @@ const CollaborativeFormBuilder: React.FC<CollaborativeFormBuilderProps> = ({
     initializeCollaboration,
     disconnectCollaboration,
     setSelectedPage,
+    resetBuilder,
 
     addField,
     addFieldAtIndex,
@@ -208,6 +209,13 @@ const CollaborativeFormBuilder: React.FC<CollaborativeFormBuilderProps> = ({
   useEffect(() => {
     autoSelectFirstPage();
   }, [autoSelectFirstPage]);
+
+  // P2-16: Reset layout and selection state when unmounting the builder
+  useEffect(() => {
+    return () => {
+      resetBuilder();
+    };
+  }, [resetBuilder]);
 
   const renderDragOverlay = useMemo(() => {
     if (!activeId || !draggedItem) return null;

--- a/apps/form-app/src/store/slices/collaborationSlice.ts
+++ b/apps/form-app/src/store/slices/collaborationSlice.ts
@@ -25,11 +25,18 @@ export const createCollaborationSlice: SliceCreator<CollaborationSlice> = (set, 
   const MAX_RECONNECT_ATTEMPTS = 5;
   const BASE_RECONNECT_DELAY_MS = 2_000;
 
+  // P2-17: Dirty flag — set to true whenever the YJS doc receives an update
+  // so disconnectCollaboration can attempt a final sync before teardown.
+  let isDirty = false;
+
   /**
    * Callback when YJS document updates
    * Updates pages, layout, and isShuffleEnabled in the store
    */
   const updateCallback = (pages: FormPage[], layout?: FormLayout, isShuffleEnabled?: boolean) => {
+    // P2-17: Mark document dirty on every incoming update
+    isDirty = true;
+
     const updates: any = { pages };
 
     if (layout) {
@@ -125,6 +132,10 @@ export const createCollaborationSlice: SliceCreator<CollaborationSlice> = (set, 
 
     /**
      * Disconnect collaboration and cleanup resources
+     *
+     * P2-17: If the document is dirty and the provider is still connected,
+     * give Hocuspocus a brief window (up to 500 ms) to flush pending awareness
+     * updates before tearing down the WebSocket.
      */
     disconnectCollaboration: () => {
       // Cancel any pending reconnect before tearing down
@@ -134,22 +145,39 @@ export const createCollaborationSlice: SliceCreator<CollaborationSlice> = (set, 
       }
       reconnectAttempts = MAX_RECONNECT_ATTEMPTS; // prevent further auto-reconnect
 
-      if (collaborationManager) {
-        collaborationManager.disconnect();
-        collaborationManager = null;
-      }
+      // P2-17: Attempt to flush pending changes before disconnecting.
+      // Hocuspocus syncs over WebSocket automatically on every ydoc update, so the
+      // dirty flag simply tells us whether we should give the provider a moment to
+      // finish any in-flight sync before we destroy the connection.
+      const shouldFlush = isDirty && collaborationManager?.isConnected();
+      isDirty = false; // reset flag regardless
 
-      set({
-        isConnected: false,
-        isLoading: false,
-        formId: null,
-        ydoc: null,
-        provider: null,
-        observerCleanups: [],
-        pages: [],
-        selectedPageId: null,
-        selectedFieldId: null,
-      });
+      const teardown = () => {
+        if (collaborationManager) {
+          collaborationManager.disconnect();
+          collaborationManager = null;
+        }
+
+        set({
+          isConnected: false,
+          isLoading: false,
+          formId: null,
+          ydoc: null,
+          provider: null,
+          observerCleanups: [],
+          pages: [],
+          selectedPageId: null,
+          selectedFieldId: null,
+        });
+      };
+
+      if (shouldFlush) {
+        // Give the WebSocket provider a short window to flush pending messages.
+        // We do not await because disconnectCollaboration is synchronous by design.
+        setTimeout(teardown, 300);
+      } else {
+        teardown();
+      }
     },
 
     /**

--- a/apps/form-app/src/store/types/store.types.ts
+++ b/apps/form-app/src/store/types/store.types.ts
@@ -127,6 +127,16 @@ export interface SelectionSlice {
 }
 
 /**
+ * Reset Slice
+ *
+ * Provides a cross-slice reset action for cleaning up transient builder state
+ * when the user navigates away from the form builder.
+ */
+export interface ResetSlice {
+  resetBuilder: () => void;
+}
+
+/**
  * Combined Store State
  *
  * All slices combined into a single store
@@ -135,7 +145,8 @@ export type FormBuilderState = CollaborationSlice &
   PagesSlice &
   FieldsSlice &
   LayoutSlice &
-  SelectionSlice;
+  SelectionSlice &
+  ResetSlice;
 
 /**
  * Slice Creator Function Type

--- a/apps/form-app/src/store/useFormBuilderStore.ts
+++ b/apps/form-app/src/store/useFormBuilderStore.ts
@@ -13,6 +13,7 @@ import { createPagesSlice } from './slices/pagesSlice';
 import { createFieldsSlice } from './slices/fieldsSlice';
 import { createLayoutSlice } from './slices/layoutSlice';
 import { createSelectionSlice } from './slices/selectionSlice';
+import { DEFAULT_LAYOUT } from './helpers/defaultLayout';
 
 /**
  * Combined Form Builder Store
@@ -36,6 +37,19 @@ export const useFormBuilderStore = create<FormBuilderState>()(
       ...createFieldsSlice(set, get),
       ...createLayoutSlice(set, get),
       ...createSelectionSlice(set, get),
+
+      /**
+       * P2-16: Reset layout and selection state when leaving the form builder.
+       * Called from CollaborativeFormBuilder's cleanup useEffect.
+       */
+      resetBuilder: () => {
+        set({
+          layout: DEFAULT_LAYOUT,
+          isShuffleEnabled: false,
+          selectedPageId: null,
+          selectedFieldId: null,
+        });
+      },
     })),
     {
       name: 'form-builder-store',

--- a/apps/form-app/vite.config.ts
+++ b/apps/form-app/vite.config.ts
@@ -19,6 +19,18 @@ export default defineConfig({
       },
     ],
   },
+  build: {
+    rollupOptions: {
+      output: {
+        // P2-20: Split heavy third-party libraries into named chunks to improve
+        // caching and reduce initial bundle size.
+        manualChunks: {
+          'vendor-yjs': ['yjs'],
+          'vendor-recharts': ['recharts'],
+        },
+      },
+    },
+  },
   server: {
     port: 3000,
     proxy: {
@@ -32,4 +44,4 @@ export default defineConfig({
       },
     },
   },
-}); 
+});

--- a/packages/ui/src/field-preview.tsx
+++ b/packages/ui/src/field-preview.tsx
@@ -175,6 +175,7 @@ export const FieldPreview: React.FC<FieldPreviewProps> = ({
               </span>
             )}
             <Input
+              id={inputId}
               type="text"
               placeholder={placeholder}
               defaultValue={defaultValue}
@@ -193,6 +194,7 @@ export const FieldPreview: React.FC<FieldPreviewProps> = ({
               </span>
             )}
             <Textarea
+              id={inputId}
               placeholder={placeholder}
               defaultValue={defaultValue}
               disabled={disabled}
@@ -210,6 +212,7 @@ export const FieldPreview: React.FC<FieldPreviewProps> = ({
               </span>
             )}
             <Input
+              id={inputId}
               type="email"
               placeholder={placeholder || 'Enter your email'}
               defaultValue={defaultValue}
@@ -229,6 +232,7 @@ export const FieldPreview: React.FC<FieldPreviewProps> = ({
               </span>
             )}
             <Input
+              id={inputId}
               type="number"
               placeholder={placeholder || 'Enter a number'}
               defaultValue={defaultValue}
@@ -337,6 +341,7 @@ export const FieldPreview: React.FC<FieldPreviewProps> = ({
         const dateField = field as any;
         return (
           <Input
+            id={inputId}
             type="date"
             defaultValue={defaultValue}
             min={dateField.minDate}
@@ -388,11 +393,14 @@ export const FieldPreview: React.FC<FieldPreviewProps> = ({
     }
   };
 
+  // Stable input id used for Label htmlFor association (P2-18)
+  const inputId = `fp-${field.id}`;
+
   return (
     <div className="space-y-2">
       {/* Field Label */}
       <div className="flex items-center space-x-1">
-        <Label className="text-sm font-medium text-gray-900 dark:text-white">
+        <Label htmlFor={inputId} className="text-sm font-medium text-gray-900 dark:text-white">
           {fieldData.label}
           {fieldData.required && <span className="text-red-500 ml-1">*</span>}
         </Label>

--- a/packages/ui/src/renderers/FormFieldRenderer.tsx
+++ b/packages/ui/src/renderers/FormFieldRenderer.tsx
@@ -407,16 +407,16 @@ export const FormFieldRenderer: React.FC<FormFieldRendererProps> = ({
                     <FileChip key={i} name={file.name} onRemove={isInteractive ? () => cf.onChange([...existing, ...pending.filter((_, j) => j !== i)]) : undefined} />
                   ))}
 
-                  {/* Drop zone */}
+                  {/* Drop zone — wrapped in <label> for keyboard/screen-reader access (P2-19) */}
                   {isInteractive && total < maxFiles && (
-                    <div
+                    <label
+                      htmlFor={`ff-${field.id}`}
                       data-testid={`file-upload-drop-zone-${field.id}`}
-                      className="border-2 border-dashed rounded-xl p-5 text-center cursor-pointer transition-all duration-150"
+                      className="border-2 border-dashed rounded-xl p-5 text-center cursor-pointer transition-all duration-150 block"
                       style={{
                         borderColor: hasError ? '#ce5d55' : 'rgba(81,76,84,0.18)',
                         backgroundColor: hasError ? 'rgba(206,93,85,0.03)' : '#f7f7f8',
                       }}
-                      onClick={() => (document.getElementById(`ff-${field.id}`) as HTMLInputElement)?.click()}
                       onDragOver={e => { e.preventDefault(); e.stopPropagation(); }}
                       onDrop={e => { e.preventDefault(); e.stopPropagation(); onFiles(e.dataTransfer.files); }}
                     >
@@ -438,7 +438,7 @@ export const FormFieldRenderer: React.FC<FormFieldRendererProps> = ({
                         disabled={!isInteractive}
                         onChange={e => onFiles(e.target.files)}
                       />
-                    </div>
+                    </label>
                   )}
 
                   {/* Disabled placeholder */}


### PR DESCRIPTION
## Summary

- **P2-16**: Added `resetBuilder` action to the Zustand store that resets `layout`, `isShuffleEnabled`, `selectedPageId`, and `selectedFieldId` to initial values. Called from `CollaborativeFormBuilder` cleanup `useEffect` on unmount.
- **P2-17**: Added `isDirty` flag to the collaboration slice, set on every Y.js document update. `disconnectCollaboration` now waits 300 ms before teardown when dirty and connected, giving Hocuspocus time to flush in-flight WebSocket messages.
- **P2-18**: Added `htmlFor={inputId}` (where `inputId = \`fp-\${field.id}\``) to the `<Label>` in `field-preview.tsx` and matching `id={inputId}` props to all primary inputs (text, textarea, email, number, date).
- **P2-19**: Changed the file upload drop zone in `FormFieldRenderer.tsx` from a `<div onClick={...}>` to a `<label htmlFor={inputId}>` element, enabling native keyboard and screen-reader access without additional ARIA workarounds.
- **P2-20**: Converted 10 heavy page imports in `App.tsx` to `React.lazy()` with `<Suspense>` fallbacks using the existing `LoadingSpinner` component. Added `manualChunks` to `vite.config.ts` for `yjs` and `recharts` (confirmed direct dependencies).

## Test plan

- [ ] Navigate to `/dashboard/form/:id/collaborate`, then navigate away — store layout resets to default (no stale theme/spacing bleeding into next form load)
- [ ] Open a form in the builder, make changes, then close the tab/navigate away — no console errors about failed sync
- [ ] In the builder field preview, clicking a label focuses the associated input
- [ ] In the form viewer, Tab key can reach the file upload input via the label drop zone
- [ ] `pnpm --filter form-app type-check` passes with zero errors
- [ ] `pnpm --filter form-viewer type-check` passes with zero errors
- [ ] `pnpm --filter admin-app type-check` passes with zero errors
- [ ] `pnpm build` produces separate `vendor-yjs` and `vendor-recharts` chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)