### PR TITLE
fix(infra): drop orphaned aws_s3_bucket_cors_configuration from dev state, gate R2 apply on should_deploy

### DIFF
--- a/.github/workflows/multi-cloud-deployment.yml
+++ b/.github/workflows/multi-cloud-deployment.yml
@@ -492,6 +492,7 @@ jobs:
           cp ../../r2-custom-domains.tf .
           cp ../../r2-api-token.tf .
           cp ../../r2-cors.tf .
+          cp ../../r2-cors-state-cleanup.tf .
           cp ../../outputs.tf .
 
           # Initialize Terraform
@@ -507,21 +508,27 @@ jobs:
           # Plan
           terraform plan
 
-          # Apply
-          terraform apply -auto-approve \
-            -var="cloudflare_account_id=${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" \
-            -var="cloudflare_api_token=${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-            -var="cloudflare_zone_id=${{ secrets.CLOUDFLARE_ZONE_ID }}"
+          # Apply — only for events that should actually deploy (push to main,
+          # workflow_dispatch, version tags). pull_request events set
+          # should_deploy=false so PRs only ever plan against real infra.
+          if [ "${{ needs.determine-environment.outputs.should_deploy }}" = "true" ]; then
+            terraform apply -auto-approve \
+              -var="cloudflare_account_id=${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" \
+              -var="cloudflare_api_token=${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+              -var="cloudflare_zone_id=${{ secrets.CLOUDFLARE_ZONE_ID }}"
 
-          # Capture outputs to environment variables (stays within job)
+            echo "✅ Cloudflare R2 deployed successfully"
+          fi
+
+          # Capture outputs to environment variables (stays within job).
+          # Safe even when apply was skipped above — these read from state,
+          # which already has real values for any previously-deployed environment.
           echo "R2_PRIVATE_BUCKET=$(terraform output -raw private_bucket_name)" >> $GITHUB_ENV
           echo "R2_PUBLIC_BUCKET=$(terraform output -raw public_bucket_name)" >> $GITHUB_ENV
           echo "R2_PUBLIC_CDN_URL=$(terraform output -raw public_cdn_url)" >> $GITHUB_ENV
           echo "R2_ACCESS_KEY_ID=$(terraform output -raw r2_access_key_id)" >> $GITHUB_ENV
           echo "R2_SECRET_ACCESS_KEY=$(terraform output -raw r2_secret_access_key)" >> $GITHUB_ENV
           echo "R2_ENDPOINT=https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com" >> $GITHUB_ENV
-
-          echo "✅ Cloudflare R2 deployed successfully"
 
       - name: Set Cloudflare outputs
         id: cloudflare-outputs

--- a/.github/workflows/multi-cloud-deployment.yml
+++ b/.github/workflows/multi-cloud-deployment.yml
@@ -1753,6 +1753,7 @@ jobs:
     needs: [ determine-environment, terraform-infrastructure-deploy ]
     if: |
       always() && !cancelled() &&
+      needs.determine-environment.outputs.should_deploy == 'true' &&
       needs.terraform-infrastructure-deploy.result == 'success'
     steps:
       - name: Wait for backend to be ready

--- a/infrastructure/multi-cloud/terraform/cloudflare/.terraform.lock.hcl
+++ b/infrastructure/multi-cloud/terraform/cloudflare/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/cloudflare/cloudflare" {
   version     = "5.12.0"
