### PR TITLE
chore: add CodeRabbit PR review config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,41 @@
+language: en-US
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: false
+  path_filters:
+    - "!**/dist/**"
+    - "!**/build/**"
+    - "!**/*.generated.*"
+    - "!**/pnpm-lock.yaml"
+    - "!apps/backend/prisma/migrations/**"
+    - "!**/*.min.js"
+  path_instructions:
+    - path: "apps/backend/src/graphql/resolvers/**"
+      instructions: >
+        Verify every resolver guards access with requireAuth and, where the
+        operation touches a specific organization/form, requireOrganizationMembership
+        or the equivalent FormPermission check, per this repo's three-layer
+        authorization model (system role, org membership, form permission).
+    - path: "apps/form-app/src/**/*.tsx"
+      instructions: >
+        Flag any hardcoded user-facing strings; this app requires i18n via
+        useTranslation for both en and ta locales.
+    - path: "**/*.env*"
+      instructions: >
+        This is a public repository. Flag any committed secrets, API keys,
+        or credentials immediately as a blocking issue.
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  learnings:
+    scope: auto


### PR DESCRIPTION
## Summary
- Adds `.coderabbit.yaml` to configure the CodeRabbit GitHub App (already installed on the org) for automated PR reviews on this repo.
- Tunes review focus to repo-specific conventions: auth/permission guards in GraphQL resolvers, missing i18n in form-app, and secret-leak flagging given this is a public repo.

## Test plan
- [x] CodeRabbit installed on `dculussoftwares` org and confirmed working via manual `@coderabbitai review` trigger on PR #94
- [x] `pnpm build` passes across all workspace packages/apps
- [x] `pnpm test:unit` passes for backend
- [ ] Confirm CodeRabbit auto-reviews this PR on open (should trigger automatically once pushed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review automation settings to improve code review coverage and consistency.
  * Excluded generated and build-related files from automated review checks.
  * Added targeted review guidance to better catch authorization issues, untranslated user-facing text, and accidental secret exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->