### PR TITLE
fix(admin): reset AI credits usage in adminResetUsage

### DIFF
--- a/apps/backend/src/graphql/resolvers/__tests__/admin.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/admin.test.ts
@@ -4,6 +4,7 @@ import { GraphQLError } from '#graphql-errors';
 import { prisma } from '../../../lib/prisma.js';
 import { cancelChargebeeSubscription, reactivateChargebeeSubscription } from '../../../services/chargebeeService.js';
 import { resetUsageCounters } from '../../../subscriptions/usageService.js';
+import { invalidateAIBudgetCache } from '../../../services/aiUsageService.js';
 
 // Mock all dependencies
 vi.mock('../../../lib/prisma.js', () => ({
@@ -78,6 +79,10 @@ vi.mock('../../../services/chargebeeService.js', () => ({
 
 vi.mock('../../../subscriptions/usageService.js', () => ({
   resetUsageCounters: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../services/aiUsageService.js', () => ({
+  invalidateAIBudgetCache: vi.fn(),
 }));
 
 describe('Admin Resolvers', () => {
@@ -1214,7 +1219,7 @@ describe('Admin Resolvers', () => {
       expect(vi.mocked(resetUsageCounters)).toHaveBeenCalledWith('org-1', periodStart, periodEnd);
       expect(vi.mocked(prisma.aIUsage.updateMany)).toHaveBeenCalledWith({
         where: { organizationId: 'org-1' },
-        data: { tokensUsed: 0 },
+        data: { tokensUsed: 0, creditsUsedMilli: 0 },
       });
       expect(vi.mocked(prisma.auditLog.create)).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1224,6 +1229,26 @@ describe('Admin Resolvers', () => {
           }),
         })
       );
+    });
+
+    it('should zero creditsUsedMilli and invalidate the AI budget cache', async () => {
+      const periodStart = new Date('2026-05-01');
+      const periodEnd = new Date('2026-05-31');
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        organizationId: 'org-1', viewsUsed: 500, submissionsUsed: 200,
+        currentPeriodStart: periodStart, currentPeriodEnd: periodEnd,
+      } as any);
+      vi.mocked(prisma.subscription.update).mockResolvedValue({} as any);
+      vi.mocked(prisma.auditLog.create).mockResolvedValue({} as any);
+      vi.mocked(prisma.aIUsage.aggregate).mockResolvedValue({ _sum: { tokensUsed: 1500 } } as any);
+      vi.mocked(prisma.aIUsage.updateMany).mockResolvedValue({ count: 1 } as any);
+
+      await adminResolvers.Mutation.adminResetUsage({}, { orgId: 'org-1' }, mockAdminContext);
+
+      expect(vi.mocked(prisma.aIUsage.updateMany)).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ creditsUsedMilli: 0 }) })
+      );
+      expect(vi.mocked(invalidateAIBudgetCache)).toHaveBeenCalledWith('org-1');
     });
 
     it('should throw NOT_FOUND when subscription does not exist', async () => {

--- a/apps/backend/src/graphql/resolvers/admin.ts
+++ b/apps/backend/src/graphql/resolvers/admin.ts
@@ -6,6 +6,7 @@ import { s3Config } from '../../lib/env.js';
 import { logger } from '../../lib/logger.js';
 import { cancelChargebeeSubscription, reactivateChargebeeSubscription } from '../../services/chargebeeService.js';
 import { resetUsageCounters } from '../../subscriptions/usageService.js';
+import { invalidateAIBudgetCache } from '../../services/aiUsageService.js';
 import { type BetterAuthContext } from '../../middleware/better-auth-middleware.js';
 
 export interface AdminOrganizationsArgs {
@@ -641,9 +642,11 @@ export const adminResolvers = {
         resetUsageCounters(orgId, subscription.currentPeriodStart, subscription.currentPeriodEnd),
         prisma.aIUsage.updateMany({
           where: { organizationId: orgId },
-          data: { tokensUsed: 0 },
+          data: { tokensUsed: 0, creditsUsedMilli: 0 },
         }),
       ]);
+
+      invalidateAIBudgetCache(orgId);
 
       await prisma.auditLog.create({
         data: {

--- a/apps/backend/src/services/__tests__/aiUsageService.test.ts
+++ b/apps/backend/src/services/__tests__/aiUsageService.test.ts
@@ -21,6 +21,7 @@ import {
   checkAITokenBudget,
   recordAITokenUsage,
   getAITokenUsage,
+  invalidateAIBudgetCache,
 } from '../aiUsageService.js';
 
 describe('aiUsageService', () => {
@@ -98,6 +99,26 @@ describe('aiUsageService', () => {
       expect(result.limit).toBe(200);
       expect(result.used).toBe(0);
       expect(result.allowed).toBe(true);
+    });
+
+    it('serves a cached blocked result within the TTL, then re-fetches after invalidateAIBudgetCache', async () => {
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'starter',
+        aiCreditsLimit: 200,
+      } as any);
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue({ creditsUsedMilli: 200_000 } as any);
+
+      const blocked = await checkAITokenBudget('org-reset');
+      expect(blocked.allowed).toBe(false);
+
+      // Simulate an admin reset zeroing the DB row without a cache-aware call.
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue({ creditsUsedMilli: 0 } as any);
+      const stillCached = await checkAITokenBudget('org-reset');
+      expect(stillCached.allowed).toBe(false); // stale cache still in effect
+
+      invalidateAIBudgetCache('org-reset');
+      const fresh = await checkAITokenBudget('org-reset');
+      expect(fresh.allowed).toBe(true);
     });
   });
 

--- a/apps/backend/src/services/aiUsageService.ts
+++ b/apps/backend/src/services/aiUsageService.ts
@@ -30,6 +30,14 @@ function effectiveCreditLimit(subscription: { planId: string; aiCreditsLimit: nu
 }
 
 /**
+ * Invalidates the in-memory budget cache for an org, forcing the next
+ * `checkAITokenBudget` call to read fresh data instead of a stale cached result.
+ */
+export function invalidateAIBudgetCache(organizationId: string): void {
+  budgetCache.delete(organizationId);
+}
+
+/**
  * Checks whether an org is within its monthly AI-credit budget.
  * `used`/`limit` are both in **credits** (not raw tokens) — 1 credit = 1,000 milli-credits.
  */


### PR DESCRIPTION
## Summary
- `adminResetUsage` zeroed `AIUsage.tokensUsed` but never touched `creditsUsedMilli`, the field `checkAITokenBudget` actually reads to decide if an org is over its AI budget. An admin running "Reset Usage Counters" against an org blocked on AI credits saw a success response but the org stayed blocked.
- `adminResetUsage` now also zeroes `creditsUsedMilli` on the org's `AIUsage` row(s).
- Added `invalidateAIBudgetCache` to `aiUsageService.ts` and call it after the reset so the 30s in-memory budget cache doesn't serve a stale `allowed: false` result.

## Test plan
- [x] `pnpm test:unit` (backend) — 2376 tests pass, including new coverage:
  - `admin.test.ts`: asserts `creditsUsedMilli: 0` is passed to `aIUsage.updateMany` and `invalidateAIBudgetCache` is called with the org ID.
  - `aiUsageService.test.ts`: asserts the cache serves a stale blocked result within the TTL, and returns fresh (allowed) data immediately after `invalidateAIBudgetCache`.
- [x] `pnpm --filter backend type-check`
- [x] `pnpm --filter backend lint` (0 errors; pre-existing warnings only)

Fixes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)