### PR TITLE
fix(subscriptions): enforce past_due/cancelled status in AI credit and usage checks

### DIFF
--- a/apps/backend/src/lib/planLimits.ts
+++ b/apps/backend/src/lib/planLimits.ts
@@ -1,0 +1,11 @@
+// Fallback limits used when Chargebee entitlements are unavailable, and as the
+// floor a cancelled/expired org's usage enforcement falls back to (it no longer
+// holds an active paid entitlement, so it must not keep the last-synced paid
+// tier's limits indefinitely).
+// Keep in sync with Chargebee entitlement config — the live values take
+// precedence once getAvailablePlans() has populated the cache.
+export const PLAN_LIMITS_FALLBACK: Record<string, { views: number | null; submissions: number | null }> = {
+  free: { views: 10000, submissions: 1000 },
+  starter: { views: null, submissions: 10000 },
+  advanced: { views: null, submissions: 100000 },
+};

--- a/apps/backend/src/services/__tests__/aiUsageService.test.ts
+++ b/apps/backend/src/services/__tests__/aiUsageService.test.ts
@@ -99,6 +99,57 @@ describe('aiUsageService', () => {
       expect(result.used).toBe(0);
       expect(result.allowed).toBe(true);
     });
+
+    it('blocks a past_due org regardless of remaining credits', async () => {
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'advanced',
+        aiCreditsLimit: 20_000,
+        status: 'past_due',
+      } as any);
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue({ creditsUsedMilli: 0 } as any);
+
+      const result = await checkAITokenBudget('org-past-due');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('falls back to the free allowance for a cancelled org instead of its last-synced paid limit', async () => {
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'advanced',
+        aiCreditsLimit: 20_000,
+        status: 'cancelled',
+      } as any);
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue({ creditsUsedMilli: 0 } as any);
+
+      const result = await checkAITokenBudget('org-cancelled');
+      expect(result.limit).toBe(200); // free fallback, not the retained 20,000 advanced limit
+      expect(result.allowed).toBe(true);
+    });
+
+    it('falls back to the free allowance for an expired org', async () => {
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'starter',
+        aiCreditsLimit: 2_000,
+        status: 'expired',
+      } as any);
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue({ creditsUsedMilli: 250_000 } as any);
+
+      const result = await checkAITokenBudget('org-expired');
+      expect(result.limit).toBe(200);
+      expect(result.allowed).toBe(false); // 250 credits used already exceeds the free 200 limit
+    });
+
+    it('leaves an active paid org unaffected', async () => {
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'advanced',
+        aiCreditsLimit: 20_000,
+        status: 'active',
+      } as any);
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue({ creditsUsedMilli: 5_000_000 } as any);
+
+      const result = await checkAITokenBudget('org-active');
+      expect(result.limit).toBe(20_000);
+      expect(result.allowed).toBe(true);
+    });
   });
 
   describe('getAITokenUsage', () => {

--- a/apps/backend/src/services/aiUsageService.ts
+++ b/apps/backend/src/services/aiUsageService.ts
@@ -19,8 +19,19 @@ function currentPeriod(): { start: Date; end: Date } {
  * `null`/missing means "not yet synced from Chargebee" — it is NOT unlimited — so we fall
  * back to the plan's default allowance in AI_CREDIT_LIMITS_FALLBACK, defaulting to `free`
  * if the plan itself is unrecognized.
+ *
+ * A cancelled/expired subscription keeps whatever `planId`/`aiCreditsLimit` it last synced
+ * from Chargebee (cancellation doesn't change which plan item was on the subscription), so
+ * without this check the org would retain paid-tier AI credits indefinitely. Fall back to
+ * the free allowance instead — mirrors the views/submissions enforcement in usageService.ts.
  */
-function effectiveCreditLimit(subscription: { planId: string; aiCreditsLimit: number | null } | null): number {
+function effectiveCreditLimit(
+  subscription: { planId: string; aiCreditsLimit: number | null; status: string } | null
+): number {
+  if (subscription && (subscription.status === 'cancelled' || subscription.status === 'expired')) {
+    return AI_CREDIT_LIMITS_FALLBACK.free;
+  }
+
   const planId = subscription?.planId ?? 'free';
   return (
     subscription?.aiCreditsLimit ??
@@ -53,7 +64,12 @@ export async function checkAITokenBudget(organizationId: string): Promise<{
   const limit = effectiveCreditLimit(subscription);
   const creditsUsedMilli = usage?.creditsUsedMilli ?? 0;
   const used = creditsUsedMilli / 1000;
-  const result = { allowed: creditsUsedMilli < limit * 1000, used, limit };
+
+  // A past_due subscription means the last payment failed. Block AI credits until
+  // payment recovers, regardless of remaining budget — consistent with how
+  // checkUsageExceeded blocks views/submissions for the same status.
+  const isPastDue = subscription?.status === 'past_due';
+  const result = { allowed: !isPastDue && creditsUsedMilli < limit * 1000, used, limit };
 
   budgetCache.set(organizationId, { result, cachedAt: Date.now() });
   return result;

--- a/apps/backend/src/services/chargebeeService.ts
+++ b/apps/backend/src/services/chargebeeService.ts
@@ -6,6 +6,7 @@ import { prisma } from '../lib/prisma.js';
 import { sendEmail } from './emailService.js';
 import * as Sentry from '@sentry/node';
 import { AI_CREDIT_LIMITS_FALLBACK } from '../lib/ai.js';
+import { PLAN_LIMITS_FALLBACK } from '../lib/planLimits.js';
 
 /**
  * Chargebee Service
@@ -17,15 +18,6 @@ const chargebee = new Chargebee({
   site: process.env.CHARGEBEE_SITE!,
   apiKey: process.env.CHARGEBEE_API_KEY!,
 });
-
-// Fallback limits used when Chargebee entitlements are unavailable.
-// Keep in sync with Chargebee entitlement config — the live values take precedence
-// once getAvailablePlans() has populated the cache.
-const PLAN_LIMITS_FALLBACK: Record<string, { views: number | null; submissions: number | null }> = {
-  free: { views: 10000, submissions: 1000 },
-  starter: { views: null, submissions: 10000 },
-  advanced: { views: null, submissions: 100000 },
-};
 
 // Chargebee returns unlimited entitlement values as the string "Unlimited"
 // (capital U) in live responses; some fixtures/tests use lowercase. Compare

--- a/apps/backend/src/subscriptions/__tests__/usageService.test.ts
+++ b/apps/backend/src/subscriptions/__tests__/usageService.test.ts
@@ -578,6 +578,78 @@ describe('usageService', () => {
         submissionsExceeded: true,
       });
     });
+
+    it('should block both views and submissions for a past_due org regardless of usage', async () => {
+      mockSubscription.findUnique.mockResolvedValue({
+        organizationId: 'org-1',
+        viewsUsed: 0,
+        viewsLimit: null,
+        submissionsUsed: 0,
+        submissionsLimit: null,
+        status: 'past_due',
+      });
+
+      const result = await checkUsageExceeded('org-1');
+
+      expect(result).toEqual({
+        viewsExceeded: true,
+        submissionsExceeded: true,
+      });
+    });
+
+    it('should fall back to the free plan limits for a cancelled org instead of its retained paid limits', async () => {
+      mockSubscription.findUnique.mockResolvedValue({
+        organizationId: 'org-1',
+        viewsUsed: 500,
+        viewsLimit: null, // retained "advanced" unlimited views from before cancellation
+        submissionsUsed: 1500, // over the free plan's 1000 submissions allowance
+        submissionsLimit: 100000, // retained "advanced" limit from before cancellation
+        status: 'cancelled',
+      });
+
+      const result = await checkUsageExceeded('org-1');
+
+      expect(result).toEqual({
+        viewsExceeded: false, // free plan's views limit (10000) not yet reached
+        submissionsExceeded: true, // free plan's submissions limit (1000) exceeded
+      });
+    });
+
+    it('should fall back to the free plan limits for an expired org', async () => {
+      mockSubscription.findUnique.mockResolvedValue({
+        organizationId: 'org-1',
+        viewsUsed: 15000, // over the free plan's 10000 views allowance
+        viewsLimit: null,
+        submissionsUsed: 5,
+        submissionsLimit: 10000,
+        status: 'expired',
+      });
+
+      const result = await checkUsageExceeded('org-1');
+
+      expect(result).toEqual({
+        viewsExceeded: true,
+        submissionsExceeded: false,
+      });
+    });
+
+    it('should leave an active paid org unaffected by the cancelled/expired fallback', async () => {
+      mockSubscription.findUnique.mockResolvedValue({
+        organizationId: 'org-1',
+        viewsUsed: 5000,
+        viewsLimit: null,
+        submissionsUsed: 50000,
+        submissionsLimit: 100000,
+        status: 'active',
+      });
+
+      const result = await checkUsageExceeded('org-1');
+
+      expect(result).toEqual({
+        viewsExceeded: false,
+        submissionsExceeded: false,
+      });
+    });
   });
 
   describe('getUsage', () => {

--- a/apps/backend/src/subscriptions/usageService.ts
+++ b/apps/backend/src/subscriptions/usageService.ts
@@ -9,6 +9,7 @@ import { SubscriptionEventType } from './types.js';
 import type { FormViewedEvent, FormSubmittedEvent } from './types.js';
 import { logger } from '../lib/logger.js';
 import { isLocalDatabase } from '../lib/prisma.js';
+import { PLAN_LIMITS_FALLBACK } from '../lib/planLimits.js';
 import { subscriptionRepository } from '../repositories/subscriptionRepository.js';
 
 // Keep the app-side pool small in production (max: 2) — PgBouncer handles
@@ -206,14 +207,21 @@ export const checkUsageExceeded = async (
   // submissions until payment recovers — consistent enforcement across all usage types.
   const isPastDue = subscription.status === 'past_due';
 
+  // A cancelled/expired subscription keeps whatever viewsLimit/submissionsLimit it last
+  // synced from Chargebee (cancellation doesn't change which plan item was on the
+  // subscription), so without this the org would retain paid-tier limits indefinitely.
+  // Fall back to the free plan's limits instead — mirrors the AI-credits enforcement in
+  // aiUsageService.ts.
+  const isCancelledOrExpired = subscription.status === 'cancelled' || subscription.status === 'expired';
+  const viewsLimit = isCancelledOrExpired ? PLAN_LIMITS_FALLBACK.free.views : subscription.viewsLimit;
+  const submissionsLimit = isCancelledOrExpired
+    ? PLAN_LIMITS_FALLBACK.free.submissions
+    : subscription.submissionsLimit;
+
   return {
-    viewsExceeded:
-      isPastDue ||
-      (subscription.viewsLimit !== null && subscription.viewsUsed >= subscription.viewsLimit),
+    viewsExceeded: isPastDue || (viewsLimit !== null && subscription.viewsUsed >= viewsLimit),
     submissionsExceeded:
-      isPastDue ||
-      (subscription.submissionsLimit !== null &&
-        subscription.submissionsUsed >= subscription.submissionsLimit),
+      isPastDue || (submissionsLimit !== null && subscription.submissionsUsed >= submissionsLimit),
   };
 };
 


### PR DESCRIPTION
## Summary
- `checkAITokenBudget` never checked `Subscription.status`, so a `past_due` org kept full AI credit access, and a `cancelled`/`expired` org retained its last-synced paid-tier AI credit limit indefinitely.
- `checkAITokenBudget` now blocks `past_due` orgs outright (`allowed: false` regardless of remaining budget) and falls back `cancelled`/`expired` orgs to the free-plan AI credit allowance, matching the pattern already used by `checkUsageExceeded` for views/submissions.
- Verified the same latent gap existed in `checkUsageExceeded` for `cancelled`/`expired` orgs (`syncSubscriptionFromWebhook` derives `planId`/limits from the still-paid-tier `subscription_items` even after cancellation), so fixed it there too for consistency.
- Extracted the shared `PLAN_LIMITS_FALLBACK` map out of `chargebeeService.ts` into `apps/backend/src/lib/planLimits.ts` so `usageService.ts` can reuse it without a circular import.

Fixes #82

## Test plan
- [x] `pnpm test:unit` — added new unit tests for past_due blocking, cancelled/expired free-plan fallback, and active-org non-regression in both `aiUsageService.test.ts` and `usageService.test.ts` (2382 tests passing)
- [x] `pnpm --filter backend type-check` — passes
- [x] `pnpm --filter backend lint` — 0 errors (pre-existing `any` warnings only)
- [ ] Manual verification against Chargebee test site (simulate `payment_failed` and `subscription_cancelled` webhooks) — not run in this session; recommend before merge per issue's testing expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)