### PR TITLE
fix(backend): P2 DB atomicity, SQL optimizations, security hardening

### DIFF
--- a/apps/backend/src/graphql/resolvers/__tests__/admin.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/admin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { adminResolvers } from '../admin.js';
+import { adminResolvers, _clearStatsCacheForTests } from '../admin.js';
 import { GraphQLError } from '#graphql-errors';
 import { prisma } from '../../../lib/prisma.js';
 
@@ -121,6 +121,9 @@ describe('Admin Resolvers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockS3Send.mockReset();
+    // P2-06: clear the S3 stats in-memory cache between tests so each test
+    // controls its own S3 mock behaviour without interference.
+    _clearStatsCacheForTests();
   });
 
   afterEach(() => {
@@ -710,6 +713,7 @@ describe('Admin Resolvers', () => {
         mockAdminContext
       );
 
+      // P2-06: forms now use a selective `select` to omit the large formSchema blob
       expect(prisma.organization.findUnique).toHaveBeenCalledWith({
         where: { id: 'org-123' },
         include: {
@@ -725,7 +729,16 @@ describe('Admin Resolvers', () => {
               },
             },
           },
-          forms: true,
+          forms: {
+            select: {
+              id: true,
+              title: true,
+              isPublished: true,
+              createdAt: true,
+              updatedAt: true,
+              sharingScope: true,
+            },
+          },
         },
       });
 

--- a/apps/backend/src/graphql/resolvers/admin.ts
+++ b/apps/backend/src/graphql/resolvers/admin.ts
@@ -29,6 +29,15 @@ export interface AdminOrganizationByIdArgs {
   id: string;
 }
 
+// P2-06: In-memory cache for S3 storage stats (expensive operation — paginates all objects)
+let statsCache: { data: { storageUsed: string; fileCount: number }; timestamp: number } | null = null;
+const STATS_CACHE_TTL = 60 * 60 * 1000; // 60 minutes
+
+/** Exposed for testing purposes only — clears the S3 stats cache. */
+export function _clearStatsCacheForTests() {
+  statsCache = null;
+}
+
 // Initialize S3 client for storage stats
 const s3Client = new S3Client({
   region: 'auto',
@@ -62,7 +71,14 @@ function formatBytes(bytes: number): string {
 }
 
 // Helper function to get S3 storage statistics
+// P2-06: Results are cached for STATS_CACHE_TTL to avoid expensive paginated S3 list calls on every request
 async function getS3StorageStats(): Promise<{ storageUsed: string; fileCount: number }> {
+  const now = Date.now();
+  if (statsCache && now - statsCache.timestamp < STATS_CACHE_TTL) {
+    logger.info('Returning cached S3 storage stats');
+    return statsCache.data;
+  }
+
   try {
     let totalSize = 0;
     let totalFiles = 0;
@@ -76,7 +92,7 @@ async function getS3StorageStats(): Promise<{ storageUsed: string; fileCount: nu
       });
 
       const response = await s3Client.send(command);
-      
+
       if (response.Contents) {
         totalFiles += response.Contents.length;
         totalSize += response.Contents.reduce((acc, obj) => acc + (obj.Size || 0), 0);
@@ -86,10 +102,13 @@ async function getS3StorageStats(): Promise<{ storageUsed: string; fileCount: nu
       continuationToken = response.NextContinuationToken;
     }
 
-    return {
+    const result = {
       storageUsed: formatBytes(totalSize),
       fileCount: totalFiles,
     };
+
+    statsCache = { data: result, timestamp: now };
+    return result;
   } catch (error) {
     logger.error('Error fetching S3 storage stats:', error);
     return {
@@ -399,6 +418,10 @@ export const adminResolvers = {
       requireAdminRole(context);
 
       try {
+        // P2-06: Use a selective `select` on forms to omit the potentially large
+        // `formSchema` JSON blob. Loading `forms: true` would eagerly fetch the
+        // full schema for every form in the organisation — this is wasteful for
+        // the admin overview which only needs basic metadata.
         const organization = await prisma.organization.findUnique({
           where: { id: args.id },
           include: {
@@ -414,7 +437,16 @@ export const adminResolvers = {
                 },
               },
             },
-            forms: true,
+            forms: {
+              select: {
+                id: true,
+                title: true,
+                isPublished: true,
+                createdAt: true,
+                updatedAt: true,
+                sharingScope: true,
+              },
+            },
           },
         });
 

--- a/apps/backend/src/graphql/resolvers/responses.ts
+++ b/apps/backend/src/graphql/resolvers/responses.ts
@@ -207,6 +207,19 @@ export const responsesResolvers = {
         }
       }
 
+      // P2-04: Validate response payload size to prevent unbounded writes
+      if (input.data && typeof input.data === 'object') {
+        const keys = Object.keys(input.data as object);
+        if (keys.length > 500) {
+          throw createGraphQLError('Response data cannot contain more than 500 fields', GRAPHQL_ERROR_CODES.BAD_USER_INPUT);
+        }
+        for (const [key, value] of Object.entries(input.data as object)) {
+          if (typeof value === 'string' && value.length > 10_000) {
+            throw createGraphQLError(`Field "${key}" exceeds the 10,000 character limit`, GRAPHQL_ERROR_CODES.BAD_USER_INPUT);
+          }
+        }
+      }
+
       // If all limits pass, save the response
       const responseData = {
         id: generateId(),

--- a/apps/backend/src/lib/better-auth.ts
+++ b/apps/backend/src/lib/better-auth.ts
@@ -123,12 +123,42 @@ export const auth: ReturnType<typeof betterAuth> = betterAuth({
   ],
 
   // CORS configuration for development
+  // P2-10: Explicit cookie security flags — httpOnly prevents XSS access,
+  // secure ensures cookies are only sent over HTTPS in production, and
+  // sameSite=lax guards against CSRF while allowing top-level navigations.
   advanced: {
     crossSubDomainCookies: {
       enabled: false,
     },
+    cookies: {
+      session_token: {
+        attributes: {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production',
+          sameSite: 'lax' as const,
+        },
+      },
+    },
   },
   databaseHooks: {
+    user: {
+      delete: {
+        // P2-09: GDPR compliance — null out PII in edit history when a user is
+        // deleted so personal data (IP address, user agent) is no longer retained
+        // in the audit trail after account removal.
+        after: async (user) => {
+          try {
+            await prisma.responseEditHistory.updateMany({
+              where: { editedById: user.id },
+              data: { ipAddress: null, userAgent: null },
+            });
+            logger.info(`Nulled out PII in edit history for deleted user: ${user.id}`);
+          } catch (error) {
+            logger.error(`Failed to null PII in edit history for user ${user.id}:`, error);
+          }
+        },
+      },
+    },
     session: {
       create: {
         before: async (session) => {

--- a/apps/backend/src/services/__tests__/analyticsService.test.ts
+++ b/apps/backend/src/services/__tests__/analyticsService.test.ts
@@ -4,10 +4,18 @@ import {
   formViewAnalyticsRepository,
   formSubmissionAnalyticsRepository,
 } from '../../repositories/index.js';
+import { prisma } from '../../lib/prisma.js';
 import { logger } from '../../lib/logger.js';
 
 // Mock repositories
 vi.mock('../../repositories/index.js');
+
+// P2-05: analyticsService now calls prisma.$queryRaw for SQL percentile calculation
+vi.mock('../../lib/prisma.js', () => ({
+  prisma: {
+    $queryRaw: vi.fn(),
+  },
+}));
 
 // Mock external dependencies
 vi.mock('ua-parser-js', () => ({
@@ -521,6 +529,11 @@ describe('Analytics Service', () => {
         .mockResolvedValueOnce([{ operatingSystem: 'Windows', _count: { operatingSystem: 1 } }] as any)
         .mockResolvedValueOnce([{ browser: 'Chrome', _count: { browser: 1 } }] as any);
 
+      // P2-05: mock the SQL percentile query result
+      vi.mocked(prisma.$queryRaw).mockResolvedValue([
+        { p50: 120, p75: 120, p90: 120, p95: 120, avg: 120, total: BigInt(1) },
+      ] as any);
+
       vi.mocked(formSubmissionAnalyticsRepository.findMany).mockResolvedValue([
         { completionTimeSeconds: 120 },
       ] as any);
@@ -545,6 +558,11 @@ describe('Analytics Service', () => {
         .mockResolvedValueOnce([] as any)
         .mockResolvedValueOnce([{ operatingSystem: 'Windows', _count: { operatingSystem: 1 } }] as any)
         .mockResolvedValueOnce([{ browser: 'Chrome', _count: { browser: 1 } }] as any);
+
+      // P2-05: mock the SQL percentile query — avg of [60, 120, 180] = 120
+      vi.mocked(prisma.$queryRaw).mockResolvedValue([
+        { p50: 120, p75: 150, p90: 162, p95: 171, avg: 120, total: BigInt(3) },
+      ] as any);
 
       vi.mocked(formSubmissionAnalyticsRepository.findMany).mockResolvedValue([
         { completionTimeSeconds: 60 },

--- a/apps/backend/src/services/__tests__/emailService.test.ts
+++ b/apps/backend/src/services/__tests__/emailService.test.ts
@@ -52,10 +52,12 @@ describe('Email Service', () => {
         text: 'Test Text',
       });
 
+      // P2-11: port 587 → STARTTLS (secure: false, requireTLS: true)
       expect(nodemailer.createTransport).toHaveBeenCalledWith({
         host: 'smtp.example.com',
         port: 587,
         secure: false,
+        requireTLS: true,
         auth: {
           user: 'test@example.com',
           pass: 'password123',

--- a/apps/backend/src/services/__tests__/formService.test.ts
+++ b/apps/backend/src/services/__tests__/formService.test.ts
@@ -9,7 +9,7 @@ import {
   regenerateShortUrl,
   duplicateForm,
 } from '../formService.js';
-import { formRepository } from '../../repositories/index.js';
+import { formRepository, createFormRepository } from '../../repositories/index.js';
 import { logger } from '../../lib/logger.js';
 
 import { initializeHocuspocusDocument, getFormSchemaFromHocuspocus } from '../hocuspocus.js';
@@ -33,6 +33,21 @@ vi.mock('@dculus/utils', async () => {
     generateId: vi.fn(),
   };
 });
+
+// P2-03: prisma.$transaction mock — executes the callback with the same mocked
+// formRepository so unit-test assertions on createForm/createOwnerPermission
+// still work while the transaction boundary is respected in production.
+vi.mock('../../lib/prisma.js', () => ({
+  prisma: {
+    $transaction: vi.fn((callback: (tx: any) => Promise<any>) => {
+      // The tx object passed here is intentionally unused inside the callback;
+      // createFormRepository(withPrisma(tx)) returns its own mock because
+      // repositories/index.js is mocked below and the mock auto-delegates to
+      // the module-level formRepository mock.
+      return callback({});
+    }),
+  },
+}));
 
 describe('Form Service', () => {
   const mockForm = {
@@ -80,6 +95,10 @@ describe('Form Service', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // P2-03: createFormRepository is called inside prisma.$transaction to create
+    // a transaction-scoped repo. Return the same mocked formRepository so all
+    // existing test assertions on createForm / createOwnerPermission still apply.
+    vi.mocked(createFormRepository).mockReturnValue(formRepository as any);
   });
 
   afterEach(() => {
@@ -406,26 +425,24 @@ describe('Form Service', () => {
       loggerWarn.mockRestore();
     });
 
-    it('should log error if OWNER permission creation fails', async () => {
-      const loggerError = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    it('should throw if OWNER permission creation fails (P2-03 atomicity)', async () => {
+      // P2-03: form creation and owner-permission grant are now atomic inside a
+      // prisma.$transaction. If createOwnerPermission throws, the entire
+      // transaction is rolled back and createForm propagates the error to the
+      // caller rather than silently swallowing it. This prevents orphan forms
+      // that have no owner permission row.
       vi.mocked(formRepository.createOwnerPermission).mockRejectedValue(
         new Error('Permission error')
       );
 
-      await createForm({
+      await expect(createForm({
         id: 'form-123',
         title: 'New Form',
         shortUrl: '',
         isPublished: false,
         organizationId: 'org-123',
         createdById: 'user-123',
-      });
-
-      expect(loggerError).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to create OWNER permission'),
-        expect.any(Error)
-      );
-      loggerError.mockRestore();
+      })).rejects.toThrow('Permission error');
     });
   });
 

--- a/apps/backend/src/services/__tests__/responseService.test.ts
+++ b/apps/backend/src/services/__tests__/responseService.test.ts
@@ -18,6 +18,13 @@ import { prisma } from '../../lib/prisma.js';
 // Mock dependencies
 vi.mock('../../repositories/index.js');
 vi.mock('../responseFilterService.js');
+// Minimal mock Prisma transaction client used by updateResponse (P2-02)
+const mockTxClient = {
+  response: {
+    update: vi.fn(),
+  },
+};
+
 vi.mock('../../lib/prisma.js', () => ({
   prisma: {
     response: {
@@ -25,6 +32,8 @@ vi.mock('../../lib/prisma.js', () => ({
       findMany: vi.fn(),
     },
     $queryRawUnsafe: vi.fn(),
+    // P2-02: updateResponse uses prisma.$transaction when edit context is provided
+    $transaction: vi.fn((callback: (tx: any) => Promise<any>) => callback(mockTxClient)),
   },
 }));
 vi.mock('../responseEditTrackingService.js', () => ({
@@ -367,7 +376,10 @@ describe('Response Service', () => {
         },
         formSchema,
       });
-      vi.mocked(responseRepository.update).mockResolvedValue(updatedResponse as any);
+
+      // P2-02: updateResponse uses prisma.$transaction; the tx.response.update call
+      // returns the updated response to the outer function
+      mockTxClient.response.update.mockResolvedValue(updatedResponse as any);
 
       const editContext = {
         userId: 'user-1',
@@ -379,6 +391,8 @@ describe('Response Service', () => {
       const result = await updateResponse('response-123', updatedData, editContext);
 
       expect(ResponseEditTrackingService.getResponseWithFormSchema).toHaveBeenCalledWith('response-123');
+      // P2-02: recordEdit receives the transaction client as the 6th argument so
+      // both the response update and the audit record are committed atomically.
       expect(ResponseEditTrackingService.recordEdit).toHaveBeenCalledWith(
         'response-123',
         { field1: 'old-value' },
@@ -390,7 +404,8 @@ describe('Response Service', () => {
           userAgent: 'vitest',
           editType: 'MANUAL',
           editReason: 'Fix typo',
-        })
+        }),
+        expect.anything() // tx client passed for atomic commit
       );
       expect(result.data.field1).toBe('new-value');
     });

--- a/apps/backend/src/services/analyticsService.ts
+++ b/apps/backend/src/services/analyticsService.ts
@@ -8,6 +8,7 @@ import {
   formSubmissionAnalyticsRepository,
 } from '../repositories/index.js';
 import { EdgeVisitorLocation } from '../middleware/edge-geolocation.js';
+import { prisma } from '../lib/prisma.js';
 
 // Create require for CommonJS modules in ES module context
 const require = createRequire(import.meta.url);
@@ -344,26 +345,6 @@ const generateDateRange = (start: Date, end: Date): string[] => {
   return dates;
 };
 
-// Helper function to calculate completion time percentiles
-const calculatePercentiles = (values: number[]) => {
-  if (values.length === 0) return { p50: null, p75: null, p90: null, p95: null };
-  
-  const sorted = values.sort((a, b) => a - b);
-  const len = sorted.length;
-  
-  const getPercentile = (p: number) => {
-    const index = Math.ceil((p / 100) * len) - 1;
-    return sorted[Math.max(0, Math.min(index, len - 1))];
-  };
-  
-  return {
-    p50: getPercentile(50),
-    p75: getPercentile(75),
-    p90: getPercentile(90),
-    p95: getPercentile(95)
-  };
-};
-
 // Helper function to create completion time distribution ranges
 const createCompletionTimeDistribution = (completionTimes: number[]) => {
   const ranges = [
@@ -556,7 +537,8 @@ const getFormSubmissionAnalytics = async (formId: string, timeRange?: { start: D
       osStats,
       browserStats,
       rawDailySubmissions,
-      completionTimeData
+      completionTimePercentilesRaw,
+      completionTimeDistributionData,
     ] = await Promise.all([
       formSubmissionAnalyticsRepository.count({ where: whereClause }),
 
@@ -604,15 +586,34 @@ const getFormSubmissionAnalytics = async (formId: string, timeRange?: { start: D
       
       formSubmissionAnalyticsRepository.getDailySubmissionStats(formId, timeRange),
 
-      // Completion time data: Get all completion times for statistical analysis
+      // P2-05: Completion time percentiles computed in SQL to avoid loading all rows
+      // into JS memory. PERCENTILE_CONT is a PostgreSQL ordered-set aggregate.
+      prisma.$queryRaw<Array<{
+        p50: number | null; p75: number | null; p90: number | null; p95: number | null;
+        avg: number | null; total: bigint;
+      }>>`
+        SELECT
+          PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY "completionTimeSeconds") AS p50,
+          PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY "completionTimeSeconds") AS p75,
+          PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY "completionTimeSeconds") AS p90,
+          PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY "completionTimeSeconds") AS p95,
+          AVG("completionTimeSeconds") AS avg,
+          COUNT(*) AS total
+        FROM form_submission_analytics
+        WHERE "formId" = ${formId} AND "completionTimeSeconds" IS NOT NULL
+      `,
+
+      // Distribution still needs individual values — cap at 10,000 rows to avoid
+      // loading unbounded data into memory for large forms.
       formSubmissionAnalyticsRepository.findMany({
-        where: { 
-          ...whereClause, 
-          completionTimeSeconds: { not: null } 
+        where: {
+          ...whereClause,
+          completionTimeSeconds: { not: null }
         },
         select: {
           completionTimeSeconds: true
-        }
+        },
+        take: 10_000,
       })
     ]);
 
@@ -666,16 +667,22 @@ const getFormSubmissionAnalytics = async (formId: string, timeRange?: { start: D
       });
     }
     
-    // Process completion time data
-    const completionTimes = completionTimeData
+    // P2-05: Use SQL-computed percentiles — no JS-side sort over all rows needed
+    const sqlPercentiles = completionTimePercentilesRaw[0] ?? null;
+    const averageCompletionTime = sqlPercentiles?.avg != null ? Number(sqlPercentiles.avg) : null;
+    const completionTimePercentiles = sqlPercentiles
+      ? {
+          p50: sqlPercentiles.p50 != null ? Number(sqlPercentiles.p50) : null,
+          p75: sqlPercentiles.p75 != null ? Number(sqlPercentiles.p75) : null,
+          p90: sqlPercentiles.p90 != null ? Number(sqlPercentiles.p90) : null,
+          p95: sqlPercentiles.p95 != null ? Number(sqlPercentiles.p95) : null,
+        }
+      : { p50: null, p75: null, p90: null, p95: null };
+
+    // Distribution still computed in JS (capped at 10,000 rows above)
+    const completionTimes = completionTimeDistributionData
       .map((record: any) => record.completionTimeSeconds)
       .filter((time: number) => time != null && time > 0);
-    
-    const averageCompletionTime = completionTimes.length > 0 
-      ? completionTimes.reduce((sum: number, time: number) => sum + time, 0) / completionTimes.length 
-      : null;
-    
-    const completionTimePercentiles = calculatePercentiles(completionTimes);
     const completionTimeDistribution = createCompletionTimeDistribution(completionTimes);
     
     return {

--- a/apps/backend/src/services/emailService.ts
+++ b/apps/backend/src/services/emailService.ts
@@ -40,11 +40,17 @@ export interface SendInvitationEmailOptions {
 }
 
 // Create transporter instance
+// P2-11: Enforce TLS for outbound email.
+//   port 465 → implicit TLS (secure: true, requireTLS not needed)
+//   other ports (587, 25) → STARTTLS upgrade required (requireTLS: true prevents
+//   silent downgrade to plaintext when the server advertises STARTTLS).
 const createTransporter = () => {
+  const port = emailConfig.port;
   return nodemailer.createTransport({
     host: emailConfig.host,
-    port: emailConfig.port,
-    secure: false, // true for 465, false for other ports
+    port,
+    secure: port === 465,
+    requireTLS: port !== 465,
     auth: {
       user: emailConfig.user,
       pass: emailConfig.password,

--- a/apps/backend/src/services/formService.ts
+++ b/apps/backend/src/services/formService.ts
@@ -16,7 +16,9 @@ import { checkFormAccess, PermissionLevel } from '../graphql/resolvers/formShari
 import { randomUUID } from 'crypto';
 import { getFormSchemaFromHocuspocus } from './hocuspocus.js';
 import { copyFileForForm } from './fileUploadService.js';
-import { formRepository } from '../repositories/index.js';
+import { formRepository, createFormRepository } from '../repositories/index.js';
+import { withPrisma } from '../repositories/baseRepository.js';
+import { prisma } from '../lib/prisma.js';
 import { logger } from '../lib/logger.js';
 
 export interface Form extends Omit<IForm, 'formSchema'> {
@@ -117,37 +119,37 @@ export const createForm = async (
   // Generate unique short URL
   const shortUrl = await generateUniqueShortUrl();
 
-  // Create form without formSchema field in database
-  const newForm = await formRepository.createForm({
-    id: formData.id,
-    title: formData.title,
-    description: formData.description,
-    shortUrl,
-    formSchema: {}, // Store empty object as placeholder
-    isPublished: formData.isPublished || false,
-    organizationId: formData.organizationId,
-    createdById: formData.createdById,
-    settings: normalizedSettings,
-  });
+  // P2-03: Wrap form creation and owner permission in a single transaction so a
+  // failure in createOwnerPermission never leaves an orphan form without an owner,
+  // and a form record is never created without a corresponding OWNER permission row.
+  const result = await prisma.$transaction(async (tx) => {
+    // Create a transaction-scoped repository so both writes share the same
+    // Prisma transaction client and are committed (or rolled back) atomically.
+    const txRepo = createFormRepository(withPrisma(tx as any));
 
-  const result = {
-    ...newForm,
-    description: newForm.description || undefined,
-  };
+    const newForm = await txRepo.createForm({
+      id: formData.id,
+      title: formData.title,
+      description: formData.description,
+      shortUrl,
+      formSchema: {}, // Store empty object as placeholder
+      isPublished: formData.isPublished || false,
+      organizationId: formData.organizationId,
+      createdById: formData.createdById,
+      settings: normalizedSettings,
+    });
 
-  // Create OWNER permission for the form creator
-  try {
-    await formRepository.createOwnerPermission({
+    await txRepo.createOwnerPermission({
       id: randomUUID(),
-      formId: result.id,
+      formId: newForm.id,
       userId: formData.createdById,
       permission: 'OWNER',
       grantedById: formData.createdById, // Self-granted
     });
-    logger.info(`✅ Created OWNER permission for form creator: ${result.id}`);
-  } catch (error) {
-    logger.error(`❌ Failed to create OWNER permission for form ${result.id}:`, error);
-  }
+
+    logger.info(`✅ Created OWNER permission for form creator: ${newForm.id}`);
+    return { ...newForm, description: newForm.description || undefined };
+  });
 
   // Initialize Hocuspocus document for collaborative editing
   const schemaToInitialize = templateFormSchema || defaultFormSchema;

--- a/apps/backend/src/services/responseEditTrackingService.ts
+++ b/apps/backend/src/services/responseEditTrackingService.ts
@@ -9,6 +9,7 @@ import { generateId } from '@dculus/utils';
 import { responseRepository } from '../repositories/index.js';
 import { prisma } from '../lib/prisma.js';
 import { logger } from '../lib/logger.js';
+import type { Prisma } from '@prisma/client';
 
 export interface FieldChange {
   fieldId: string;
@@ -287,14 +288,20 @@ export class ResponseEditTrackingService {
   }
 
   /**
-   * Records edit history with field-level changes
+   * Records edit history with field-level changes.
+   *
+   * P2-02: Accepts an optional Prisma transaction context (`tx`). When `tx` is
+   * provided the writes are executed inside the caller's transaction so the
+   * response update and the audit record always succeed or fail together. When
+   * called without `tx` the method opens its own internal transaction.
    */
   static async recordEdit(
     responseId: string,
     oldData: Record<string, any>,
     newData: Record<string, any>,
     formSchema: FormSchema,
-    editContext: EditContext
+    editContext: EditContext,
+    tx?: Prisma.TransactionClient
   ): Promise<void> {
     const changes = this.detectChanges(oldData, newData, formSchema);
 
@@ -306,9 +313,8 @@ export class ResponseEditTrackingService {
     const editHistoryId = generateId();
     const changesSummary = this.createChangesSummary(changes);
 
-    // Wrap both writes in a transaction so a partial failure leaves no orphan records
-    await prisma.$transaction(async (tx) => {
-      await tx.responseEditHistory.create({
+    const writeHistory = async (client: Prisma.TransactionClient) => {
+      await client.responseEditHistory.create({
         data: {
           id: editHistoryId,
           responseId,
@@ -324,7 +330,7 @@ export class ResponseEditTrackingService {
 
       await Promise.all(
         changes.map((change) =>
-          tx.responseFieldChange.create({
+          client.responseFieldChange.create({
             data: {
               id: generateId(),
               editHistoryId,
@@ -339,7 +345,17 @@ export class ResponseEditTrackingService {
           })
         )
       );
-    });
+    };
+
+    if (tx) {
+      // Use the caller's transaction — no nested $transaction needed
+      await writeHistory(tx);
+    } else {
+      // Wrap both writes in a transaction so a partial failure leaves no orphan records
+      await prisma.$transaction(async (innerTx) => {
+        await writeHistory(innerTx);
+      });
+    }
   }
 
   /**

--- a/apps/backend/src/services/responseService.ts
+++ b/apps/backend/src/services/responseService.ts
@@ -334,26 +334,34 @@ export const updateResponse = async (
       const { response: currentResponse, formSchema } = await ResponseEditTrackingService.getResponseWithFormSchema(responseId);
       const oldData = currentResponse.data as Prisma.JsonObject;
 
-      // Update the response
-      const updatedResponse = await responseRepository.update({
-        where: { id: responseId },
-        data: { data: data as Prisma.InputJsonValue },
-      });
+      // P2-02: Wrap the response update and edit history recording in a single
+      // transaction so a failure in recordEdit never leaves an untracked edit,
+      // and a failure in the response update never creates an orphaned audit record.
+      const updatedResponse = await prisma.$transaction(async (tx) => {
+        // 1. Update the response row inside the transaction
+        const updated = await tx.response.update({
+          where: { id: responseId },
+          data: { data: data as Prisma.InputJsonValue },
+        });
 
-      // Record the edit with field-level changes
-      await ResponseEditTrackingService.recordEdit(
-        responseId,
-        oldData,
-        data,
-        formSchema,
-        {
-          userId: editContext.userId,
-          ipAddress: editContext.ipAddress,
-          userAgent: editContext.userAgent,
-          editType: 'MANUAL',
-          editReason: editContext.editReason
-        }
-      );
+        // 2. Record the edit history inside the same transaction
+        await ResponseEditTrackingService.recordEdit(
+          responseId,
+          oldData,
+          data,
+          formSchema,
+          {
+            userId: editContext.userId,
+            ipAddress: editContext.ipAddress,
+            userAgent: editContext.userAgent,
+            editType: 'MANUAL',
+            editReason: editContext.editReason
+          },
+          tx
+        );
+
+        return updated;
+      });
 
       return {
         id: updatedResponse.id,


### PR DESCRIPTION
## Summary

Implements P2-02 through P2-11 from the production readiness audit. All changes are in the backend package; 0 TypeScript errors; all 1890 unit tests pass.

- **P2-02** — `updateResponse` + `recordEdit` wrapped in a single `prisma.$transaction`; `recordEdit` accepts an optional `Prisma.TransactionClient` so callers can inject their own transaction context.
- **P2-03** — `createForm` now wraps `createForm` + `createOwnerPermission` in one `prisma.$transaction`; a permission-write failure rolls back the form row instead of leaving an owner-less orphan form.
- **P2-04** — `submitResponse` resolver validates `input.data`: rejects payloads with >500 keys or any string value exceeding 10,000 characters (`BAD_USER_INPUT`).
- **P2-05** — `getFormSubmissionAnalytics` replaced JS-side percentile sort with a `PERCENTILE_CONT` SQL aggregate; distribution query capped at `take: 10_000`.
- **P2-06** — `adminOrganizationById` switched from `forms: true` (loads `formSchema` blob) to a selective `select`; S3 `listObjects` in `adminStats` cached for 60 minutes with an exported `_clearStatsCacheForTests()` hook.
- **P2-09** — `better-auth` `user.delete.after` hook nulls out `ipAddress` / `userAgent` on all `ResponseEditHistory` rows for the deleted user (GDPR compliance).
- **P2-10** — `session_token` cookie gets explicit `httpOnly: true`, `secure` (production only), `sameSite: 'lax'` attributes.
- **P2-11** — `emailService` transporter uses `secure: port === 465` and `requireTLS: port !== 465` to prevent silent STARTTLS downgrade.

## Test plan

- [ ] `pnpm --filter backend type-check` passes (0 errors)
- [ ] `pnpm test:unit` passes (71 test files, 1890 tests)
- [ ] `pnpm --filter backend lint` — no errors
- [ ] Submit a form response with >500 fields → expect `BAD_USER_INPUT` error
- [ ] Submit a form response with a string field >10,000 chars → expect `BAD_USER_INPUT` error
- [ ] Delete a user and verify `ResponseEditHistory.ipAddress` / `userAgent` are nulled
- [ ] Verify outbound emails use STARTTLS (check SMTP logs for TLS negotiation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)