### PR TITLE
docs: add Prisma schema change checklist to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,17 @@ Has its own auth hook, locale support, and translation namespace.
 
 ## Key Conventions
 
+### Prisma Schema Changes
+
+Any change to `apps/backend/prisma/schema.prisma` requires **both** of these — the schema edit alone is not enough:
+
+1. **A committed migration** in `apps/backend/prisma/migrations/<timestamp>_<name>/migration.sql`. Deployments run `db:migrate:deploy`, which only applies checked-in migrations — never `db push`. Use `ADD COLUMN IF NOT EXISTS` guards, since dev databases may already have the columns via `pnpm db:push`.
+2. **After pulling a schema change** into a checkout: run `pnpm db:generate` and `pnpm db:push`. The Prisma client is generated into `apps/backend/src/generated/prisma` (inside the repo, gitignored), so pulling code does **not** refresh it.
+
+Failure signatures when this is skipped:
+- **Stale generated client** → silent missing fields: GraphQL throws `"Cannot return null for non-nullable field ..."` because the old client never selects the new column.
+- **Missing DB column** (client regenerated but DB not pushed) → loud Prisma error `P2022: column does not exist`.
+
 ### Import Rules
 
 ```typescript


### PR DESCRIPTION
## Why

After merging #105, the main checkout hit `"Cannot return null for non-nullable field PlanSubscription.enterprisePendingActivation"` on every GetSubscription query. Root cause: the Prisma client is generated into `apps/backend/src/generated/prisma` (gitignored), so pulling a schema change does **not** refresh it — the stale client silently drops new columns from query results.

The same PR also initially shipped without a migration file, which both review bots flagged as a P1: deploys run `db:migrate:deploy` and only apply checked-in migrations.

## What

Adds a "Prisma Schema Changes" section under Key Conventions in `CLAUDE.md` covering:

- Schema PRs must include a committed migration (with `ADD COLUMN IF NOT EXISTS` guards, since dev DBs get columns early via `db push`)
- After pulling a schema change: `pnpm db:generate` + `pnpm db:push`
- The two failure signatures (silent GraphQL non-nullable error = stale client; loud Prisma P2022 = missing DB column) to speed up diagnosis

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for safely applying database schema updates across development environments.
  * Documented the required migration and client regeneration steps after schema changes.
  * Included troubleshooting information for common errors caused by outdated generated data or missing database fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->