### PR TITLE
chore(p4): frontend housekeeping

### DIFF
--- a/apps/admin-app/src/App.tsx
+++ b/apps/admin-app/src/App.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { useAuth } from './hooks/useAuth';
 import AdminLayout from './components/AdminLayout';
@@ -9,6 +10,30 @@ import { UsersPage } from './pages/users/UsersPage';
 import { UserDetailPage } from './pages/users/UserDetailPage';
 import TemplatesPage from './pages/TemplatesPage';
 import { LoadingSpinner } from '@dculus/ui';
+
+class AdminErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { hasError: boolean }
+> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+  static getDerivedStateFromError() { return { hasError: true }; }
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '100vh', gap: '16px', fontFamily: 'sans-serif' }}>
+          <p style={{ color: '#6b7280' }}>Something went wrong.</p>
+          <button onClick={() => window.location.reload()} style={{ padding: '8px 16px', background: '#3b82f6', color: 'white', border: 'none', borderRadius: '6px', cursor: 'pointer' }}>
+            Reload
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 function App() {
   const { isLoading, isAuthenticated, isAdmin } = useAuth();
@@ -41,4 +66,10 @@ function App() {
   );
 }
 
-export default App;
+const WrappedApp: React.FC = () => (
+  <AdminErrorBoundary>
+    <App />
+  </AdminErrorBoundary>
+);
+
+export default WrappedApp;

--- a/apps/form-app/src/components/AuthorizationErrorBoundary.tsx
+++ b/apps/form-app/src/components/AuthorizationErrorBoundary.tsx
@@ -84,7 +84,7 @@ export const AuthorizationErrorBoundary: React.FC<AuthorizationErrorBoundaryProp
         </Alert>
 
         {/* Show detailed error message in development or for debugging */}
-        {process.env.NODE_ENV === 'development' && (
+        {import.meta.env.DEV && (
           <details className="text-sm text-muted-foreground">
             <summary className="cursor-pointer hover:text-foreground">
               {t('labels.technicalError')}

--- a/apps/form-app/src/graphql/queries.ts
+++ b/apps/form-app/src/graphql/queries.ts
@@ -159,20 +159,6 @@ export const GET_FORM_RESPONSES = gql`
   }
 `;
 
-export const GET_ALL_FORM_RESPONSES = gql`
-  query GetAllFormResponses($formId: ID!) {
-    responsesByForm(formId: $formId, page: 1, limit: 10000, sortBy: "submittedAt", sortOrder: "desc") {
-      data {
-        id
-        formId
-        data
-        submittedAt
-      }
-      total
-    }
-  }
-`;
-
 export const GENERATE_FORM_RESPONSE_REPORT = gql`
   mutation GenerateFormResponseReport($formId: ID!, $format: ExportFormat!, $filters: [ResponseFilterInput!], $filterLogic: FilterLogic) {
     generateFormResponseReport(formId: $formId, format: $format, filters: $filters, filterLogic: $filterLogic) {

--- a/apps/form-app/src/pages/ResponseEditHistory.tsx
+++ b/apps/form-app/src/pages/ResponseEditHistory.tsx
@@ -5,7 +5,7 @@ import { format } from 'date-fns';
 import { useTranslation } from '../hooks/useTranslation';
 import { GET_FORM_BY_ID, GET_RESPONSE_BY_ID } from '../graphql/queries';
 import { useResponseEditHistory } from '../hooks/useResponseEditHistory';
-import { Alert, AlertDescription, Button, LoadingSpinner, EmptyState } from '@dculus/ui';
+import { Alert, AlertDescription, Button, LoadingSpinner, EmptyState, toastError } from '@dculus/ui';
 import {
   ArrowLeft,
   History,
@@ -59,9 +59,8 @@ export const ResponseEditHistory: React.FC = () => {
   const response = responseData?.response;
   const isLoading = formLoading || responseLoading || isLoadingHistory;
 
-  const handleViewSnapshot = (editId: string) => {
-    // Could open a modal or navigate to a detailed view in the future
-    console.log('View snapshot for edit:', editId);
+  const handleViewSnapshot = (_editId: string) => {
+    toastError('Not available', 'Snapshot view is coming soon');
   };
 
   const handleGoToEdit = () => {

--- a/apps/form-viewer/src/pages/FormViewer.tsx
+++ b/apps/form-viewer/src/pages/FormViewer.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery, useMutation } from '@apollo/client';
-import { Button, FormRenderer } from '@dculus/ui';
+import { Button, FormRenderer, useFormResponseStore } from '@dculus/ui';
 import { deserializeFormSchema, FieldType } from '@dculus/types';
 import { RendererMode } from '@dculus/utils';
 import { GET_FORM_BY_SHORT_URL, SUBMIT_RESPONSE } from '../graphql/queries';
@@ -350,6 +350,12 @@ const FormViewer: React.FC = () => {
     console.warn('No CDN endpoint found. Images may not load properly.');
   }
 
+  const handleSubmitAnother = () => {
+    useFormResponseStore.getState().clearAllResponses();
+    setSubmissionState('idle');
+    setThankYouData(null);
+  };
+
   // Show success message after submission
   if (submissionState === 'success' && thankYouData) {
     return (
@@ -361,10 +367,7 @@ const FormViewer: React.FC = () => {
           />
           <div className="text-center mt-6">
             <Button
-              onClick={() => {
-                setSubmissionState('idle');
-                setThankYouData(null);
-              }}
+              onClick={handleSubmitAnother}
               className="px-4 py-2"
             >
               Submit Another Response


### PR DESCRIPTION
## Summary

- **P4-10**: Add `AdminErrorBoundary` class component to `admin-app/src/App.tsx` to catch unhandled render errors and show a user-friendly reload prompt
- **P4-11**: Replace `process.env.NODE_ENV === 'development'` with `import.meta.env.DEV` in `AuthorizationErrorBoundary.tsx` (correct Vite API)
- **P4-12**: Remove dead `GET_ALL_FORM_RESPONSES` query (limit: 10000) from `form-app/src/graphql/queries.ts` — confirmed zero call sites
- **P4-13**: Replace silent `console.log('View snapshot...')` stub in `ResponseEditHistory.tsx` with a `toastError('Not available', 'Snapshot view is coming soon')` so users get actionable feedback
- **P4-14**: Call `useFormResponseStore.getState().clearAllResponses()` before resetting submission state when the user clicks "Submit Another Response" in `FormViewer.tsx`, preventing stale field values from pre-populating the next submission

## Test plan

- [ ] Admin app: Trigger a render error (e.g. throw in a child component) — should show "Something went wrong" with a Reload button instead of a blank screen
- [ ] Form app: Confirm the technical error details `<details>` section only appears in dev builds (not production)
- [ ] Form app: Verify no TypeScript or runtime errors from the removed query
- [ ] Response edit history: Click "View Snapshot" — should show a toast "Snapshot view is coming soon" instead of silently logging
- [ ] Form viewer: Submit a form, click "Submit Another Response" — all fields should be blank (not pre-filled with previous answers)
- [ ] `pnpm --filter form-app type-check` passes
- [ ] `pnpm --filter admin-app type-check` passes
- [ ] `pnpm --filter form-viewer type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)