### PR TITLE
fix(infra): configure CORS on the private R2 bucket via aws provider

### DIFF
--- a/.github/workflows/multi-cloud-deployment.yml
+++ b/.github/workflows/multi-cloud-deployment.yml
@@ -491,6 +491,7 @@ jobs:
           cp ../../r2-buckets.tf .
           cp ../../r2-custom-domains.tf .
           cp ../../r2-api-token.tf .
+          cp ../../r2-cors.tf .
           cp ../../outputs.tf .
 
           # Initialize Terraform

--- a/infrastructure/multi-cloud/terraform/cloudflare/main.tf
+++ b/infrastructure/multi-cloud/terraform/cloudflare/main.tf
@@ -6,10 +6,44 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = ">= 4.43.0"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
   }
 }
 
 provider "cloudflare" {
   # The provider will automatically use CLOUDFLARE_API_TOKEN environment variable
   # No need to explicitly set api_token here
+}
+
+# R2's bucket-level settings (CORS, lifecycle policies) are only exposed via
+# its S3-compatible API, not the Cloudflare provider — so bucket CORS is
+# managed through the AWS provider pointed at R2's S3 endpoint, using the
+# same R2 API token (see r2-api-token.tf) as S3-style credentials.
+#
+# NOTE: this makes the aws provider's config depend on a resource created in
+# this same configuration (cloudflare_api_token.r2_access). Terraform's graph
+# handles this correctly in a single `terraform apply` as long as that
+# resource already exists in state (true for every environment here, since
+# the R2 buckets/token were provisioned before this file was added). If a
+# *brand new* environment is ever bootstrapped from scratch, the very first
+# apply may need `-target=cloudflare_api_token.r2_access` first, then a
+# regular apply, to avoid a "provider config not yet known" ordering error.
+provider "aws" {
+  region = "auto" # R2 ignores region; the endpoint override below is what matters
+
+  access_key = cloudflare_api_token.r2_access.id
+  secret_key = sha256(cloudflare_api_token.r2_access.value)
+
+  skip_credentials_validation = true
+  skip_region_validation      = true
+  skip_requesting_account_id  = true
+  skip_metadata_api_check     = true
+  s3_use_path_style           = true
+
+  endpoints {
+    s3 = "https://${var.cloudflare_account_id}.r2.cloudflarestorage.com"
+  }
 }

--- a/infrastructure/multi-cloud/terraform/cloudflare/main.tf
+++ b/infrastructure/multi-cloud/terraform/cloudflare/main.tf
@@ -3,12 +3,9 @@ terraform {
 
   required_providers {
     cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = ">= 4.43.0"
-    }
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      source = "cloudflare/cloudflare"
+      # cloudflare_r2_bucket_cors (r2-cors.tf) requires the v5 provider
+      version = "~> 5.0"
     }
   }
 }
