### PR TITLE
fix(pdf-templates): serve @pdfme/converter's PDF-render worker asset in dev

### DIFF
--- a/apps/form-app/tsconfig.node.json
+++ b/apps/form-app/tsconfig.node.json
@@ -6,5 +6,5 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vite-pdfme-worker-fallback.ts"]
 } 

--- a/apps/form-app/vite-pdfme-worker-fallback.ts
+++ b/apps/form-app/vite-pdfme-worker-fallback.ts
@@ -42,7 +42,17 @@ export function pdfmeWorkerAssetFallbackPlugin(): Plugin {
         if (!assetPath) return next();
 
         res.setHeader('Content-Type', 'text/javascript');
-        fs.createReadStream(assetPath).pipe(res);
+        fs.createReadStream(assetPath)
+          .on('error', (err) => {
+            // Guards against a race between the existsSync check in
+            // findConverterAsset and this read (e.g. a concurrent
+            // node_modules reinstall) — an unhandled stream error here would
+            // otherwise crash the dev server process.
+            if (!res.headersSent) res.statusCode = 500;
+            res.end();
+            console.error('[pdfme-worker-asset-fallback] failed to stream asset:', err);
+          })
+          .pipe(res);
       });
     },
   };

--- a/apps/form-app/vite-pdfme-worker-fallback.ts
+++ b/apps/form-app/vite-pdfme-worker-fallback.ts
@@ -1,0 +1,77 @@
+import fs from 'fs';
+import path from 'path';
+import type { Plugin } from 'vite';
+
+/**
+ * @pdfme/converter (used internally by @pdfme/ui's Designer to render an
+ * uploaded base PDF onto the canvas) builds its worker script URL as
+ * `new URL('assets/clawpdf-worker-<hash>.js', import.meta.url)`. When Vite's
+ * dependency optimizer pre-bundles @pdfme/ui into node_modules/.vite/deps/,
+ * that relative URL resolves against the pre-bundled file's location instead
+ * of @pdfme/converter's own dist/ folder, so the browser 404s requesting
+ * node_modules/.vite/deps/assets/clawpdf-worker-<hash>.js and the designer
+ * fails with "PDF render worker failed".
+ *
+ * Excluding @pdfme/converter from pre-bundling avoids the broken relative
+ * URL, but drags its transitive CommonJS-only dependencies (pako@1.0.11 via
+ * @pdf-lib/standard-fonts and @pdf-lib/upng) into unbundled native-ESM
+ * requests, which then fail with "does not provide an export named
+ * 'default'" — deep pnpm isolation makes those nested deps unresolvable via
+ * optimizeDeps.include chains from the project root.
+ *
+ * Instead, this plugin leaves normal pre-bundling untouched (so CJS interop
+ * keeps working) and only patches the one broken static-asset lookup: when
+ * Vite's dep-serving middleware 404s a request for
+ * /node_modules/.vite/deps/assets/<file>.js, fall back to serving the same
+ * filename from @pdfme/converter's real dist/assets/ directory.
+ */
+export function pdfmeWorkerAssetFallbackPlugin(): Plugin {
+  return {
+    name: 'pdfme-worker-asset-fallback',
+    configureServer(server) {
+      // Registered without returning a function so this runs BEFORE Vite's
+      // internal deps-serving middleware — that middleware ends the response
+      // with a 404 directly (without calling next()) when the asset is
+      // missing, so a post-hook middleware never gets a chance to run.
+      server.middlewares.use((req, res, next) => {
+        const url = req.url ?? '';
+        const match = url.match(/^\/node_modules\/\.vite\/deps\/assets\/([\w.-]+\.js)(\?.*)?$/);
+        if (!match) return next();
+
+        const assetPath = findConverterAsset(match[1]);
+        if (!assetPath) return next();
+
+        res.setHeader('Content-Type', 'text/javascript');
+        fs.createReadStream(assetPath).pipe(res);
+      });
+    },
+  };
+}
+
+let cachedAssetsDir: string | null | undefined;
+
+function findConverterAssetsDir(): string | null {
+  if (cachedAssetsDir !== undefined) return cachedAssetsDir;
+
+  const pnpmStore = path.resolve(__dirname, '../../node_modules/.pnpm');
+  cachedAssetsDir = null;
+  try {
+    const entry = fs
+      .readdirSync(pnpmStore)
+      .find((name) => name.startsWith('@pdfme+converter@'));
+    if (entry) {
+      const dir = path.join(pnpmStore, entry, 'node_modules/@pdfme/converter/dist/assets');
+      if (fs.existsSync(dir)) cachedAssetsDir = dir;
+    }
+  } catch {
+    // pnpm store not found at the expected location — leave cachedAssetsDir null
+  }
+  return cachedAssetsDir;
+}
+
+function findConverterAsset(filename: string): string | null {
+  const dir = findConverterAssetsDir();
+  if (!dir) return null;
+  const filePath = path.join(dir, filename);
+  return fs.existsSync(filePath) ? filePath : null;
+}

