### PR TITLE
feat(subscriptions): emit usage-limit events for AI credits

### DIFF
--- a/apps/backend/src/services/__tests__/aiUsageService.test.ts
+++ b/apps/backend/src/services/__tests__/aiUsageService.test.ts
@@ -17,12 +17,18 @@ vi.mock('../../lib/logger.js', () => ({
   logger: { warn: vi.fn(), debug: vi.fn(), info: vi.fn(), error: vi.fn() },
 }));
 
+vi.mock('../../subscriptions/events.js', () => ({
+  emitUsageLimitReached: vi.fn(),
+  emitUsageLimitExceeded: vi.fn(),
+}));
+
 import {
   checkAITokenBudget,
   recordAITokenUsage,
   getAITokenUsage,
   invalidateAIBudgetCache,
 } from '../aiUsageService.js';
+import { emitUsageLimitReached, emitUsageLimitExceeded } from '../../subscriptions/events.js';
 
 describe('aiUsageService', () => {
   beforeEach(() => {
@@ -53,6 +59,111 @@ describe('aiUsageService', () => {
       expect(call.update.creditsUsedMilli).toEqual({ increment: 10000 });
       expect(call.create.tokensUsed).toBe(2000);
       expect(call.create.creditsUsedMilli).toBe(10000);
+    });
+
+    it('does not emit any usage-limit event while usage stays below the 80% warning threshold', async () => {
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'starter',
+        aiCreditsLimit: 100,
+      } as any);
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue({ creditsUsedMilli: 1000 } as any);
+      vi.mocked(prisma.aIUsage.upsert).mockResolvedValue({ creditsUsedMilli: 2000 } as any);
+
+      await recordAITokenUsage('org-below-threshold', 1000, 'nano');
+
+      expect(emitUsageLimitReached).not.toHaveBeenCalled();
+      expect(emitUsageLimitExceeded).not.toHaveBeenCalled();
+    });
+
+    it('emits USAGE_LIMIT_REACHED exactly once when this request crosses the 80% threshold', async () => {
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'starter',
+        aiCreditsLimit: 100, // limit = 100,000 milli-credits
+      } as any);
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue({ creditsUsedMilli: 79_000 } as any); // 79%
+      vi.mocked(prisma.aIUsage.upsert).mockResolvedValue({ creditsUsedMilli: 81_000 } as any); // 81%
+
+      await recordAITokenUsage('org-crossing-80', 2000, 'nano');
+
+      expect(emitUsageLimitReached).toHaveBeenCalledTimes(1);
+      expect(emitUsageLimitReached).toHaveBeenCalledWith(
+        'org-crossing-80',
+        undefined,
+        'ai_credits',
+        81,
+        100,
+        81
+      );
+      expect(emitUsageLimitExceeded).not.toHaveBeenCalled();
+    });
+
+    it('does not re-emit USAGE_LIMIT_REACHED when usage was already past 80% before this request', async () => {
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'starter',
+        aiCreditsLimit: 100,
+      } as any);
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue({ creditsUsedMilli: 85_000 } as any); // 85%
+      vi.mocked(prisma.aIUsage.upsert).mockResolvedValue({ creditsUsedMilli: 90_000 } as any); // 90%
+
+      await recordAITokenUsage('org-already-warned', 5000, 'nano');
+
+      expect(emitUsageLimitReached).not.toHaveBeenCalled();
+      expect(emitUsageLimitExceeded).not.toHaveBeenCalled();
+    });
+
+    it('emits USAGE_LIMIT_EXCEEDED exactly once when this request crosses 100%, not USAGE_LIMIT_REACHED', async () => {
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'starter',
+        aiCreditsLimit: 100, // limit = 100,000 milli-credits
+      } as any);
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue({ creditsUsedMilli: 95_000 } as any); // 95%
+      vi.mocked(prisma.aIUsage.upsert).mockResolvedValue({ creditsUsedMilli: 105_000 } as any); // 105%
+
+      await recordAITokenUsage('org-crossing-100', 10_000, 'nano');
+
+      expect(emitUsageLimitExceeded).toHaveBeenCalledTimes(1);
+      expect(emitUsageLimitExceeded).toHaveBeenCalledWith(
+        'org-crossing-100',
+        undefined,
+        'ai_credits',
+        105,
+        100
+      );
+      expect(emitUsageLimitReached).not.toHaveBeenCalled();
+    });
+
+    it('does not re-emit USAGE_LIMIT_EXCEEDED when usage was already over the limit before this request', async () => {
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'starter',
+        aiCreditsLimit: 100,
+      } as any);
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue({ creditsUsedMilli: 110_000 } as any); // already over
+      vi.mocked(prisma.aIUsage.upsert).mockResolvedValue({ creditsUsedMilli: 120_000 } as any);
+
+      await recordAITokenUsage('org-already-exceeded', 10_000, 'nano');
+
+      expect(emitUsageLimitExceeded).not.toHaveBeenCalled();
+      expect(emitUsageLimitReached).not.toHaveBeenCalled();
+    });
+
+    it('treats a first-usage org (no prior AIUsage row) as starting from zero for threshold crossing', async () => {
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'free',
+        aiCreditsLimit: null, // falls back to AI_CREDIT_LIMITS_FALLBACK.free (200 credits)
+      } as any);
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue(null);
+      vi.mocked(prisma.aIUsage.upsert).mockResolvedValue({ creditsUsedMilli: 250_000 } as any); // 250 credits > 200 limit
+
+      await recordAITokenUsage('org-first-usage', 250_000, 'nano');
+
+      expect(emitUsageLimitExceeded).toHaveBeenCalledTimes(1);
+      expect(emitUsageLimitExceeded).toHaveBeenCalledWith(
+        'org-first-usage',
+        undefined,
+        'ai_credits',
+        250,
+        200
+      );
     });
   });
 

