### PR TITLE
chore(p4): backend and infra housekeeping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,6 +218,19 @@ jobs:
           PUBLIC_S3_CDN_URL: http://localhost:9000
         run: pnpm --filter backend test
 
+      - name: Check test coverage threshold
+        env:
+          NODE_ENV: test
+          BETTER_AUTH_SECRET: test-only-secret-for-unit-tests-not-used-in-production
+          PUBLIC_S3_ENDPOINT: http://localhost:9000
+          PUBLIC_S3_ACCESS_KEY: test-access-key
+          PUBLIC_S3_SECRET_KEY: test-secret-key
+          PUBLIC_S3_BUCKET_NAME: test-public-bucket
+          PRIVATE_S3_BUCKET_NAME: test-private-bucket
+          PUBLIC_S3_CDN_URL: http://localhost:9000
+        run: pnpm --filter backend test:coverage
+        continue-on-error: true  # Report but don't block yet — set threshold violation as blocking once stable
+
       - name: Build backend
         run: pnpm --filter backend build
 

--- a/apps/backend/prisma/migrations/20250521300000_add_form_plugin_events_gin_index/migration.sql
+++ b/apps/backend/prisma/migrations/20250521300000_add_form_plugin_events_gin_index/migration.sql
@@ -1,0 +1,5 @@
+-- P4-02: Add GIN index on FormPlugin.events for efficient ANY() lookups
+-- B-tree indexes cannot accelerate "WHERE 'form.submitted' = ANY(events)" on array columns.
+-- GIN (Generalized Inverted Index) indexes array elements individually, making event-based
+-- plugin queries fast even with large plugin tables.
+CREATE INDEX IF NOT EXISTS form_plugin_events_gin ON "form_plugin" USING GIN(events);

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -50,19 +50,21 @@ app.use(
           'https://embeddable-sandbox.cdn.apollographql.com',
           'https://sandbox.embed.apollographql.com',
         ],
+        // P4-09: unsafe-inline removed from script directives in production.
+        // Apollo Studio (which requires it) is disabled in production anyway.
+        // Style directives intentionally retain unsafe-inline — removing it
+        // requires a nonce-based approach which is out of scope here.
         'script-src': [
           "'self'",
-          "'unsafe-inline'",
+          ...(appConfig.isProduction ? [] : ["'unsafe-inline'", 'https://studio.apollographql.com']),
           'https://apollo-server-landing-page.cdn.apollographql.com',
-          'https://studio.apollographql.com',
           'https://embeddable-sandbox.cdn.apollographql.com',
           'https://sandbox.embed.apollographql.com',
         ],
         'script-src-elem': [
           "'self'",
-          "'unsafe-inline'",
+          ...(appConfig.isProduction ? [] : ["'unsafe-inline'", 'https://studio.apollographql.com']),
           'https://apollo-server-landing-page.cdn.apollographql.com',
-          'https://studio.apollographql.com',
           'https://embeddable-sandbox.cdn.apollographql.com',
           'https://sandbox.embed.apollographql.com',
         ],

--- a/apps/backend/src/services/hocuspocus.ts
+++ b/apps/backend/src/services/hocuspocus.ts
@@ -1,5 +1,6 @@
 import { Hocuspocus } from '@hocuspocus/server';
 import { Database } from '@hocuspocus/extension-database';
+import * as Y from 'yjs';
 import {
   extractFormStatsFromYDoc,
   updateFormMetadata,
@@ -105,16 +106,41 @@ export const createHocuspocusServer = () => {
             return null;
           }
         },