--- a/apps/form-app/vite.config.ts
+++ b/apps/form-app/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import { pdfmeWorkerAssetFallbackPlugin } from './vite-pdfme-worker-fallback';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), pdfmeWorkerAssetFallbackPlugin()],
   resolve: {
     alias: [
       { find: '@', replacement: path.resolve(__dirname, './src') },


### PR DESCRIPTION
## Summary

Follow-up to #108 (PDF Templates feature, closes #87). Uploading a base PDF into the PDF Templates designer failed in local dev with **"PDF render worker failed"** — initially reported as a CORS error, but investigation found the presigned R2 GET for the uploaded PDF succeeded in every test; the real cause is a Vite dev-server dependency-optimization bug, unrelated to Cloudflare/R2.

**Root cause**: `@pdfme/converter` (used internally by `@pdfme/ui`'s Designer to render an uploaded base PDF onto the canvas) builds its worker script URL as `new URL('assets/clawpdf-worker-*.js', import.meta.url)`. When Vite's dependency optimizer pre-bundles it into `node_modules/.vite/deps/`, that relative URL resolves against the pre-bundled file's location instead of the package's own `dist/assets/` folder, so the browser 404s fetching the worker.

I first tried the standard fix — `optimizeDeps.exclude: ['@pdfme/converter']` — but that drags its nested CommonJS-only dependency (`pako@1.0.11`, via `@pdf-lib/standard-fonts`/`@pdf-lib/upng`) into unbundled native-ESM requests, which then fail with `"does not provide an export named 'default'"`. pnpm's strict dependency isolation makes those nested deps unresolvable via `optimizeDeps.include` chain syntax from the project root, so that path was a dead end.

**Fix**: `apps/form-app/vite-pdfme-worker-fallback.ts` — a small Vite plugin that intercepts dev-server requests for the missing worker asset and serves it from `@pdfme/converter`'s real `dist/assets/` location, leaving normal pre-bundling (and its automatic CJS interop) untouched.

- The `configureServer` hook is dev-only and a no-op during production builds — `pnpm build` still succeeds cleanly with no bundle-size or output changes.
- Also added the new file to `apps/form-app/tsconfig.node.json`'s `include` so the vite config project type-checks it.

## Test plan
- [x] Verified end-to-end: uploaded a real multi-page PDF into the designer — all pages render correctly, page navigation works, no console/network errors
- [x] `pnpm --filter form-app build` — clean, no bundle changes
- [x] `pnpm --filter form-app type-check` and `tsc --noEmit -p tsconfig.node.json` — clean
- [x] Confirmed via curl that the previously-404ing worker asset now returns 200 from the dev server
- [ ] No automated test added for this dev-server-only middleware (not exercised by CI's build step, which doesn't start the dev server) — manual verification only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed development-time loading of PDF conversion worker assets by adding a server-side fallback for missing Vite dependency asset requests.
  * Prevented related 404 errors when worker asset files can’t be resolved, allowing PDF conversion to continue working reliably in dev environments.
* **Chores**
  * Updated project TypeScript configuration to include the new fallback logic for proper build/type coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->