### PR TITLE
fix(subscriptions): align AI credit billing period with Chargebee cycle

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -540,6 +540,12 @@ model Subscription {
   @@map("subscription")
 }
 
+// periodStart/periodEnd track the org's actual Chargebee billing cycle
+// (Subscription.currentPeriodStart/currentPeriodEnd), not the calendar month.
+// Rows created before this alignment are keyed to calendar-month boundaries and
+// will simply stop being matched once the org's billing-cycle periodStart no
+// longer coincides with the 1st of the month — no backfill needed, they're kept
+// only as a historical audit trail (see aiUsageService.currentPeriod).
 model AIUsage {
   id               String   @id @default(cuid())
   organizationId   String

--- a/apps/backend/src/services/__tests__/aiUsageService.test.ts
+++ b/apps/backend/src/services/__tests__/aiUsageService.test.ts
@@ -31,6 +31,7 @@ describe('aiUsageService', () => {
 
   describe('recordAITokenUsage', () => {
     it('increments both tokensUsed and creditsUsedMilli on the update branch (nano tier: 1:1 weight)', async () => {
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue(null);
       vi.mocked(prisma.aIUsage.upsert).mockResolvedValue({} as any);
 
       await recordAITokenUsage('org-1', 2000, 'nano');
@@ -44,6 +45,7 @@ describe('aiUsageService', () => {
     });
 
     it('increments creditsUsedMilli by the mini-tier weighted amount (default weight 5x) in both branches', async () => {
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue(null);
       vi.mocked(prisma.aIUsage.upsert).mockResolvedValue({} as any);
 
       await recordAITokenUsage('org-2', 2000, 'mini');
@@ -53,6 +55,26 @@ describe('aiUsageService', () => {
       expect(call.update.creditsUsedMilli).toEqual({ increment: 10000 });
       expect(call.create.tokensUsed).toBe(2000);
       expect(call.create.creditsUsedMilli).toBe(10000);
+    });
+
+    it('keys the upsert to the org billing-cycle periodStart/periodEnd from Subscription, not the calendar month', async () => {
+      const currentPeriodStart = new Date('2024-03-15T00:00:00.000Z');
+      const currentPeriodEnd = new Date('2024-04-14T23:59:59.999Z');
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        currentPeriodStart,
+        currentPeriodEnd,
+      } as any);
+      vi.mocked(prisma.aIUsage.upsert).mockResolvedValue({} as any);
+
+      await recordAITokenUsage('org-billing-cycle', 1000, 'nano');
+
+      const call = vi.mocked(prisma.aIUsage.upsert).mock.calls[0][0] as any;
+      expect(call.where.organizationId_periodStart).toEqual({
+        organizationId: 'org-billing-cycle',
+        periodStart: currentPeriodStart,
+      });
+      expect(call.create.periodStart).toBe(currentPeriodStart);
+      expect(call.create.periodEnd).toBe(currentPeriodEnd);
     });
   });
 
@@ -171,6 +193,76 @@ describe('aiUsageService', () => {
       expect(result.limit).toBe(20_000);
       expect(result.allowed).toBe(true);
     });
+
+    it('looks up AIUsage by the org billing-cycle periodStart from Subscription, not the calendar month', async () => {
+      const currentPeriodStart = new Date('2024-03-15T00:00:00.000Z');
+      const currentPeriodEnd = new Date('2024-04-14T23:59:59.999Z');
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'starter',
+        aiCreditsLimit: 2_000,
+        currentPeriodStart,
+        currentPeriodEnd,
+      } as any);
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue({ creditsUsedMilli: 0 } as any);
+
+      await checkAITokenBudget('org-mid-cycle');
+
+      expect(prisma.aIUsage.findFirst).toHaveBeenCalledWith({
+        where: { organizationId: 'org-mid-cycle', periodStart: currentPeriodStart },
+      });
+    });
+
+    it('a mid-cycle plan upgrade raises the limit without resetting usage already accrued this period', async () => {
+      const currentPeriodStart = new Date('2024-03-15T00:00:00.000Z');
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'starter',
+        aiCreditsLimit: 2_000,
+        currentPeriodStart,
+        currentPeriodEnd: new Date('2024-04-14T23:59:59.999Z'),
+      } as any);
+      // 1,500 of the 2,000 starter credits already used earlier this period.
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue({ creditsUsedMilli: 1_500_000 } as any);
+
+      const beforeUpgrade = await checkAITokenBudget('org-upgrade');
+      expect(beforeUpgrade.used).toBe(1500);
+      expect(beforeUpgrade.limit).toBe(2000);
+      expect(beforeUpgrade.allowed).toBe(true);
+
+      invalidateAIBudgetCache('org-upgrade');
+
+      // Upgrade to advanced mid-period: aiCreditsLimit jumps, periodStart/currentPeriodEnd
+      // is untouched by syncSubscriptionFromWebhook on a plan-change event (only a real
+      // renewal moves the period), and the AIUsage row is untouched too.
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'advanced',
+        aiCreditsLimit: 20_000,
+        currentPeriodStart,
+        currentPeriodEnd: new Date('2024-04-14T23:59:59.999Z'),
+      } as any);
+
+      const afterUpgrade = await checkAITokenBudget('org-upgrade');
+      expect(afterUpgrade.used).toBe(1500); // usage carries over, unchanged
+      expect(afterUpgrade.limit).toBe(20_000); // limit raised immediately
+      expect(afterUpgrade.allowed).toBe(true);
+    });
+
+    it('falls back to calendar-month boundaries when the subscription row is missing period fields', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-03-20T12:00:00.000Z'));
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'starter',
+        aiCreditsLimit: 2_000,
+        // currentPeriodStart/currentPeriodEnd absent — e.g. pre-backfill org
+      } as any);
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue({ creditsUsedMilli: 0 } as any);
+
+      await checkAITokenBudget('org-pre-backfill');
+
+      const call = vi.mocked(prisma.aIUsage.findFirst).mock.calls[0][0] as any;
+      expect(call.where.periodStart).toEqual(new Date(2024, 2, 1));
+
+      vi.useRealTimers();
+    });
   });
 
   describe('getAITokenUsage', () => {
@@ -191,6 +283,25 @@ describe('aiUsageService', () => {
       expect(result.creditsLimit).toBe(2000); // starter fallback
       expect(result.limit).toBe(result.creditsLimit * 1000);
       expect(typeof result.resetAt).toBe('string');
+    });
+
+    it('reports resetAt as the org billing-cycle currentPeriodEnd, not the calendar month end', async () => {
+      const currentPeriodStart = new Date('2024-03-15T00:00:00.000Z');
+      const currentPeriodEnd = new Date('2024-04-14T23:59:59.999Z');
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'starter',
+        aiCreditsLimit: 2_000,
+        currentPeriodStart,
+        currentPeriodEnd,
+      } as any);
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue({
+        tokensUsed: 0,
+        creditsUsedMilli: 0,
+      } as any);
+
+      const result = await getAITokenUsage('org-mid-cycle-reset');
+
+      expect(result.resetAt).toBe(currentPeriodEnd.toISOString());
     });
   });
 });