@@ -16,34 +13,4 @@ terraform {
 provider "cloudflare" {
   # The provider will automatically use CLOUDFLARE_API_TOKEN environment variable
   # No need to explicitly set api_token here
-}
-
-# R2's bucket-level settings (CORS, lifecycle policies) are only exposed via
-# its S3-compatible API, not the Cloudflare provider — so bucket CORS is
-# managed through the AWS provider pointed at R2's S3 endpoint, using the
-# same R2 API token (see r2-api-token.tf) as S3-style credentials.
-#
-# NOTE: this makes the aws provider's config depend on a resource created in
-# this same configuration (cloudflare_api_token.r2_access). Terraform's graph
-# handles this correctly in a single `terraform apply` as long as that
-# resource already exists in state (true for every environment here, since
-# the R2 buckets/token were provisioned before this file was added). If a
-# *brand new* environment is ever bootstrapped from scratch, the very first
-# apply may need `-target=cloudflare_api_token.r2_access` first, then a
-# regular apply, to avoid a "provider config not yet known" ordering error.
-provider "aws" {
-  region = "auto" # R2 ignores region; the endpoint override below is what matters
-
-  access_key = cloudflare_api_token.r2_access.id
-  secret_key = sha256(cloudflare_api_token.r2_access.value)
-
-  skip_credentials_validation = true
-  skip_region_validation      = true
-  skip_requesting_account_id  = true
-  skip_metadata_api_check     = true
-  s3_use_path_style           = true
-
-  endpoints {
-    s3 = "https://${var.cloudflare_account_id}.r2.cloudflarestorage.com"
-  }
 }

--- a/infrastructure/multi-cloud/terraform/cloudflare/r2-buckets.tf
+++ b/infrastructure/multi-cloud/terraform/cloudflare/r2-buckets.tf
@@ -12,5 +12,5 @@ resource "cloudflare_r2_bucket" "public" {
   location   = var.r2_location
 }
 
-# Note: CORS configuration and lifecycle policies must be configured using the AWS S3 provider
-# See README.md for instructions on configuring CORS and other bucket policies
+# Note: CORS configuration must be set via the AWS S3 provider — see r2-cors.tf.
+# Lifecycle policies would follow the same pattern if ever needed.

--- a/infrastructure/multi-cloud/terraform/cloudflare/r2-buckets.tf
+++ b/infrastructure/multi-cloud/terraform/cloudflare/r2-buckets.tf
@@ -12,5 +12,5 @@ resource "cloudflare_r2_bucket" "public" {
   location   = var.r2_location
 }
 
-# Note: CORS configuration must be set via the AWS S3 provider — see r2-cors.tf.
-# Lifecycle policies would follow the same pattern if ever needed.
+# Note: CORS configuration for the private bucket lives in r2-cors.tf
+# (cloudflare_r2_bucket_cors, provider v5+).

--- a/infrastructure/multi-cloud/terraform/cloudflare/r2-cors.tf
+++ b/infrastructure/multi-cloud/terraform/cloudflare/r2-cors.tf
@@ -1,0 +1,22 @@
+# CORS configuration for the private R2 bucket.
+#
+# Needed by form-app's PDF Templates designer: when opening a template built
+# from an uploaded base PDF, the browser fetches the PDF directly from R2 via
+# a pre-signed URL (to hydrate pdfme's Designer) — a cross-origin `fetch()`
+# that Chrome blocks without a matching Access-Control-Allow-Origin response
+# header. R2 buckets have no CORS policy by default, which is why this was
+# failing with "No 'Access-Control-Allow-Origin' header is present".
+#
+# Scoped to the private bucket only: the public bucket is served through the
+# public-cdn-{env}.dculus.com custom domain (see r2-custom-domains.tf), not
+# fetched cross-origin from form-app directly, so it doesn't need this.
+resource "aws_s3_bucket_cors_configuration" "private" {
+  bucket = cloudflare_r2_bucket.private.name
+
+  cors_rule {
+    allowed_methods = ["GET"]
+    allowed_origins = var.cors_allowed_origins
+    allowed_headers = ["*"]
+    max_age_seconds = 3600
+  }
+}

--- a/infrastructure/multi-cloud/terraform/cloudflare/r2-cors.tf
+++ b/infrastructure/multi-cloud/terraform/cloudflare/r2-cors.tf
@@ -10,13 +10,16 @@
 # Scoped to the private bucket only: the public bucket is served through the
 # public-cdn-{env}.dculus.com custom domain (see r2-custom-domains.tf), not
 # fetched cross-origin from form-app directly, so it doesn't need this.
-resource "aws_s3_bucket_cors_configuration" "private" {
-  bucket = cloudflare_r2_bucket.private.name
+resource "cloudflare_r2_bucket_cors" "private" {
+  account_id  = var.cloudflare_account_id
+  bucket_name = cloudflare_r2_bucket.private.name
 
-  cors_rule {
-    allowed_methods = ["GET"]
-    allowed_origins = var.cors_allowed_origins
-    allowed_headers = ["*"]
+  rules = [{
+    id = "allow-form-app-origins"
+    allowed = {
+      methods = ["GET"]
+      origins = var.cors_allowed_origins
+    }
     max_age_seconds = 3600
-  }
+  }]
 }


### PR DESCRIPTION
## Summary

Follow-up to #87/#108/#109. The original CORS report on the PDF Templates feature was real — I initially dismissed it after a Vite dev-server bug (#109) turned out to be the *first* thing blocking the upload-PDF flow, but once that was fixed, a genuine CORS failure showed up underneath it. Confirmed with a direct probe against the dev bucket:

```
OPTIONS preflight  -> 403 "CORS not configured for this bucket"
GET (w/ Origin hdr) -> 200, but no Access-Control-Allow-Origin header at all
```

**Root cause**: R2 buckets have no CORS policy by default. This repo already had a `cors_allowed_origins` variable declared and populated per-environment in `environments/*/terraform.tfvars` (including `http://localhost:3000` for dev) — it was just never wired to an actual resource.

**Fix**:
- `r2-cors.tf` (new) — `cloudflare_r2_bucket_cors` (native Cloudflare provider v5 resource) for the **private** bucket only, using the existing `cors_allowed_origins` variable. The public bucket is served through its CDN custom domain, not fetched cross-origin from form-app directly, so it doesn't need this.
- `main.tf` — bumps the Cloudflare provider constraint to `~> 5.0` (the resource doesn't exist in v4; the rest of this module was already using v5-style syntax in practice).
- `multi-cloud-deployment.yml` — added `r2-cors.tf` to the Cloudflare R2 deploy step's file-copy list (it copies specific named files into the per-environment working directory before running Terraform; a new file silently never applies otherwise).

**Correction (2026-07-10)**: the first version of this PR added a separate `aws` provider + `aws_s3_bucket_cors_configuration`, working around what I assumed was a gap in the Cloudflare provider. That was wrong — the Cloudflare provider has a native `cloudflare_r2_bucket_cors` resource ([docs](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/r2_bucket_cors)). Replaced entirely; the `aws` provider is gone.

## ⚠️ Please review before merging

I have **no Cloudflare credentials in this environment**, so this has only been checked with `terraform fmt -check` and `terraform validate` (both pass) — **not** `terraform plan`/`apply` against a real account. Recommend running `terraform plan` against the dev environment folder before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CORS configuration for the private Cloudflare R2 bucket to enable cross-origin `GET` requests from approved origins.
  * Updated multi-cloud deployment so the latest private bucket CORS settings are applied during provisioning.
* **Documentation**
  * Clarified that private-bucket CORS is managed via the dedicated R2 CORS configuration, rather than through the earlier referenced setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->