### PR TITLE
feat(admin-app): add AI credits usage to organization subscription tab

### DIFF
--- a/apps/admin-app/src/graphql/organizationDetail.ts
+++ b/apps/admin-app/src/graphql/organizationDetail.ts
@@ -27,6 +27,7 @@ export const ADMIN_ORGANIZATION_BY_ID_QUERY : TypedDocumentNode<any, any> = gql`
         status
         viewsUsed
         submissionsUsed
+        aiCreditsUsed
         viewsLimit
         submissionsLimit
         aiCreditsLimit
@@ -87,6 +88,7 @@ export interface OrgSubscription {
   status: string;
   viewsUsed: number;
   submissionsUsed: number;
+  aiCreditsUsed: number;
   viewsLimit: number | null;
   submissionsLimit: number | null;
   aiCreditsLimit: number | null;

--- a/apps/admin-app/src/pages/organizations/OrganizationDetailPage.tsx
+++ b/apps/admin-app/src/pages/organizations/OrganizationDetailPage.tsx
@@ -435,6 +435,7 @@ export const OrganizationDetailPage = () => {
                 <div className="flex flex-col sm:flex-row gap-6">
                   <UsageBar label="Form Views" used={sub.viewsUsed} limit={sub.viewsLimit} />
                   <UsageBar label="Submissions" used={sub.submissionsUsed} limit={sub.submissionsLimit} />
+                  <UsageBar label="AI Credits" used={Math.round(sub.aiCreditsUsed * 10) / 10} limit={sub.aiCreditsLimit} />
                 </div>
               </div>
 
@@ -589,7 +590,7 @@ export const OrganizationDetailPage = () => {
                   <div className="flex items-center justify-between gap-3">
                     <div>
                       <p className="text-sm font-medium text-primary">Reset Usage Counters</p>
-                      <p className="text-xs text-muted-foreground">Resets views, submissions, and AI token usage to zero immediately.</p>
+                      <p className="text-xs text-muted-foreground">Resets views, submissions, and AI credits usage to zero immediately.</p>
                     </div>
                     <Button variant="outline" size="sm" onClick={() => setConfirmModal('resetUsage')} disabled={resettingUsage} className="shrink-0">
                       {resettingUsage
@@ -708,7 +709,7 @@ export const OrganizationDetailPage = () => {
           <div className="relative bg-white rounded-xl p-6 max-w-sm w-full mx-4 space-y-4" style={MODAL_STYLE}>
             <h3 className="text-base font-semibold text-primary">Reset Usage Counters</h3>
             <p className="text-sm text-muted-foreground">
-              Resets views, submissions, and AI token usage to zero. Type <strong>{org.name}</strong> to confirm.
+              Resets views, submissions, and AI credits usage to zero. Type <strong>{org.name}</strong> to confirm.
             </p>
             <input
               className="w-full rounded-lg px-3 py-2 text-sm"

--- a/apps/backend/src/graphql/resolvers/__tests__/admin.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/admin.test.ts
@@ -101,6 +101,13 @@ vi.mock('../../../subscriptions/usageService.js', () => ({
 
 vi.mock('../../../services/aiUsageService.js', () => ({
   invalidateAIBudgetCache: vi.fn(),
+  getAITokenUsage: vi.fn().mockResolvedValue({
+    used: 0,
+    limit: 1000,
+    resetAt: '2026-05-31T23:59:59.999Z',
+    creditsUsed: 0,
+    creditsLimit: 100,
+  }),
 }));
 
 describe('Admin Resolvers', () => {

--- a/apps/backend/src/graphql/resolvers/admin.ts
+++ b/apps/backend/src/graphql/resolvers/admin.ts
@@ -18,7 +18,7 @@ import {
   type PlanPriceInput,
 } from '../../services/chargebeeService.js';
 import { resetUsageCounters } from '../../subscriptions/usageService.js';
-import { invalidateAIBudgetCache } from '../../services/aiUsageService.js';
+import { invalidateAIBudgetCache, getAITokenUsage } from '../../services/aiUsageService.js';
 import { type BetterAuthContext } from '../../middleware/better-auth-middleware.js';
 
 export interface AdminOrganizationsArgs {
@@ -612,6 +612,12 @@ export const adminResolvers = {
           },
         });
 
+        let aiCreditsUsed = 0;
+        if (organization.subscription) {
+          const aiUsage = await getAITokenUsage(organization.id);
+          aiCreditsUsed = aiUsage.creditsUsed;
+        }
+
         return {
           id: organization.id,
           name: organization.name,
@@ -636,6 +642,7 @@ export const adminResolvers = {
                 status: organization.subscription.status,
                 viewsUsed: organization.subscription.viewsUsed,
                 submissionsUsed: organization.subscription.submissionsUsed,
+                aiCreditsUsed,
                 viewsLimit: organization.subscription.viewsLimit,
                 submissionsLimit: organization.subscription.submissionsLimit,
                 aiCreditsLimit: organization.subscription.aiCreditsLimit,

--- a/apps/backend/src/graphql/schema.ts
+++ b/apps/backend/src/graphql/schema.ts
@@ -533,6 +533,7 @@ export const typeDefs = gql`
     status: String!
     viewsUsed: Int!
     submissionsUsed: Int!
+    aiCreditsUsed: Float!
     viewsLimit: Int
     submissionsLimit: Int
     aiCreditsLimit: Int
@@ -1393,3 +1394,4 @@ export const typeDefs = gql`
 
   scalar Upload
 `;
+


### PR DESCRIPTION
## Summary
Adds AI credits usage display in the admin dashboard's Usage section alongside form views and submissions. This allows admins to monitor actual AI credit consumption for each organization.

## Changes
- Backend: fetch AI credits used via `getAITokenUsage` in `adminOrganizationById` resolver
- GraphQL: added `aiCreditsUsed: Float!` field to `OrgSubscription` type
- Admin app: updated GraphQL query to fetch `aiCreditsUsed` field
- UI: added AI Credits usage bar showing current usage vs limit in the subscription tab
- Updated descriptions to accurately mention AI credits (not tokens)

## Test Plan
- [ ] Admin dashboard loads organization details without errors
- [ ] AI Credits usage bar displays correctly with progress indicator
- [ ] Usage limit enforcement works as expected
- [ ] Reset usage counters resets AI credits to zero
- [ ] Unlimited AI credits display correctly

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI credits used to organization subscription details in the admin organization view.

* **Bug Fixes**
  * Updated the AI credits usage display to show used values rounded to one decimal place.
  * Improved the reset-usage confirmation messaging to consistently refer to AI credits.

* **Tests**
  * Updated admin GraphQL resolver tests to include AI credits usage data in the mocked responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->