### PR TITLE
fix(ai-credits): migrate legacy calendar-month AIUsage rows onto billing-cycle key

### DIFF
--- a/apps/backend/src/services/__tests__/aiUsageService.test.ts
+++ b/apps/backend/src/services/__tests__/aiUsageService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { prisma } from '../../lib/prisma.js';
 
 vi.mock('../../lib/prisma.js', () => ({
@@ -6,6 +6,7 @@ vi.mock('../../lib/prisma.js', () => ({
     aIUsage: {
       findFirst: vi.fn(),
       upsert: vi.fn(),
+      delete: vi.fn(),
     },
     subscription: {
       findUnique: vi.fn(),
@@ -525,6 +526,156 @@ describe('aiUsageService', () => {
       expect(call.where.periodStart).toEqual(new Date(2024, 2, 1));
 
       vi.useRealTimers();
+    });
+  });
+
+  describe('legacy calendar-month AIUsage migration (issue #77)', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('rolls a same-month legacy calendar-key row onto the billing-cycle key and deletes the legacy row', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 6, 20, 12, 0, 0)); // "now": 2026-07-20
+
+      const currentPeriodStart = new Date(2026, 6, 5); // billing term started 2026-07-05
+      const currentPeriodEnd = new Date(2026, 7, 4, 23, 59, 59, 999);
+      const legacyStart = new Date(2026, 6, 1); // pre-deploy calendar-month key
+
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'starter',
+        aiCreditsLimit: 2_000,
+        currentPeriodStart,
+        currentPeriodEnd,
+      } as any);
+
+      (prisma.aIUsage.findFirst as any).mockImplementation(async ({ where }: any) => {
+        if (where.periodStart.getTime() === legacyStart.getTime()) {
+          return { id: 'legacy-row', tokensUsed: 3000, creditsUsedMilli: 450_000 } as any;
+        }
+        return null; // nothing yet under the new billing-cycle key
+      });
+      vi.mocked(prisma.aIUsage.upsert).mockResolvedValue({} as any);
+      vi.mocked(prisma.aIUsage.delete).mockResolvedValue({} as any);
+
+      await checkAITokenBudget('org-migrate');
+
+      expect(prisma.aIUsage.upsert).toHaveBeenCalledWith({
+        where: { organizationId_periodStart: { organizationId: 'org-migrate', periodStart: currentPeriodStart } },
+        update: { tokensUsed: { increment: 3000 }, creditsUsedMilli: { increment: 450_000 } },
+        create: {
+          organizationId: 'org-migrate',
+          periodStart: currentPeriodStart,
+          periodEnd: currentPeriodEnd,
+          tokensUsed: 3000,
+          creditsUsedMilli: 450_000,
+        },
+      });
+      expect(prisma.aIUsage.delete).toHaveBeenCalledWith({ where: { id: 'legacy-row' } });
+    });
+
+    it('does nothing when there is no legacy row to migrate', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 6, 20, 12, 0, 0));
+
+      const currentPeriodStart = new Date(2026, 6, 5);
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'starter',
+        aiCreditsLimit: 2_000,
+        currentPeriodStart,
+        currentPeriodEnd: new Date(2026, 7, 4, 23, 59, 59, 999),
+      } as any);
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue(null);
+
+      await checkAITokenBudget('org-no-legacy');
+
+      expect(prisma.aIUsage.upsert).not.toHaveBeenCalled();
+      expect(prisma.aIUsage.delete).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the billing-cycle key already has a row (already migrated or genuinely fresh)', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 6, 20, 12, 0, 0));
+
+      const currentPeriodStart = new Date(2026, 6, 5);
+      const legacyStart = new Date(2026, 6, 1);
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'starter',
+        aiCreditsLimit: 2_000,
+        currentPeriodStart,
+        currentPeriodEnd: new Date(2026, 7, 4, 23, 59, 59, 999),
+      } as any);
+      (prisma.aIUsage.findFirst as any).mockImplementation(async ({ where }: any) => {
+        if (where.periodStart.getTime() === currentPeriodStart.getTime()) {
+          return { id: 'new-row', tokensUsed: 10, creditsUsedMilli: 10_000 } as any;
+        }
+        if (where.periodStart.getTime() === legacyStart.getTime()) {
+          return { id: 'legacy-row', tokensUsed: 3000, creditsUsedMilli: 450_000 } as any;
+        }
+        return null;
+      });
+
+      await checkAITokenBudget('org-already-migrated');
+
+      expect(prisma.aIUsage.upsert).not.toHaveBeenCalled();
+      expect(prisma.aIUsage.delete).not.toHaveBeenCalled();
+    });
+
+    it('skips migration when the billing term started in an earlier calendar month', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 6, 20, 12, 0, 0)); // "now": July 2026
+
+      // Term started in June — a July-keyed legacy row (if any) can't be safely attributed
+      // to this term without splitting usage at the month boundary (out of scope).
+      const currentPeriodStart = new Date(2026, 5, 15);
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'starter',
+        aiCreditsLimit: 2_000,
+        currentPeriodStart,
+        currentPeriodEnd: new Date(2026, 6, 14, 23, 59, 59, 999),
+      } as any);
+      vi.mocked(prisma.aIUsage.findFirst).mockResolvedValue({ creditsUsedMilli: 0 } as any);
+
+      await checkAITokenBudget('org-earlier-term');
+
+      // Only the main lookup runs — no legacy-row probe.
+      expect(prisma.aIUsage.findFirst).toHaveBeenCalledTimes(1);
+      expect(prisma.aIUsage.upsert).not.toHaveBeenCalled();
+    });
+
+    it('carries migrated usage forward through recordAITokenUsage so it is not lost on the first post-deploy write', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 6, 20, 12, 0, 0));
+
+      const currentPeriodStart = new Date(2026, 6, 5);
+      const currentPeriodEnd = new Date(2026, 7, 4, 23, 59, 59, 999);
+      const legacyStart = new Date(2026, 6, 1);
+
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+        planId: 'starter',
+        aiCreditsLimit: 2_000,
+        currentPeriodStart,
+        currentPeriodEnd,
+      } as any);
+
+      // First findFirst call (inside migration, for the legacy key) returns the legacy row;
+      // all other findFirst calls (new-key probes) return null until the migration upsert lands.
+      (prisma.aIUsage.findFirst as any).mockImplementation(async ({ where }: any) => {
+        if (where.periodStart.getTime() === legacyStart.getTime()) {
+          return { id: 'legacy-row', tokensUsed: 3000, creditsUsedMilli: 450_000 } as any;
+        }
+        return null;
+      });
+      vi.mocked(prisma.aIUsage.upsert).mockResolvedValue({ creditsUsedMilli: 451_000 } as any);
+      vi.mocked(prisma.aIUsage.delete).mockResolvedValue({} as any);
+
+      await recordAITokenUsage('org-migrate-record', 1000, 'nano');
+
+      // Migration upsert (rolling the legacy 450,000 forward) plus the normal record upsert.
+      expect(prisma.aIUsage.upsert).toHaveBeenCalledTimes(2);
+      const migrationCall = vi.mocked(prisma.aIUsage.upsert).mock.calls[0][0] as any;
+      expect(migrationCall.update.creditsUsedMilli).toEqual({ increment: 450_000 });
+      expect(prisma.aIUsage.delete).toHaveBeenCalledWith({ where: { id: 'legacy-row' } });
     });
   });
 

