### PR TITLE
fix(billing): include quantity when switching subscription to $0 enterprise plan

### DIFF
--- a/apps/backend/src/services/__tests__/chargebeeService.test.ts
+++ b/apps/backend/src/services/__tests__/chargebeeService.test.ts
@@ -1267,7 +1267,14 @@ describe('Chargebee Service', () => {
       expect(mockChargebee.hostedPage.checkoutExistingForItems).not.toHaveBeenCalled();
       expect(mockChargebee.subscription.updateForItems).toHaveBeenCalledWith(
         'chargebee_sub_ent_0',
-        expect.objectContaining({ auto_collection: 'off' })
+        expect.objectContaining({
+          // Chargebee rejects subscription items without an explicit quantity
+          subscription_items: [
+            { item_price_id: 'enterprise-usd-monthly', unit_price: 0, quantity: 1 },
+          ],
+          replace_items_list: true,
+          auto_collection: 'off',
+        })
       );
       expect(subscriptionRepository.update).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/apps/backend/src/services/chargebeeService.ts
+++ b/apps/backend/src/services/chargebeeService.ts
@@ -210,7 +210,7 @@ export const setEnterpriseSubscription = async (
       const result: any = await chargebee.subscription.updateForItems(
         subscription.chargebeeSubscriptionId,
         {
-          subscription_items: [{ item_price_id: itemPriceId, unit_price: 0 }],
+          subscription_items: [{ item_price_id: itemPriceId, unit_price: 0, quantity: 1 }],
           replace_items_list: true,
           auto_collection: 'off',
         } as any


### PR DESCRIPTION
## Problem

`adminSetEnterprisePlan` failed for $0 enterprise deals with:

```
Failed to update Chargebee subscription: subscription_items[quantity][0] : cannot be blank
```

The $0 branch of `setEnterpriseSubscription` calls Chargebee's `updateForItems` with a subscription item that has no `quantity`, which Chargebee rejects. The paid-checkout branch a few lines below already passes `quantity: 1`.

## Fix

Add `quantity: 1` to the subscription item in the $0 update branch, matching the paid path.

## Verification

Ran the backend locally and replayed the failing `AdminSetEnterprisePlan` mutation ($0 USD monthly) as super admin — it returned `{ requiresPayment: false, checkoutUrl: null }`, and `adminOrganizationById` confirmed the org's subscription is now `planId: enterprise`, `status: active` with the requested limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed $0 enterprise subscription updates to correctly apply a zero unit price when switching plans (ensuring the update payload includes the intended pricing).
* **Tests**
  * Updated the related unit test to validate the full subscription update request more precisely, improving coverage for the $0 “no checkout” scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->