-  constraints = ">= 4.43.0"
+  constraints = "~> 5.0"
   hashes = [
     "h1:vrbI9qWFMZPA47W+OLnqcBT7+3gk24vfqj5kzoOAyMU=",
     "zh:06166a72e69eb712ad2c8b49c1ed060223b0d57bb95ce5f6c8440ce19253913e",
@@ -15,5 +15,29 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
     "zh:f000d33075c30e616df8e58e341614e958eed4a51f3427d2e1a18ea1b7e0c6c6",
     "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
     "zh:ff4fd5b3b0327f8f41fc65d909839288fb98ecfe32a9aff11d2e2638f2109302",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.54.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:i89hWLGo3bPwJKYBv3+S67qbfr0tydFqs70Hq5VcoYs=",
+    "zh:0557777baa82faa7907adce61a2a3f9b2a487070bb03f29df20a7502edfe966f",
+    "zh:0767256c36b9c4d4b66d4af882de480c6535ff9eac26410fca253e87b89cb478",
+    "zh:0be7595ef70273af5eb72d850d45eb264d39796d0578c7f3eda9988d7f0781e5",
+    "zh:0fd81edad00c8da35b37aa310c7466f7a8d61056b95b37b349c510d21a8a52f6",
+    "zh:11a976648c864d126a70eb2d40182a17ecfeb3c6c3bf790c4f7eafa5e4c204ba",
+    "zh:14065875294ea597303ae8e462189041067de3b1f5d97c9f2b04b5d14aeb4f7c",
+    "zh:55a76258b109f8394cad20c9e07f376fe3051920931bf43d1b62f4d7242f20c8",
+    "zh:69b04cc363dda4df3d703c3954ae87ef36b0fea8fe45a236db89f8647a879274",
+    "zh:79e3425219f59e285f128e88a7c294a6d33c7bfa73c57a42e31ac0d8daa2f20a",
+    "zh:8d6c46c8a215f73c3c1109695a9bfd8894852d0b1c592516f09efb8a84e08b0c",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9db8f8fac77d6e999a2886df52bebb106b93ba8dfc4fea1e04decc8fda8070cd",
+    "zh:b4fc365f093b232531905547a50d4f62dbd9d5a843707867520b8b04e8b36e4f",
+    "zh:c9135045fbc561d30ec72f0b9335fcfe7590eed7e6b4eb8988455e6c8b4d348a",
+    "zh:db5f51f9f7037428cb7e8f8d43a63e0d3de498c9730fe98a3c539a75cc49208e",
+    "zh:f807b2a66174b20749c11d58cf7b2ffa8e89b4ec60dd70382959074f8490c387",
   ]
 }

--- a/infrastructure/multi-cloud/terraform/cloudflare/main.tf
+++ b/infrastructure/multi-cloud/terraform/cloudflare/main.tf
@@ -7,10 +7,41 @@ terraform {
       # cloudflare_r2_bucket_cors (r2-cors.tf) requires the v5 provider
       version = "~> 5.0"
     }
+    # TEMPORARY — see r2-cors-state-cleanup.tf. Remove this block together
+    # with that file once the cleanup has applied in every environment that
+    # ran the early aws-provider draft of PR #110 (currently just dev).
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
   }
 }
 
 provider "cloudflare" {
   # The provider will automatically use CLOUDFLARE_API_TOKEN environment variable
   # No need to explicitly set api_token here
+}
+
+# TEMPORARY — see r2-cors-state-cleanup.tf for why this exists. This is the
+# same aws provider config PR #110's first draft used (pointed at R2's
+# S3-compatible endpoint via the existing R2 API token), restored only so
+# Terraform can refresh/forget the orphaned aws_s3_bucket_cors_configuration
+# resource that draft left behind in state. It performs no create/update —
+# the `removed` block's `destroy = false` means no API calls are made
+# against it at all beyond authentication.
+provider "aws" {
+  region = "auto" # R2 ignores region; the endpoint override below is what matters
+
+  access_key = cloudflare_api_token.r2_access.id
+  secret_key = sha256(cloudflare_api_token.r2_access.value)
+
+  skip_credentials_validation = true
+  skip_region_validation      = true
+  skip_requesting_account_id  = true
+  skip_metadata_api_check     = true
+  s3_use_path_style           = true
+
+  endpoints {
+    s3 = "https://${var.cloudflare_account_id}.r2.cloudflarestorage.com"
+  }
 }