--- a/apps/backend/src/services/aiUsageService.ts
+++ b/apps/backend/src/services/aiUsageService.ts
@@ -1,9 +1,14 @@
 import { prisma } from '../lib/prisma.js';
 import { AI_CREDIT_LIMITS_FALLBACK, tokensToMilliCredits, type AIModelTier } from '../lib/ai.js';
 import { logger } from '../lib/logger.js';
+import { emitUsageLimitReached, emitUsageLimitExceeded } from '../subscriptions/events.js';
 
 const budgetCache = new Map<string, { result: { allowed: boolean; used: number; limit: number }; cachedAt: number }>();
 const BUDGET_CACHE_TTL_MS = 30_000;
+
+// Mirrors WARNING_THRESHOLD in subscriptions/usageService.ts — kept as a separate constant
+// since AI credits are enforced from this service, not usageService.ts.
+const AI_CREDITS_WARNING_THRESHOLD = 80;
 
 function currentPeriod(): { start: Date; end: Date } {
   const now = new Date();
@@ -84,6 +89,40 @@ export async function checkAITokenBudget(organizationId: string): Promise<{
 }
 
 /**
+ * Emits `USAGE_LIMIT_REACHED`/`USAGE_LIMIT_EXCEEDED` for `ai_credits` exactly once per
+ * threshold crossing, mirroring `checkUsageLimits` in `subscriptions/usageService.ts`.
+ * Unlike views/submissions (incremented one at a time), AI credit increments can jump by
+ * an arbitrary amount in one request, so crossing is detected by comparing the
+ * pre-increment and post-increment values rather than assuming a fixed step of 1.
+ */
+function checkAICreditLimits(
+  organizationId: string,
+  previousMilli: number,
+  currentMilli: number,
+  limitCredits: number
+): void {
+  const limitMilli = limitCredits * 1000;
+  if (limitMilli <= 0) return;
+
+  // Already over the limit before this request — the exceeded event already fired then.
+  if (previousMilli > limitMilli) return;
+
+  if (currentMilli > limitMilli) {
+    const currentCredits = currentMilli / 1000;
+    emitUsageLimitExceeded(organizationId, undefined, 'ai_credits', currentCredits, limitCredits);
+    return;
+  }
+
+  const previousPercentage = (previousMilli / limitMilli) * 100;
+  const currentPercentage = (currentMilli / limitMilli) * 100;
+
+  if (currentPercentage >= AI_CREDITS_WARNING_THRESHOLD && previousPercentage < AI_CREDITS_WARNING_THRESHOLD) {
+    const currentCredits = currentMilli / 1000;
+    emitUsageLimitReached(organizationId, undefined, 'ai_credits', currentCredits, limitCredits, currentPercentage);
+  }
+}
+
+/**
  * Records AI usage for an org's current billing period. Increments both the raw
  * `tokensUsed` (kept as an audit trail) and `creditsUsedMilli` (the model-weighted
  * amount actually charged against the org's credit budget, per `tier`).
@@ -98,7 +137,13 @@ export async function recordAITokenUsage(
   const creditsUsedMilli = tokensToMilliCredits(tokensUsed, tier);
 
   try {
-    await prisma.aIUsage.upsert({
+    const [existing, subscription] = await Promise.all([
+      prisma.aIUsage.findFirst({ where: { organizationId, periodStart: start } }),
+      prisma.subscription.findUnique({ where: { organizationId } }),
+    ]);
+    const previousMilli = existing?.creditsUsedMilli ?? 0;
+
+    const updated = await prisma.aIUsage.upsert({
       where: { organizationId_periodStart: { organizationId, periodStart: start } },
       update: {
         tokensUsed: { increment: tokensUsed },
@@ -112,6 +157,8 @@ export async function recordAITokenUsage(
         periodEnd: end,
       },
     });
+
+    checkAICreditLimits(organizationId, previousMilli, updated.creditsUsedMilli, effectiveCreditLimit(subscription));
   } catch {
     logger.warn({ organizationId, tokensUsed, tier }, 'Failed to record AI token usage');
   }

--- a/apps/backend/src/subscriptions/__tests__/events.test.ts
+++ b/apps/backend/src/subscriptions/__tests__/events.test.ts
@@ -372,6 +372,26 @@ describe('subscription events', () => {
       expect(call.timestamp.getTime()).toBeGreaterThanOrEqual(beforeEmit.getTime());
       expect(call.timestamp.getTime()).toBeLessThanOrEqual(afterEmit.getTime());
     });
+
+    it('should emit usage limit reached event for ai_credits with no formId', () => {
+      const mockHandler = vi.fn();
+      eventEmitter.on(SubscriptionEventType.USAGE_LIMIT_REACHED, mockHandler);
+
+      emitUsageLimitReached('org-1', undefined, 'ai_credits', 81, 100, 81);
+
+      expect(mockHandler).toHaveBeenCalledWith({
+        type: SubscriptionEventType.USAGE_LIMIT_REACHED,
+        organizationId: 'org-1',
+        formId: undefined,
+        timestamp: expect.any(Date),
+        data: {
+          usageType: 'ai_credits',
+          current: 81,
+          limit: 100,
+          percentage: 81,
+        },
+      });
+    });
   });
 
   describe('emitUsageLimitExceeded', () => {
@@ -455,6 +475,25 @@ describe('subscription events', () => {
       expect(call.timestamp).toBeInstanceOf(Date);
       expect(call.timestamp.getTime()).toBeGreaterThanOrEqual(beforeEmit.getTime());
       expect(call.timestamp.getTime()).toBeLessThanOrEqual(afterEmit.getTime());
+    });
+
+    it('should emit usage limit exceeded event for ai_credits with no formId', () => {
+      const mockHandler = vi.fn();
+      eventEmitter.on(SubscriptionEventType.USAGE_LIMIT_EXCEEDED, mockHandler);
+
+      emitUsageLimitExceeded('org-1', undefined, 'ai_credits', 105, 100);
+
+      expect(mockHandler).toHaveBeenCalledWith({
+        type: SubscriptionEventType.USAGE_LIMIT_EXCEEDED,
+        organizationId: 'org-1',
+        formId: undefined,
+        timestamp: expect.any(Date),
+        data: {
+          usageType: 'ai_credits',
+          current: 105,
+          limit: 100,
+        },
+      });
     });
   });
 

--- a/apps/backend/src/subscriptions/events.ts
+++ b/apps/backend/src/subscriptions/events.ts
@@ -154,16 +154,16 @@ export const emitFormSubmitted = (
  * Triggered when usage reaches a warning threshold (e.g., 80% of limit)
  *
  * @param organizationId - ID of the organization
- * @param formId - ID of the form
- * @param usageType - Type of usage ('views' or 'submissions')
+ * @param formId - ID of the form (undefined for org-level usage types like 'ai_credits')
+ * @param usageType - Type of usage ('views', 'submissions', or 'ai_credits')
  * @param current - Current usage count
  * @param limit - Usage limit
  * @param percentage - Current usage as percentage of limit
  */
 export const emitUsageLimitReached = (
   organizationId: string,
-  formId: string,
-  usageType: 'views' | 'submissions',
+  formId: string | undefined,
+  usageType: 'views' | 'submissions' | 'ai_credits',
   current: number,
   limit: number,
   percentage: number
@@ -189,15 +189,15 @@ export const emitUsageLimitReached = (
  * Triggered when usage exceeds the plan limit
  *
  * @param organizationId - ID of the organization
- * @param formId - ID of the form
- * @param usageType - Type of usage ('views' or 'submissions')
+ * @param formId - ID of the form (undefined for org-level usage types like 'ai_credits')
+ * @param usageType - Type of usage ('views', 'submissions', or 'ai_credits')
  * @param current - Current usage count
  * @param limit - Usage limit
  */
 export const emitUsageLimitExceeded = (
   organizationId: string,
-  formId: string,
-  usageType: 'views' | 'submissions',
+  formId: string | undefined,
+  usageType: 'views' | 'submissions' | 'ai_credits',
   current: number,
   limit: number
 ): void => {

--- a/apps/backend/src/subscriptions/types.ts
+++ b/apps/backend/src/subscriptions/types.ts
@@ -51,10 +51,13 @@ export interface FormSubmittedEvent extends SubscriptionEvent {
  * Usage limit reached event
  * Emitted when usage reaches a warning threshold (e.g., 80% of limit)
  */
-export interface UsageLimitReachedEvent extends SubscriptionEvent {
+export interface UsageLimitReachedEvent extends Omit<SubscriptionEvent, 'formId'> {
   type: SubscriptionEventType.USAGE_LIMIT_REACHED;
+  // AI credit usage is tracked per-organization, not per-form, so 'ai_credits' events have
+  // no associated form. Views/submissions events always populate this.
+  formId?: string;
   data: {
-    usageType: 'views' | 'submissions';
+    usageType: 'views' | 'submissions' | 'ai_credits';
     current: number;
     limit: number;
     percentage: number;
@@ -65,10 +68,13 @@ export interface UsageLimitReachedEvent extends SubscriptionEvent {
  * Usage limit exceeded event
  * Emitted when usage exceeds the plan limit
  */
-export interface UsageLimitExceededEvent extends SubscriptionEvent {
+export interface UsageLimitExceededEvent extends Omit<SubscriptionEvent, 'formId'> {
   type: SubscriptionEventType.USAGE_LIMIT_EXCEEDED;
+  // AI credit usage is tracked per-organization, not per-form, so 'ai_credits' events have
+  // no associated form. Views/submissions events always populate this.
+  formId?: string;
   data: {
-    usageType: 'views' | 'submissions';
+    usageType: 'views' | 'submissions' | 'ai_credits';
     current: number;
     limit: number;
   };


### PR DESCRIPTION
## Summary
- `form_views`/`form_submissions` usage already fire `USAGE_LIMIT_REACHED` (80%) and `USAGE_LIMIT_EXCEEDED` events through the subscription event system, but AI credits didn't — orgs got no warning before AI chat was hard-blocked with a 402.
- Extends `usageType` to include `'ai_credits'` and wires `recordAITokenUsage` (`aiUsageService.ts`) to emit the same events, reusing the existing event system rather than inventing a new one.

## Changes
- `subscriptions/types.ts`: `usageType` union now includes `'ai_credits'`; `formId` is optional on the two usage-limit event types only (AI credits are org-level, not per-form) — `FormViewedEvent`/`FormSubmittedEvent` are unaffected.
- `subscriptions/events.ts`: `emitUsageLimitReached`/`emitUsageLimitExceeded` accept `formId: string | undefined` and the wider `usageType`.
- `services/aiUsageService.ts`: `recordAITokenUsage` now reads the org's AI usage row (and subscription) *before* incrementing, then compares pre/post values in a new `checkAICreditLimits` helper to detect an 80%/100% threshold crossing and emit exactly once per billing period — mirroring `checkUsageLimits` in `subscriptions/usageService.ts`, but comparing before/after values (rather than assuming a fixed +1 step) since AI credit increments can jump by an arbitrary amount in a single request.

## Test plan
- [x] `pnpm --filter backend test` — full backend suite (2392 tests) passes, including new coverage in `services/__tests__/aiUsageService.test.ts` (threshold crossing, no-double-fire per billing period, first-usage-from-zero) and `subscriptions/__tests__/events.test.ts` (`ai_credits` usageType, undefined `formId`)
- [x] `pnpm --filter backend type-check` — clean
- [x] `pnpm --filter backend lint` — clean (only pre-existing `no-explicit-any` warnings elsewhere in the codebase)

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)