### PR TITLE
fix(backend): stop flaky ai-tagger handler test from hitting a real Prisma connection

### DIFF
--- a/apps/backend/src/plugins/ai-tagger/__tests__/handler.test.ts
+++ b/apps/backend/src/plugins/ai-tagger/__tests__/handler.test.ts
@@ -8,8 +8,14 @@ vi.mock('ai', () => ({
   Output: { object: vi.fn(() => ({})) },
 }));
 
-vi.mock('../../../../lib/ai.js', () => ({
+vi.mock('../../../lib/ai.js', () => ({
   getFastModel: vi.fn(() => 'mock-model'),
+}));
+
+// Must be mocked: the real module reaches Prisma via collaborativeDocumentRepository,
+// which would attempt an actual database connection during unit tests.
+vi.mock('../../../services/hocuspocus.js', () => ({
+  getFormSchemaFromHocuspocus: vi.fn(async () => null),
 }));
 
 const TEST_PLUGIN_ID = 'plugin-abc';


### PR DESCRIPTION
## Problem

`apps/backend/src/plugins/ai-tagger/__tests__/handler.test.ts` was flaky depending on cross-file test ordering: it hit a **real Prisma connection** instead of its mock.

Two mock defects:

1. **Unmocked Prisma path** — the handler calls `getFormSchemaFromHocuspocus()` from `services/hocuspocus.js`, which the test never mocked. That module pulls in `collaborativeDocumentRepository` → the real Prisma client, so every test that got past the config checks issued a real database query — racing the service's 30s DB timeout against the 10s vitest test timeout. Whether it failed fast, hung, or accidentally connected depended on the environment and shared process state from previously-run test files. Other suites (`forms.test.ts`, `unifiedExport.test.ts`, `fieldAnalytics.test.ts`) already mock this module; this one didn't.
2. **Wrong mock path** — `vi.mock('../../../../lib/ai.js')` had four `../` instead of three, resolving outside `src/`, so the `getFastModel` mock silently never applied.

## Fix

Test file only:
- Mock `services/hocuspocus.js` with `getFormSchemaFromHocuspocus` returning `null` — matching what the tests already assume, since their expectations use raw field keys (the handler's fallback when no schema resolves).
- Correct the `lib/ai.js` mock path.

## Verification

- ai-tagger suite: 11/11 pass; per-file test time dropped from 3.6s → 1.1s (connection attempts gone)
- Full backend unit suite: 87 files / 2474 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated AI Tagger handler tests to use isolated service mocks.
  * Prevented test runs from accessing external database-related services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->