--- a/infrastructure/multi-cloud/terraform/cloudflare/r2-cors-state-cleanup.tf
+++ b/infrastructure/multi-cloud/terraform/cloudflare/r2-cors-state-cleanup.tf
@@ -1,0 +1,26 @@
+# One-time cleanup for PR #110.
+#
+# That PR's first draft configured private-bucket CORS via the aws provider
+# (aws_s3_bucket_cors_configuration.private) before being corrected to use
+# the native cloudflare_r2_bucket_cors resource in r2-cors.tf. The draft was
+# briefly applied to the dev environment by a pull_request-triggered CI run
+# (the same run that exposed the should_deploy gating bug fixed in
+# multi-cloud-deployment.yml), leaving aws_s3_bucket_cors_configuration.private
+# orphaned in dev's Terraform state once the aws resource was dropped from
+# config. Every plan/apply since has failed trying to refresh it without an
+# aws provider block present.
+#
+# destroy = false: this only forgets the state entry. It does not touch the
+# real R2 bucket, whose CORS policy is already managed by
+# cloudflare_r2_bucket_cors.private (r2-cors.tf).
+#
+# Delete this file together with the temporary aws provider block in main.tf
+# once this has applied successfully (state list should no longer show
+# aws_s3_bucket_cors_configuration.private).
+removed {
+  from = aws_s3_bucket_cors_configuration.private
+
+  lifecycle {
+    destroy = false
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #110. That PR's `r2-cors.tf` code (`cloudflare_r2_bucket_cors`) is correct — verified against the [official Cloudflare Terraform provider docs](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/r2_bucket_cors) — but the post-merge deploy still fails:

```
Error: Invalid provider configuration
Provider "registry.terraform.io/hashicorp/aws" requires explicit configuration
Error: No valid credential sources found
```

**Root cause**, traced through the CI run history for #110:

1. #110's *first* commit (`e02e6ee8`) used an `aws` provider workaround (`aws_s3_bucket_cors_configuration`) before being corrected to the native `cloudflare_r2_bucket_cors` resource.
2. `multi-cloud-deployment.yml` triggers `terraform apply -auto-approve` on `pull_request` events touching `infrastructure/**` — that first commit's `pull_request` CI run actually **applied** `aws_s3_bucket_cors_configuration.private` to the real dev environment's Terraform state (`dculus-forms-cloudflare-r2-dev-state`).
3. Once the code was corrected and merged, the `aws` provider block was removed entirely — but the resource it created is still sitting in remote state. Every `plan`/`apply` since fails trying to refresh it without an `aws` provider config.

**Separate bug this exposed**: `determine-environment` already sets `should_deploy=false` for `pull_request` events (comment: *"For pull requests, only plan (no deploy)"*), and the Azure Container Apps deploy step in the same job correctly gates its `terraform apply` on that output — but the Cloudflare R2 deploy step never did. That's how an unreviewed first draft ended up mutating real dev infrastructure before merge.

## Changes

- **`r2-cors-state-cleanup.tf`** (new): a `removed` block (`lifecycle { destroy = false }`) to drop `aws_s3_bucket_cors_configuration.private` from state without touching the real R2 bucket — its CORS policy is already managed by `cloudflare_r2_bucket_cors.private` in `r2-cors.tf`.
- **`main.tf`**: temporarily restores the exact `aws` provider config `e02e6ee8` used (pointed at R2's S3-compatible endpoint via the existing R2 API token), so Terraform can authenticate long enough to process the removal. Marked `TEMPORARY` — delete this block + `r2-cors-state-cleanup.tf` in a follow-up PR once `terraform state list` no longer shows the orphaned resource in every environment that ran the aws-provider draft (currently just dev).
- **`multi-cloud-deployment.yml`**: wraps the Cloudflare R2 step's `terraform apply` in the same `should_deploy` guard the Azure step already uses, so `pull_request` runs only ever plan against real infra going forward. Output capture (`terraform output`) stays unconditional — it reads from existing state and is needed by the downstream Azure step regardless of event type.

## Verification

- `terraform fmt -check` and `terraform validate` both pass, run from `environments/dev` with real `terraform.tfvars` (matching what CI does) — confirmed the same `policies` type-inference error appears identically on `main` when validating from the shared directory without vars, so that's unrelated to this change.
- `.terraform.lock.hcl` diff confirmed minimal: `cloudflare` stays pinned at `5.12.0`, only `hashicorp/aws 6.54.0` added.
- Workflow YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).

I have no Cloudflare/Azure credentials in this environment, so this has **not** been `terraform plan`'d against the real dev state. Please review the `removed` block carefully and confirm the plan output on this PR (`pull_request` trigger will now only plan, per the workflow fix) shows `aws_s3_bucket_cors_configuration.private` being dropped from state before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cloudflare R2 deployments now run Terraform apply only when deployment is enabled, avoiding changes during plan-only runs.
  * Health-check execution is now aligned with the same deployment-enabled condition.
  * Added cleanup to remove stale Terraform state related to the old R2 CORS setup without destroying existing resources.

* **Chores**
  * Updated and aligned Terraform provider configuration to support S3-compatible access to Cloudflare R2, including provider version pinning and additional shared Terraform config copying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->