--- a/apps/backend/src/services/aiUsageService.ts
+++ b/apps/backend/src/services/aiUsageService.ts
@@ -92,6 +92,71 @@ function currentPeriod(subscription: SubscriptionPeriod): { start: Date; end: Da
 }
 
 /**
+ * One-time bridge from the old calendar-month-keyed `AIUsage` rows to the new
+ * Chargebee-billing-cycle key (issue #77 acceptance criteria: existing rows must be
+ * migrated or handled without breaking `checkAITokenBudget` for orgs mid-transition).
+ *
+ * Without this, an org whose billing term started earlier in the current calendar
+ * month would have usage from before this deploy sitting under the old calendar-month
+ * key — invisible to lookups against the new billing-cycle key, effectively granting a
+ * fresh AI budget mid-cycle until the next Chargebee renewal. Rolls that legacy row's
+ * totals onto the new key and deletes it so it isn't matched again.
+ *
+ * Deliberately narrow: only migrates when the billing term started in the *current*
+ * calendar month, so the legacy row can be safely attributed to the current term.
+ * Terms that started in an earlier calendar month would need to reconcile usage split
+ * across multiple legacy rows at a month boundary — that's the historical reconciliation
+ * the issue explicitly scoped out. Best-effort: failures are logged and swallowed, since
+ * a missed migration only loses one month's carryover usage, not a hard failure.
+ */
+async function migrateLegacyPeriodUsage(
+  organizationId: string,
+  newStart: Date,
+  newEnd: Date,
+  subscription: SubscriptionPeriod
+): Promise<void> {
+  if (!subscription?.currentPeriodStart) return; // already on the calendar-month key
+
+  const now = new Date();
+  const legacyStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  if (legacyStart.getTime() === newStart.getTime()) return; // no key change to migrate from
+
+  const sameCalendarMonth =
+    subscription.currentPeriodStart.getFullYear() === legacyStart.getFullYear() &&
+    subscription.currentPeriodStart.getMonth() === legacyStart.getMonth();
+  if (!sameCalendarMonth) return; // legacy row (if any) predates this billing term
+
+  try {
+    const [existingNew, legacy] = await Promise.all([
+      prisma.aIUsage.findFirst({ where: { organizationId, periodStart: newStart } }),
+      prisma.aIUsage.findFirst({ where: { organizationId, periodStart: legacyStart } }),
+    ]);
+    if (existingNew || !legacy) return;
+
+    await prisma.aIUsage.upsert({
+      where: { organizationId_periodStart: { organizationId, periodStart: newStart } },
+      update: {
+        tokensUsed: { increment: legacy.tokensUsed },
+        creditsUsedMilli: { increment: legacy.creditsUsedMilli },
+      },
+      create: {
+        organizationId,
+        periodStart: newStart,
+        periodEnd: newEnd,
+        tokensUsed: legacy.tokensUsed,
+        creditsUsedMilli: legacy.creditsUsedMilli,
+      },
+    });
+    await prisma.aIUsage.delete({ where: { id: legacy.id } });
+  } catch {
+    logger.warn(
+      { organizationId },
+      'Failed to migrate legacy calendar-month AI usage onto the billing-cycle period key'
+    );
+  }
+}
+
+/**
  * Effective monthly AI-credit limit for an org.
  *
  * `Subscription.aiCreditsLimit` is populated by a Chargebee webhook sync (a later task).
@@ -152,7 +217,8 @@ export async function checkAITokenBudget(organizationId: string): Promise<{
   const generationAtStart = currentWriteGeneration(organizationId);
 
   const subscription = await prisma.subscription.findUnique({ where: { organizationId } });
-  const { start } = currentPeriod(subscription);
+  const { start, end } = currentPeriod(subscription);
+  await migrateLegacyPeriodUsage(organizationId, start, end, subscription);
 
   const usage = await prisma.aIUsage.findFirst({
     where: { organizationId, periodStart: start },
@@ -231,6 +297,7 @@ export async function recordAITokenUsage(
   // and effectiveCreditLimit() below needs planId/aiCreditsLimit/status from the same row.
   const subscription = await prisma.subscription.findUnique({ where: { organizationId } });
   const { start, end } = currentPeriod(subscription);
+  await migrateLegacyPeriodUsage(organizationId, start, end, subscription);
   const creditsUsedMilli = tokensToMilliCredits(tokensUsed, tier);
 
   try {
@@ -279,6 +346,7 @@ export async function getAITokenUsage(organizationId: string): Promise<{
 }> {
   const subscription = await prisma.subscription.findUnique({ where: { organizationId } });
   const { start, end } = currentPeriod(subscription);
+  await migrateLegacyPeriodUsage(organizationId, start, end, subscription);
 
   const usage = await prisma.aIUsage.findFirst({ where: { organizationId, periodStart: start } });
 


### PR DESCRIPTION
## Summary

- Follow-up to #89 (Codex review, P1): once `aiUsageService.currentPeriod()` started keying `AIUsage` rows by `Subscription.currentPeriodStart` instead of the calendar month, orgs whose billing term didn't start on the 1st had their already-accrued usage for the current term stranded under the old calendar-month key — invisible to the new lookup, effectively granting a fresh AI budget mid-cycle on deploy.
- Issue #77's acceptance criteria explicitly required *"Existing `AIUsage` rows (calendar-month keyed) are migrated or handled without breaking `checkAITokenBudget` for orgs mid-transition"* — that criterion was unmet by #89. (The issue's "Out of Scope" item only excludes reconciling *historical/past* calendar-month periods, not the current in-flight one at deploy time.)
- Adds `migrateLegacyPeriodUsage`, called from `checkAITokenBudget`, `recordAITokenUsage`, and `getAITokenUsage`: when an org's billing term started within the *current* calendar month, roll the legacy calendar-month row's `tokensUsed`/`creditsUsedMilli` onto the new billing-cycle key and delete the legacy row so it isn't matched again.
- Deliberately narrow: terms that started in an *earlier* calendar month are left alone — safely attributing a legacy row split across a month boundary is real reconciliation work, which is what the issue scoped out. Failures are logged and swallowed (best-effort), since a missed migration only loses one month's carryover, not a hard failure of the budget check.

## Test plan

- [x] `pnpm --filter backend test` — full backend suite passes (2409 tests); added 5 new tests covering: same-month migration + legacy row deletion, no-op when no legacy row exists, no-op when the new key already has a row, skip when the term started in an earlier calendar month, and that migrated usage carries forward correctly through `recordAITokenUsage`.
- [x] `pnpm --filter backend type-check` — clean
- [x] `pnpm --filter backend lint` — no new warnings/errors
- [x] pre-push hooks (backend/form-viewer tests, all app builds) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)