--- a/apps/backend/src/services/__tests__/chargebeeService.test.ts
+++ b/apps/backend/src/services/__tests__/chargebeeService.test.ts
@@ -14,6 +14,7 @@ import {
 import { resetUsageCounters } from '../../subscriptions/usageService.js';
 import { subscriptionRepository } from '../../repositories/index.js';
 import { logger } from '../../lib/logger.js';
+import { invalidateAIBudgetCache } from '../aiUsageService.js';
 import * as Sentry from '@sentry/node';
 
 // Mock dependencies
@@ -53,6 +54,7 @@ vi.mock('chargebee', () => {
 });
 vi.mock('../../subscriptions/usageService.js');
 vi.mock('../../repositories/index.js');
+vi.mock('../aiUsageService.js', () => ({ invalidateAIBudgetCache: vi.fn() }));
 vi.mock('@sentry/node', () => ({ captureException: vi.fn() }));
 
 const Chargebee = await import('chargebee') as any;
@@ -559,6 +561,20 @@ describe('Chargebee Service', () => {
         new Date(1704067200 * 1000),
         new Date(1706745600 * 1000)
       );
+    });
+
+    it('should invalidate the AI budget cache on renewal, so a mid-cycle upgrade limit or new-period reset is not masked by a stale cached result', async () => {
+      const subscriptionData = {
+        customer_id: 'org_org-123',
+        current_term_start: 1704067200,
+        current_term_end: 1706745600,
+      };
+
+      vi.mocked(resetUsageCounters).mockResolvedValue(undefined);
+
+      await handleSubscriptionRenewal(subscriptionData);
+
+      expect(invalidateAIBudgetCache).toHaveBeenCalledWith('org-123');
     });
 
     it('should handle renewal errors', async () => {

--- a/apps/backend/src/services/aiUsageService.ts
+++ b/apps/backend/src/services/aiUsageService.ts
@@ -5,7 +5,22 @@ import { logger } from '../lib/logger.js';
 const budgetCache = new Map<string, { result: { allowed: boolean; used: number; limit: number }; cachedAt: number }>();
 const BUDGET_CACHE_TTL_MS = 30_000;
 
-function currentPeriod(): { start: Date; end: Date } {
+type SubscriptionPeriod = { currentPeriodStart: Date; currentPeriodEnd: Date } | null | undefined;
+
+/**
+ * AI credit periods follow the org's actual Chargebee billing cycle
+ * (`Subscription.currentPeriodStart`/`currentPeriodEnd`) — the same source of
+ * truth `viewsUsed`/`submissionsUsed` reset against. This keeps a mid-month
+ * billing date from producing two different reset dates for the same org.
+ *
+ * Falls back to calendar-month boundaries when there's no synced subscription
+ * yet (e.g. a pre-backfill org, or a subscription row missing period fields).
+ */
+function currentPeriod(subscription: SubscriptionPeriod): { start: Date; end: Date } {
+  if (subscription?.currentPeriodStart && subscription?.currentPeriodEnd) {
+    return { start: subscription.currentPeriodStart, end: subscription.currentPeriodEnd };
+  }
+
   const now = new Date();
   const start = new Date(now.getFullYear(), now.getMonth(), 1);
   const end = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
@@ -60,14 +75,12 @@ export async function checkAITokenBudget(organizationId: string): Promise<{
   const hit = budgetCache.get(organizationId);
   if (hit && Date.now() - hit.cachedAt < BUDGET_CACHE_TTL_MS) return hit.result;
 
-  const { start } = currentPeriod();
+  const subscription = await prisma.subscription.findUnique({ where: { organizationId } });
+  const { start } = currentPeriod(subscription);
 
-  const [usage, subscription] = await Promise.all([
-    prisma.aIUsage.findFirst({
-      where: { organizationId, periodStart: start },
-    }),
-    prisma.subscription.findUnique({ where: { organizationId } }),
-  ]);
+  const usage = await prisma.aIUsage.findFirst({
+    where: { organizationId, periodStart: start },
+  });
 
   const limit = effectiveCreditLimit(subscription);
   const creditsUsedMilli = usage?.creditsUsedMilli ?? 0;
@@ -94,7 +107,11 @@ export async function recordAITokenUsage(
   tier: AIModelTier
 ): Promise<void> {
   budgetCache.delete(organizationId); // invalidate so next check is fresh
-  const { start, end } = currentPeriod();
+  const subscription = await prisma.subscription.findUnique({
+    where: { organizationId },
+    select: { currentPeriodStart: true, currentPeriodEnd: true },
+  });
+  const { start, end } = currentPeriod(subscription);
   const creditsUsedMilli = tokensToMilliCredits(tokensUsed, tier);
 
   try {
@@ -124,12 +141,10 @@ export async function getAITokenUsage(organizationId: string): Promise<{
   creditsUsed: number;
   creditsLimit: number;
 }> {
-  const { start, end } = currentPeriod();
+  const subscription = await prisma.subscription.findUnique({ where: { organizationId } });
+  const { start, end } = currentPeriod(subscription);
 
-  const [usage, subscription] = await Promise.all([
-    prisma.aIUsage.findFirst({ where: { organizationId, periodStart: start } }),
-    prisma.subscription.findUnique({ where: { organizationId } }),
-  ]);
+  const usage = await prisma.aIUsage.findFirst({ where: { organizationId, periodStart: start } });
 
   const creditsLimit = effectiveCreditLimit(subscription);
   const creditsUsedMilli = usage?.creditsUsedMilli ?? 0;

--- a/apps/backend/src/services/chargebeeService.ts
+++ b/apps/backend/src/services/chargebeeService.ts
@@ -7,6 +7,7 @@ import { sendEmail } from './emailService.js';
 import * as Sentry from '@sentry/node';
 import { AI_CREDIT_LIMITS_FALLBACK } from '../lib/ai.js';
 import { PLAN_LIMITS_FALLBACK } from '../lib/planLimits.js';
+import { invalidateAIBudgetCache } from './aiUsageService.js';
 
 /**
  * Chargebee Service
@@ -331,7 +332,13 @@ export const syncSubscriptionFromWebhook = async (
 
 /**
  * Handle subscription renewal from webhook
- * Resets usage counters for the new billing period
+ * Resets views/submissions usage counters for the new billing period.
+ *
+ * AI credit usage does NOT need an explicit reset here: `aiUsageService`'s
+ * `currentPeriod()` reads `Subscription.currentPeriodStart`/`currentPeriodEnd`
+ * directly, and `resetUsageCounters` below just updated those to the new
+ * period, so the next `recordAITokenUsage` call upserts an `AIUsage` row
+ * keyed to the new `periodStart` — starting that period's usage at zero.
  */
 export const handleSubscriptionRenewal = async (
   subscriptionData: any
@@ -344,6 +351,7 @@ export const handleSubscriptionRenewal = async (
     const periodEnd = new Date(subscriptionData.current_term_end * 1000);
 
     await resetUsageCounters(organizationId, periodStart, periodEnd);
+    invalidateAIBudgetCache(organizationId);
 
     logger.info('[Chargebee Service] Reset usage counters for organization:', organizationId);
   } catch (error: any) {


### PR DESCRIPTION
## Summary

- `aiUsageService.currentPeriod()` now derives period boundaries from `Subscription.currentPeriodStart`/`currentPeriodEnd` (the same source of truth `viewsUsed`/`submissionsUsed` reset against) instead of a hardcoded calendar month, so an org billed mid-month no longer sees two different reset dates for its usage counters.
- Falls back to calendar-month boundaries only when there's no synced subscription yet (e.g. a pre-backfill org) or the subscription row is missing period fields.
- A `subscription_renewed` webhook now rolls AI credit usage into the new period "for free" — `resetUsageCounters` already updates `Subscription.currentPeriodStart`/`currentPeriodEnd`, so the next `recordAITokenUsage` call upserts a fresh `AIUsage` row keyed to the new `periodStart`. No explicit reset step was needed. `handleSubscriptionRenewal` now also invalidates the in-memory AI budget cache so this isn't masked by a stale cached result for up to 30s.
- A mid-cycle plan upgrade still raises `aiCreditsLimit` immediately without wiping `creditsUsedMilli` already accrued this period (verified with a new test) — the limit and usage counter are on separate rows/columns, so this was already correct once the period keys align.
- Old calendar-month-keyed `AIUsage` rows are left as-is (documented in `schema.prisma`) — they simply stop being matched once the org's real billing-cycle `periodStart` no longer falls on the 1st of the month; no backfill needed, per the issue's stated "out of scope" for retroactive reconciliation.

Fixes #77

## Test plan

- [x] `pnpm test:unit` — full backend suite passes (2390 tests); added coverage for period lookup from `Subscription`, the pre-backfill/missing-period fallback, renewal-triggered cache invalidation, and mid-cycle-upgrade-does-not-reset-usage.
- [x] `pnpm --filter backend type-check` — clean
- [x] `pnpm --filter backend lint` — no new warnings/errors
- [ ] Manual verification against the Chargebee test site (simulate `subscription_renewed` for a non-1st-of-month org) — not run in this session, recommend before merge per the issue's testing expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)