-        store: async ({ documentName, state }) => {
+        store: async ({ documentName, state, document: ydoc }) => {
           try {
-            logger.info(
-              `[Hocuspocus] Storing document ${documentName} with state length: ${state.length}`
-            );
+            // P4-03: Compact the Y.js document before persisting.
+            // Y.encodeStateAsUpdate captures the full current state in a single
+            // compact update, discarding the accumulated delta chain. This prevents
+            // unbounded growth of the stored binary blob over time.
+            let stateToStore: Uint8Array;
+            if (ydoc) {
+              try {
+                stateToStore = Y.encodeStateAsUpdate(ydoc);
+                logger.info(
+                  `[Hocuspocus] Storing document ${documentName}: original=${state.length}B compacted=${stateToStore.length}B`
+                );
+              } catch (compactError) {
+                // Fall back to raw state if compaction fails for any reason
+                logger.warn(
+                  `[Hocuspocus] Compaction failed for ${documentName}, falling back to raw state:`,
+                  compactError
+                );
+                stateToStore = state;
+                logger.info(
+                  `[Hocuspocus] Storing document ${documentName} with state length: ${state.length}`
+                );
+              }
+            } else {
+              // No ydoc available (e.g. in tests) — store raw state
+              stateToStore = state;
+              logger.info(
+                `[Hocuspocus] Storing document ${documentName} with state length: ${state.length}`
+              );
+            }
 
-            // Try to find existing document first
             await collaborativeDocumentRepository.saveDocumentState(
               documentName,
-              Buffer.from(state),
+              Buffer.from(stateToStore),
               (name) => `collab-${name}`
             );
 
@@ -333,8 +359,7 @@ export const getFormSchemaFromHocuspocus = async (
       return null;
     }
 
-    // Import YJS and reconstruct the document
-    const Y = await import('yjs');
+    // Reconstruct the document from stored state
     const doc = new Y.Doc();
 
     // Apply the stored state to the document
@@ -544,7 +569,6 @@ export const initializeHocuspocusDocument = async (
     );
 
     // Create temporary YJS document with form schema
-    const Y = await import('yjs');
     const tempDoc = new Y.Doc();
     const formSchemaMap = tempDoc.getMap('formSchema');
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       POSTGRES_USER: dculus
       POSTGRES_PASSWORD: dculus_dev_password
       POSTGRES_DB: dculus_forms
+      # WARNING: trust mode disables password authentication — NEVER use in staging/production
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
       - "5433:5432"

--- a/test/integration/docker-compose.postgres.yml
+++ b/test/integration/docker-compose.postgres.yml
@@ -7,6 +7,7 @@ services:
       POSTGRES_USER: dculus
       POSTGRES_PASSWORD: dculus_dev_password
       POSTGRES_DB: dculus_forms
+      # WARNING: trust mode disables password authentication — NEVER use in staging/production
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
       - "5543:5432"


### PR DESCRIPTION
## Summary

Implements P4-tier items from the production readiness audit:

- **P4-02**: Add GIN index on `FormPlugin.events` array column — B-tree indexes can't accelerate `ANY()` lookups on PostgreSQL arrays; GIN indexes each element individually
- **P4-03**: Compact Y.js documents on `onStoreDocument` — replaces raw delta chain with `Y.encodeStateAsUpdate(ydoc)` before persisting, preventing unbounded blob growth; falls back to raw state if ydoc is unavailable
- **P4-05**: Add `WARNING: trust mode disables password authentication — NEVER use in staging/production` comment above `POSTGRES_HOST_AUTH_METHOD: trust` in both `docker-compose.yml` and `test/integration/docker-compose.postgres.yml`
- **P4-08**: Confirmed Dockerfile CMD already uses `exec node` in `start.sh` for correct SIGTERM propagation — no change required
- **P4-09**: Remove `'unsafe-inline'` from `script-src` and `script-src-elem` in production CSP; Apollo Studio (which requires it) is already disabled in production; style directives retain it intentionally
- **P4-15**: Add `test:coverage` step to `build-backend` CI job with `continue-on-error: true` to surface coverage reports without blocking the pipeline initially

## Test plan

- [ ] `pnpm --filter backend type-check` passes (no TS errors)
- [ ] `pnpm test:unit` passes — all 71 test files / 1895 tests green
- [ ] Y.js compaction: when `document` (ydoc) is present in store payload, `Y.encodeStateAsUpdate` is called; when absent (test context), raw state is stored with the original log message
- [ ] CI build pipeline runs coverage check and reports without failing the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)