### PR TITLE
fix(ai): calibrate mini credit weight against real Azure pricing (5x -> 3.75x)

### DIFF
--- a/apps/backend/src/lib/__tests__/ai.test.ts
+++ b/apps/backend/src/lib/__tests__/ai.test.ts
@@ -124,9 +124,9 @@ describe('tokensToMilliCredits', () => {
     expect(tokensToMilliCredits(2000, 'nano')).toBe(2000);
   });
 
-  it('converts 2000 mini tokens to 10000 mCr using the default weight (5)', async () => {
+  it('converts 2000 mini tokens to 7500 mCr using the default weight (3.75)', async () => {
     const { tokensToMilliCredits } = await import('../ai.js');
-    expect(tokensToMilliCredits(2000, 'mini')).toBe(10_000);
+    expect(tokensToMilliCredits(2000, 'mini')).toBe(7500);
   });
 
   it('honors AI_CREDIT_WEIGHT_MINI env override', async () => {
@@ -140,7 +140,7 @@ describe('tokensToMilliCredits', () => {
     async (invalid) => {
       process.env.AI_CREDIT_WEIGHT_MINI = invalid;
       const { tokensToMilliCredits } = await import('../ai.js');
-      expect(tokensToMilliCredits(2000, 'mini')).toBe(10_000);
+      expect(tokensToMilliCredits(2000, 'mini')).toBe(7500);
     },
   );
 

--- a/apps/backend/src/lib/ai.ts
+++ b/apps/backend/src/lib/ai.ts
@@ -101,9 +101,17 @@ export const AI_CREDIT_LIMITS_FALLBACK: Record<string, number> = {
 
 export type AIModelTier = 'nano' | 'mini';
 
+// Calibrated against actual Azure OpenAI Global Standard pricing for the deployed
+// models (gpt-5.4-mini / gpt-5.4-nano, see infrastructure/.../ai.tf):
+//   nano: $0.20 / 1M input, $1.25 / 1M output
+//   mini: $0.75 / 1M input, $4.50 / 1M output
+// Ratio is ~3.6-3.75x depending on input/output mix (stable across mixes, since
+// both tiers scale similarly) — not the previously assumed 5x, which matched the
+// prior-generation gpt-5-mini/nano pricing ($0.25/$2.00 vs $0.05/$0.40) rather than
+// the gpt-5.4 models actually in use. See docs/superpowers/specs/2026-07-08-ai-credit-weight-calibration.md.
 const DEFAULT_CREDIT_WEIGHTS: Record<AIModelTier, number> = {
   nano: 1,
-  mini: 5,
+  mini: 3.75,
 };
 
 // Reads a per-tier credit weight from env, lazily (so tests can override env

--- a/apps/backend/src/services/__tests__/aiUsageService.test.ts
+++ b/apps/backend/src/services/__tests__/aiUsageService.test.ts
@@ -43,16 +43,16 @@ describe('aiUsageService', () => {
       expect(call.create.creditsUsedMilli).toBe(2000);
     });
 
-    it('increments creditsUsedMilli by the mini-tier weighted amount (default weight 5x) in both branches', async () => {
+    it('increments creditsUsedMilli by the mini-tier weighted amount (default weight 3.75x) in both branches', async () => {
       vi.mocked(prisma.aIUsage.upsert).mockResolvedValue({} as any);
 
       await recordAITokenUsage('org-2', 2000, 'mini');
 
       const call = vi.mocked(prisma.aIUsage.upsert).mock.calls[0][0] as any;
       expect(call.update.tokensUsed).toEqual({ increment: 2000 });
-      expect(call.update.creditsUsedMilli).toEqual({ increment: 10000 });
+      expect(call.update.creditsUsedMilli).toEqual({ increment: 7500 });
       expect(call.create.tokensUsed).toBe(2000);
-      expect(call.create.creditsUsedMilli).toBe(10000);
+      expect(call.create.creditsUsedMilli).toBe(7500);
     });
   });
 

--- a/docs/superpowers/specs/2026-07-08-ai-credit-weight-calibration.md
+++ b/docs/superpowers/specs/2026-07-08-ai-credit-weight-calibration.md
@@ -1,0 +1,90 @@
+# AI Credit Weight Calibration
+
+**Date:** 2026-07-08
+**Status:** Decided
+**Related:** GitHub issue #80
+
+## Question
+
+`DEFAULT_CREDIT_WEIGHTS` in `apps/backend/src/lib/ai.ts` assumed `mini` costs ~5x
+`nano` per token. That number was a placeholder, never checked against real Azure
+pricing for the models actually deployed. Is 5x correct?
+
+## Models actually in production
+
+Per `infrastructure/multi-cloud/terraform/azure/ai.tf` and the `ai.ts` fallback
+defaults (confirmed live as of commit `a116067a`, which replaced an earlier
+DeepSeek-V3-0324 + gpt-4.1-nano combo — see
+`2026-06-07-ai-model-swap-deepseek-gpt41nano-design.md` — with the current
+GPT-5.4 family):
+
+- **mini** (primary, `AI_PRIMARY_MODEL`) → `gpt-5.4-mini`
+- **nano** (fast, `AI_FAST_MODEL`) → `gpt-5.4-nano`
+
+## Real Azure OpenAI pricing (Global Standard / PAYG, short context)
+
+| Model | Input / 1M tokens | Output / 1M tokens |
+|---|---|---|
+| `gpt-5.4-nano` | $0.20 | $1.25 |
+| `gpt-5.4-mini` | $0.75 | $4.50 |
+
+Source: OpenAI API pricing docs (mirrored by Azure OpenAI Global Standard pricing
+for the same model family).
+
+## Ratio analysis
+
+| Basis | mini : nano ratio |
+|---|---|
+| Input only | 0.75 / 0.20 = **3.75x** |
+| Output only | 4.50 / 1.25 = **3.6x** |
+| Blended (any input/output mix) | **3.6x – 3.75x** (stable — both tiers scale similarly regardless of mix) |
+
+`tokensToMilliCredits()` weights *total* tokens (input + output combined, see
+`recordAITokenUsage` callers in `aiChat.ts` / `resolvers/ai.ts` which pass
+`usage.totalTokens`), so a single blended weight is the correct model. Since the
+ratio barely moves across plausible input/output splits, the exact split doesn't
+matter much — any reasonable choice lands in the 3.6–3.75 range.
+
+**Where the 5x came from:** it matches the *previous-generation* pricing almost
+exactly — `gpt-5-mini` ($0.25 / $2.00) vs. `gpt-5-nano` ($0.05 / $0.40) is exactly
+5x on both axes. The weight was set (or copied) against that generation and never
+re-validated after the project moved to `gpt-5.4-mini` / `gpt-5.4-nano`.
+
+## Decision
+
+**5x is meaningfully wrong for the live models** (>20% threshold from the issue:
+5 / 3.75 ≈ 1.33, i.e. 33% too high) and is corrected to **3.75x**, using the
+input-price ratio as the concrete constant (matches the upper end of the blended
+range, i.e. the safer/more conservative choice for margin protection).
+
+`DEFAULT_CREDIT_WEIGHTS` updated in `apps/backend/src/lib/ai.ts`:
+
+```ts
+const DEFAULT_CREDIT_WEIGHTS: Record<AIModelTier, number> = {
+  nano: 1,
+  mini: 3.75, // was 5
+};
+```
+
+Still overridable via `AI_CREDIT_WEIGHT_MINI` / `AI_CREDIT_WEIGHT_NANO` env vars
+if Azure pricing changes again — no env vars currently set these in any
+deployment config, so this code default is what's live in prod.
+
+## `AI_CREDIT_LIMITS_FALLBACK` — left unchanged
+
+Lowering the mini weight increases the *token* allowance a fixed credit budget
+buys on the mini tier (free plan: 200 credits → 40,000 mini tokens/month under
+the old 5x weight vs. ~53,333 tokens/month under 3.75x). At current usage volumes
+(low thousands of tokens per org per month, per `aiUsageService.ts` telemetry)
+that's a difference of a few cents of Azure spend per free-tier org per month —
+not material enough to justify changing user-facing plan numbers (200 / 2,000 /
+20,000), which are also product/marketing decisions, not purely cost-derived.
+Revisit if per-org usage volume grows by an order of magnitude.
+
+## Reconciliation check
+
+Out of scope per the issue (no automated pipeline required). A simple manual
+spot-check: compare `SUM(creditsUsedMilli)/1000` from `AIUsage` for a period
+against the actual Azure invoice for the same period, converted to nano-token-
+equivalents via the same weight. Revisit this doc if a new model tier is added
+or Azure repriced GPT-5.4.


### PR DESCRIPTION
## Summary

- `DEFAULT_CREDIT_WEIGHTS.mini` (`apps/backend/src/lib/ai.ts`) was a placeholder `5x` guess, never checked against real Azure pricing for the models actually deployed (`gpt-5.4-mini` / `gpt-5.4-nano`, per `infrastructure/multi-cloud/terraform/azure/ai.tf`).
- Real Azure OpenAI Global Standard pricing: `gpt-5.4-nano` = $0.20/$1.25 per 1M input/output, `gpt-5.4-mini` = $0.75/$4.50 per 1M input/output. This gives a **~3.6–3.75x** ratio (stable across input/output token mix), not 5x.
- The 5x figure matches the *previous-generation* `gpt-5-mini`/`gpt-5-nano` pricing exactly ($0.25/$2.00 vs $0.05/$0.40 = 5x on both axes) — it was likely carried over from before the model swap to `gpt-5.4-*` (commit `a116067a`) and never re-validated.
- Updated `DEFAULT_CREDIT_WEIGHTS.mini` from `5` to `3.75` and updated the corresponding unit tests.
- `AI_CREDIT_LIMITS_FALLBACK` (200/2,000/20,000) left unchanged — the dollar impact of the corrected weight at current usage volumes is a few cents/org/month, not material enough to justify changing user-facing plan numbers. Full reasoning documented.
- Full analysis and decision record: `docs/superpowers/specs/2026-07-08-ai-credit-weight-calibration.md`

Closes #80

## Test plan

- [x] `pnpm --filter backend test` — full backend suite passes (2384 tests)
- [x] `pnpm --filter backend type-check` — clean
- [x] `pnpm --filter backend lint` — no new warnings/errors introduced
- [x] Updated unit tests in `ai.test.ts` and `aiUsageService.test.ts` assert the new `3.75x` default and derived milli-credit values
- [x] Pre-push hook (full backend test + form-viewer/form-app/admin-app builds) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)