### PR TITLE
fix(billing): env-aware checkout redirect, hosted-page fallback sync, success-page flicker

### DIFF
--- a/apps/backend/src/graphql/resolvers/__tests__/subscriptions.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/subscriptions.test.ts
@@ -26,6 +26,8 @@ vi.mock('../../../services/chargebeeService.js', () => ({
   createPortalSession: vi.fn(),
   createChargebeeCustomer: vi.fn(),
   createFreeSubscription: vi.fn(),
+  getEnterpriseCheckoutUrl: vi.fn(),
+  syncFromHostedPage: vi.fn(),
 }));
 
 vi.mock('../../../middleware/better-auth-middleware.js', () => ({
@@ -273,6 +275,120 @@ describe('Subscription Resolvers', () => {
           mockContext
         )
       ).rejects.toThrow('Invalid item price ID format');
+    });
+  });
+
+  describe('Mutation: syncCheckoutSession', () => {
+    it('syncs immediately and returns the refreshed subscription when the hosted page succeeded', async () => {
+      vi.mocked(betterAuthMiddleware.requireAuth).mockReturnValue(mockContext.auth as any);
+      vi.mocked(betterAuthMiddleware.requireOrganizationMembership).mockResolvedValue(
+        mockMember as any
+      );
+      vi.mocked(chargebeeService.syncFromHostedPage).mockResolvedValue({
+        synced: true,
+        state: 'succeeded',
+      });
+      const syncedSubscription = { ...mockSubscription, planId: 'starter', status: 'active' };
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue(syncedSubscription as any);
+
+      const result = await subscriptionResolvers.Mutation.syncCheckoutSession(
+        {},
+        { hostedPageId: 'hosted_page_123' },
+        mockContext
+      );
+
+      expect(result).toEqual({ synced: true, subscription: syncedSubscription });
+      expect(chargebeeService.syncFromHostedPage).toHaveBeenCalledWith(
+        'hosted_page_123',
+        'org-123'
+      );
+    });
+
+    it('returns synced=false without throwing when checkout has not completed yet', async () => {
+      vi.mocked(betterAuthMiddleware.requireAuth).mockReturnValue(mockContext.auth as any);
+      vi.mocked(betterAuthMiddleware.requireOrganizationMembership).mockResolvedValue(
+        mockMember as any
+      );
+      vi.mocked(chargebeeService.syncFromHostedPage).mockResolvedValue({
+        synced: false,
+        state: 'created',
+      });
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue(mockSubscription as any);
+
+      const result = await subscriptionResolvers.Mutation.syncCheckoutSession(
+        {},
+        { hostedPageId: 'hosted_page_123' },
+        mockContext
+      );
+
+      expect(result).toEqual({ synced: false, subscription: mockSubscription });
+    });
+
+    it('swallows Chargebee errors and returns synced=false instead of throwing (best-effort fallback)', async () => {
+      vi.mocked(betterAuthMiddleware.requireAuth).mockReturnValue(mockContext.auth as any);
+      vi.mocked(betterAuthMiddleware.requireOrganizationMembership).mockResolvedValue(
+        mockMember as any
+      );
+      vi.mocked(chargebeeService.syncFromHostedPage).mockRejectedValue(
+        new Error('Chargebee API error')
+      );
+      vi.mocked(prisma.subscription.findUnique).mockResolvedValue(mockSubscription as any);
+
+      const result = await subscriptionResolvers.Mutation.syncCheckoutSession(
+        {},
+        { hostedPageId: 'hosted_page_123' },
+        mockContext
+      );
+
+      expect(result).toEqual({ synced: false, subscription: mockSubscription });
+    });
+
+    it('throws when hostedPageId is empty or invalid', async () => {
+      vi.mocked(betterAuthMiddleware.requireAuth).mockReturnValue(mockContext.auth as any);
+
+      await expect(
+        subscriptionResolvers.Mutation.syncCheckoutSession(
+          {},
+          { hostedPageId: '' },
+          mockContext
+        )
+      ).rejects.toThrow('Invalid hosted page ID format');
+      expect(chargebeeService.syncFromHostedPage).not.toHaveBeenCalled();
+    });
+
+    it('throws when no active organization', async () => {
+      vi.mocked(betterAuthMiddleware.requireAuth).mockReturnValue(mockContext.auth as any);
+
+      const contextWithoutOrg = {
+        auth: {
+          user: mockContext.auth.user,
+          session: { id: 'session-123' },
+          isAuthenticated: true,
+        },
+      };
+
+      await expect(
+        subscriptionResolvers.Mutation.syncCheckoutSession(
+          {},
+          { hostedPageId: 'hosted_page_123' },
+          contextWithoutOrg
+        )
+      ).rejects.toThrow('No active organization');
+    });
+
+    it('throws when user is not organization member', async () => {
+      vi.mocked(betterAuthMiddleware.requireAuth).mockReturnValue(mockContext.auth as any);
+      vi.mocked(betterAuthMiddleware.requireOrganizationMembership).mockRejectedValue(
+        new GraphQLError('Not a member of this organization')
+      );
+
+      await expect(
+        subscriptionResolvers.Mutation.syncCheckoutSession(
+          {},
+          { hostedPageId: 'hosted_page_123' },
+          mockContext
+        )
+      ).rejects.toThrow('Not a member of this organization');
     });
   });
 

--- a/apps/backend/src/graphql/resolvers/subscriptions.ts
+++ b/apps/backend/src/graphql/resolvers/subscriptions.ts
@@ -7,6 +7,7 @@ import {
   createChargebeeCustomer,
   createFreeSubscription,
   getEnterpriseCheckoutUrl,
+  syncFromHostedPage,
 } from '../../services/chargebeeService.js';
 import { requireAuth, requireOrganizationMembership, type BetterAuthContext } from '../../middleware/better-auth-middleware.js';
 import { GraphQLError } from '#graphql-errors';
@@ -155,6 +156,51 @@ export const subscriptionResolvers = {
           'Failed to resume enterprise payment',
           GRAPHQL_ERROR_CODES.INTERNAL_SERVER_ERROR
         );
+      }
+    },
+
+    /**
+     * Fallback sync for the /subscription/success redirect. Chargebee
+     * appends ?id=<hostedPageId>&state=... on redirect — retrieving that
+     * hosted page server-side and syncing immediately means the org's plan
+     * doesn't have to wait on webhook delivery, which is slow in general and
+     * entirely unreachable in local dev (Chargebee can't deliver test-site
+     * webhooks to localhost).
+     */
+    syncCheckoutSession: async (
+      _: any,
+      { hostedPageId }: { hostedPageId: string },
+      context: { auth: BetterAuthContext }
+    ) => {
+      requireAuth(context.auth);
+
+      if (!hostedPageId || !/^[a-zA-Z0-9_-]{1,100}$/.test(hostedPageId)) {
+        throw createGraphQLError('Invalid hosted page ID format', GRAPHQL_ERROR_CODES.BAD_USER_INPUT);
+      }
+
+      const session = context.auth.session;
+      if (!session?.activeOrganizationId) {
+        throw createGraphQLError('No active organization', GRAPHQL_ERROR_CODES.BAD_USER_INPUT);
+      }
+
+      // 🔒 SECURITY: Verify user is a member of the active organization
+      await requireOrganizationMembership(context.auth, session.activeOrganizationId);
+
+      try {
+        const { synced } = await syncFromHostedPage(hostedPageId, session.activeOrganizationId);
+        const subscription = await prisma.subscription.findUnique({
+          where: { organizationId: session.activeOrganizationId },
+        });
+        return { synced, subscription };
+      } catch (error: unknown) {
+        // Don't fail the redirect page over this — it's a best-effort fallback
+        // and the caller (success.tsx) still has webhook-driven polling as a
+        // safety net.
+        logger.error('[Subscription Resolver] Error syncing checkout session:', error);
+        const subscription = await prisma.subscription.findUnique({
+          where: { organizationId: session.activeOrganizationId },
+        });
+        return { synced: false, subscription };
       }
     },
 

--- a/apps/backend/src/graphql/resolvers/subscriptions.ts
+++ b/apps/backend/src/graphql/resolvers/subscriptions.ts
@@ -186,22 +186,19 @@ export const subscriptionResolvers = {
       // 🔒 SECURITY: Verify user is a member of the active organization
       await requireOrganizationMembership(context.auth, session.activeOrganizationId);
 
+      let synced = false;
       try {
-        const { synced } = await syncFromHostedPage(hostedPageId, session.activeOrganizationId);
-        const subscription = await prisma.subscription.findUnique({
-          where: { organizationId: session.activeOrganizationId },
-        });
-        return { synced, subscription };
+        ({ synced } = await syncFromHostedPage(hostedPageId, session.activeOrganizationId));
       } catch (error: unknown) {
         // Don't fail the redirect page over this — it's a best-effort fallback
         // and the caller (success.tsx) still has webhook-driven polling as a
         // safety net.
         logger.error('[Subscription Resolver] Error syncing checkout session:', error);
-        const subscription = await prisma.subscription.findUnique({
-          where: { organizationId: session.activeOrganizationId },
-        });
-        return { synced: false, subscription };
       }
+      const subscription = await prisma.subscription.findUnique({
+        where: { organizationId: session.activeOrganizationId },
+      });
+      return { synced, subscription };
     },
 
     /**

--- a/apps/backend/src/graphql/schema.ts
+++ b/apps/backend/src/graphql/schema.ts
@@ -1183,6 +1183,16 @@ export const typeDefs = gql`
     message: String
   }
 
+  # Result of the post-checkout fallback sync (see syncCheckoutSession).
+  # synced=true means the hosted page had already succeeded and Postgres was
+  # updated immediately; synced=false means checkout hasn't completed yet
+  # (still 'created'/'requested') or was cancelled — callers should keep
+  # relying on webhook-driven polling in that case.
+  type SyncCheckoutSessionResult {
+    synced: Boolean!
+    subscription: PlanSubscription
+  }
+
   type PlanPrice {
     id: String!
     currency: String!
@@ -1285,6 +1295,12 @@ export const typeDefs = gql`
     # themselves instead of relying solely on the admin-shared/emailed link.
     # Only valid while Subscription.enterprisePendingActivation is true.
     completeEnterprisePayment: CheckoutSessionResponse!
+    # Fallback sync called from /subscription/success on redirect. Chargebee
+    # appends ?id=<hostedPageId>&state=... to redirect_url — this retrieves
+    # that hosted page and, if it succeeded, syncs Postgres immediately
+    # instead of waiting on webhook delivery (which can be delayed, or in
+    # local dev, unreachable entirely).
+    syncCheckoutSession(hostedPageId: String!): SyncCheckoutSessionResult!
 
     # Form Mutations
     createForm(input: CreateFormInput!): Form!

--- a/apps/backend/src/routes/__tests__/chargebee-webhooks.test.ts
+++ b/apps/backend/src/routes/__tests__/chargebee-webhooks.test.ts
@@ -67,7 +67,8 @@ describe('Chargebee Webhook Routes', () => {
       expect(response.body).toEqual({ received: true });
       expect(logger.info).toHaveBeenCalledWith(
         '[Chargebee Webhook] Received event:',
-        'subscription_created'
+        'subscription_created',
+        expect.objectContaining({ subscriptionId: 'sub_123', subscriptionStatus: 'active' })
       );
       expect(syncSubscriptionFromWebhook).toHaveBeenCalledWith(subscription);
       expect(handleSubscriptionRenewal).not.toHaveBeenCalled();
@@ -232,7 +233,8 @@ describe('Chargebee Webhook Routes', () => {
       expect(response.body).toEqual({ received: true });
       expect(logger.info).toHaveBeenCalledWith(
         '[Chargebee Webhook] Received event:',
-        'payment_succeeded'
+        'payment_succeeded',
+        expect.any(Object)
       );
       expect(syncSubscriptionFromWebhook).not.toHaveBeenCalled();
     });
@@ -402,7 +404,8 @@ describe('Chargebee Webhook Routes', () => {
 
         expect(logger.info).toHaveBeenCalledWith(
           '[Chargebee Webhook] Received event:',
-          eventType
+          eventType,
+          expect.any(Object)
         );
       }
     });

--- a/apps/backend/src/routes/chargebee-webhooks.ts
+++ b/apps/backend/src/routes/chargebee-webhooks.ts
@@ -49,7 +49,12 @@ router.post('/webhooks/chargebee', async (req, res) => {
 
     const event = req.body;
 
-    logger.info('[Chargebee Webhook] Received event:', event.event_type);
+    logger.info('[Chargebee Webhook] Received event:', event.event_type, {
+      eventId: event.id,
+      subscriptionId: event.content?.subscription?.id,
+      subscriptionStatus: event.content?.subscription?.status,
+      customerId: event.content?.subscription?.customer_id ?? event.content?.customer?.id,
+    });
 
     // Handle different event types
     switch (event.event_type) {

--- a/apps/backend/src/services/__tests__/chargebeeService.test.ts
+++ b/apps/backend/src/services/__tests__/chargebeeService.test.ts
@@ -8,6 +8,7 @@ import {
   cancelChargebeeSubscription,
   reactivateChargebeeSubscription,
   syncSubscriptionFromWebhook,
+  syncFromHostedPage,
   handleSubscriptionRenewal,
   getAvailablePlans,
   setEnterpriseSubscription,
@@ -37,6 +38,7 @@ vi.mock('chargebee', () => {
     hostedPage: {
       checkoutNewForItems: vi.fn(),
       checkoutExistingForItems: vi.fn(),
+      retrieve: vi.fn(),
     },
     portalSession: {
       create: vi.fn(),
@@ -101,6 +103,7 @@ describe('Chargebee Service', () => {
     mockChargebee.customer.retrieve.mockReset();
     mockChargebee.hostedPage.checkoutNewForItems.mockReset();
     mockChargebee.hostedPage.checkoutExistingForItems.mockReset();
+    mockChargebee.hostedPage.retrieve.mockReset();
     mockChargebee.portalSession.create.mockReset();
     mockChargebee.subscription.retrieve.mockReset();
     mockChargebee.subscription.cancel.mockReset();
@@ -769,6 +772,87 @@ describe('Chargebee Service', () => {
 
       expect(loggerError).toHaveBeenCalled();
       loggerError.mockRestore();
+    });
+  });
+
+  describe('syncFromHostedPage', () => {
+    it('syncs Postgres immediately when the hosted page succeeded and belongs to the requesting org', async () => {
+      mockChargebee.hostedPage.retrieve.mockResolvedValue({
+        hosted_page: {
+          id: 'hp_123',
+          state: 'succeeded',
+          content: {
+            subscription: {
+              id: 'sub_123',
+              customer_id: 'org_org-123',
+              status: 'active',
+              subscription_items: [{ item_price_id: 'starter-usd-monthly' }],
+              current_term_start: 1704067200,
+              current_term_end: 1706745600,
+            },
+          },
+        },
+      });
+      vi.mocked(subscriptionRepository.upsertForOrganization).mockResolvedValue({} as any);
+
+      const result = await syncFromHostedPage('hp_123', 'org-123');
+
+      expect(result).toEqual({ synced: true, state: 'succeeded' });
+      expect(mockChargebee.hostedPage.retrieve).toHaveBeenCalledWith('hp_123');
+      expect(subscriptionRepository.upsertForOrganization).toHaveBeenCalledWith(
+        'org-123',
+        expect.objectContaining({ planId: 'starter', status: 'active' }),
+        expect.any(Object)
+      );
+    });
+
+    it('does not sync when the hosted page has not succeeded yet', async () => {
+      mockChargebee.hostedPage.retrieve.mockResolvedValue({
+        hosted_page: { id: 'hp_123', state: 'created', content: {} },
+      });
+
+      const result = await syncFromHostedPage('hp_123', 'org-123');
+
+      expect(result).toEqual({ synced: false, state: 'created' });
+      expect(subscriptionRepository.upsertForOrganization).not.toHaveBeenCalled();
+    });
+
+    it('refuses to sync when the hosted page belongs to a different organization', async () => {
+      const loggerWarn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      mockChargebee.hostedPage.retrieve.mockResolvedValue({
+        hosted_page: {
+          id: 'hp_123',
+          state: 'succeeded',
+          content: {
+            subscription: {
+              id: 'sub_123',
+              customer_id: 'org_some-other-org',
+              status: 'active',
+              subscription_items: [{ item_price_id: 'starter-usd-monthly' }],
+              current_term_start: 1704067200,
+              current_term_end: 1706745600,
+            },
+          },
+        },
+      });
+
+      const result = await syncFromHostedPage('hp_123', 'org-123');
+
+      expect(result).toEqual({ synced: false, state: 'succeeded' });
+      expect(subscriptionRepository.upsertForOrganization).not.toHaveBeenCalled();
+      expect(loggerWarn).toHaveBeenCalled();
+      loggerWarn.mockRestore();
+    });
+
+    it('does not sync when a succeeded hosted page has no subscription content', async () => {
+      mockChargebee.hostedPage.retrieve.mockResolvedValue({
+        hosted_page: { id: 'hp_123', state: 'succeeded', content: {} },
+      });
+
+      const result = await syncFromHostedPage('hp_123', 'org-123');
+
+      expect(result).toEqual({ synced: false, state: 'succeeded' });
+      expect(subscriptionRepository.upsertForOrganization).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/services/chargebeeService.ts
+++ b/apps/backend/src/services/chargebeeService.ts
@@ -196,6 +196,12 @@ const buildEnterpriseCheckoutUrl = async (
   await lockEnterpriseItemPriceQuantity(itemPriceId);
 
   const baseUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+  logger.info('[Chargebee Service] Creating enterprise checkout hosted page', {
+    chargebeeSubscriptionId,
+    itemPriceId,
+    redirectBaseUrl: baseUrl,
+    frontendUrlSet: Boolean(process.env.FRONTEND_URL),
+  });
   const result: any = await chargebee.hostedPage.checkoutExistingForItems({
     subscription: { id: chargebeeSubscriptionId, auto_collection: 'on' },
     subscription_items: [{ item_price_id: itemPriceId, unit_price: priceInSmallestUnit, quantity: 1 }],
@@ -435,6 +441,12 @@ export const createCheckoutHostedPage = async (
   try {
     // Get base URL from environment or use default
     const baseUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+    logger.info('[Chargebee Service] Creating checkout hosted page', {
+      customerId,
+      itemPriceId,
+      redirectBaseUrl: baseUrl,
+      frontendUrlSet: Boolean(process.env.FRONTEND_URL),
+    });
 
     // Use checkoutNewForItems for Product Catalog 2.0
     const result = await chargebee.hostedPage.checkoutNewForItems({
@@ -658,6 +670,71 @@ export const syncSubscriptionFromWebhook = async (
     logger.error('[Chargebee Service] Error syncing subscription:', error);
     throw error;
   }
+};
+
+/**
+ * Fallback sync for the post-checkout redirect landing page.
+ *
+ * Chargebee's hosted-page checkout redirects the browser back to
+ * `redirect_url` with `?id=<hostedPageId>&state=<state>` query params.
+ * Per Chargebee's documented pattern, the receiving page should retrieve
+ * that hosted page server-side to get an immediate, synchronous read of the
+ * checkout outcome — the webhook that would otherwise drive the sync is
+ * asynchronous and, in local development, frequently can't reach the
+ * backend at all (Chargebee can't deliver test-site webhooks to
+ * localhost). This applies the exact same sync path a webhook would
+ * (`syncSubscriptionFromWebhook`), so it stays idempotent with — not a
+ * duplicate of — normal webhook-driven sync.
+ *
+ * Verifies the hosted page's customer belongs to the calling organization
+ * before syncing anything, so one org can't force a sync using another
+ * org's (guessable, sequential-looking) hosted page id.
+ */
+export const syncFromHostedPage = async (
+  hostedPageId: string,
+  organizationId: string
+): Promise<{ synced: boolean; state?: string }> => {
+  const result: any = await chargebee.hostedPage.retrieve(hostedPageId);
+  const hostedPage = result.hosted_page;
+  const state = hostedPage?.state;
+
+  if (state !== 'succeeded') {
+    // 'created'/'requested' — payment still in flight, let the caller keep
+    // polling. 'cancelled'/'acknowledged' — nothing new to sync.
+    logger.info('[Chargebee Service] Hosted page not in succeeded state — skipping sync', {
+      hostedPageId,
+      organizationId,
+      state,
+    });
+    return { synced: false, state };
+  }
+
+  const subscriptionData = hostedPage.content?.subscription;
+  if (!subscriptionData) {
+    logger.warn('[Chargebee Service] Hosted page succeeded but has no subscription content', {
+      hostedPageId,
+      organizationId,
+    });
+    return { synced: false, state };
+  }
+
+  const expectedCustomerId = `org_${organizationId}`;
+  if (subscriptionData.customer_id !== expectedCustomerId) {
+    logger.warn(
+      '[Chargebee Service] Hosted page customer does not match requesting organization — refusing to sync',
+      { hostedPageId, organizationId }
+    );
+    return { synced: false, state };
+  }
+
+  await syncSubscriptionFromWebhook(subscriptionData);
+  logger.info('[Chargebee Service] Synced subscription from hosted page', {
+    hostedPageId,
+    organizationId,
+    subscriptionId: subscriptionData.id,
+    subscriptionStatus: subscriptionData.status,
+  });
+  return { synced: true, state };
 };
 
 /**

--- a/apps/form-app/src/graphql/subscription.ts
+++ b/apps/form-app/src/graphql/subscription.ts
@@ -124,6 +124,23 @@ export const INITIALIZE_ORGANIZATION_SUBSCRIPTION: TypedDocumentNode<any, any> =
   }
 `;
 
+// Fallback sync for the /subscription/success redirect — retrieves the
+// Chargebee hosted page (by the id Chargebee appends to redirect_url) and
+// syncs Postgres immediately if checkout succeeded, instead of waiting on
+// webhook delivery.
+export const SYNC_CHECKOUT_SESSION: TypedDocumentNode<any, any> = gql`
+  mutation SyncCheckoutSession($hostedPageId: String!) {
+    syncCheckoutSession(hostedPageId: $hostedPageId) {
+      synced
+      subscription {
+        id
+        planId
+        status
+      }
+    }
+  }
+`;
+
 // Get AI token usage for organization
 export const GET_AI_TOKEN_USAGE : TypedDocumentNode<any, any> = gql`
   query GetAITokenUsage($organizationId: ID!) {

--- a/apps/form-app/src/pages/subscription/success.tsx
+++ b/apps/form-app/src/pages/subscription/success.tsx
@@ -22,7 +22,7 @@ export const CheckoutSuccess = () => {
   // 'poll' counts as loading) and bounce this page between the spinner and
   // the plan card every 3 seconds. We only want `loading` to reflect the
   // initial fetch.
-  const { data, loading, stopPolling } = useQuery(GET_SUBSCRIPTION, {
+  const { data, loading, stopPolling, refetch } = useQuery(GET_SUBSCRIPTION, {
     pollInterval: 3000, // Poll every 3 seconds for Chargebee webhook to sync
     fetchPolicy: 'network-only',
     notifyOnNetworkStatusChange: false,
@@ -38,7 +38,15 @@ export const CheckoutSuccess = () => {
   // the hosted page hasn't finished processing yet, the poll above still
   // catches the eventual webhook-driven sync.
   const hostedPageId = searchParams.get('id');
-  const [syncCheckoutSession] = useMutation(SYNC_CHECKOUT_SESSION);
+  const [syncCheckoutSession] = useMutation(SYNC_CHECKOUT_SESSION, {
+    onCompleted: (result) => {
+      // Refetch right away when the sync landed, instead of leaving the
+      // page waiting up to 3s for the next poll tick.
+      if (result?.syncCheckoutSession?.synced) {
+        refetch();
+      }
+    },
+  });
   const hasSyncedRef = useRef(false);
   useEffect(() => {
     if (!hostedPageId || hasSyncedRef.current) return;

--- a/apps/form-app/src/pages/subscription/success.tsx
+++ b/apps/form-app/src/pages/subscription/success.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
-import { useQuery } from '@apollo/client/react';
+import { useNavigate, useSearchParams } from 'react-router';
+import { useQuery, useMutation } from '@apollo/client/react';
 import { Button, Card } from '@dculus/ui';
 import { CheckCircle2, Sparkles, TrendingUp, ArrowRight, Info } from 'lucide-react';
-import { GET_SUBSCRIPTION } from '../../graphql/subscription';
+import { GET_SUBSCRIPTION, SYNC_CHECKOUT_SESSION } from '../../graphql/subscription';
 import { useTranslation } from '../../hooks/useTranslation';
 
 const POLLING_TIMEOUT_MS = 60000;
@@ -11,17 +11,42 @@ const POLLING_TIMEOUT_MS = 60000;
 export const CheckoutSuccess = () => {
   const { t } = useTranslation('checkoutSuccess');
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [showConfetti, setShowConfetti] = useState(true);
   const [timedOut, setTimedOut] = useState(false);
   const startTimeRef = useRef(Date.now());
 
-  // Fetch subscription to get updated details
+  // Fetch subscription to get updated details. notifyOnNetworkStatusChange
+  // is explicitly false here: Apollo Client 4 defaults it to true, which
+  // would flip `loading` back to true on every poll tick (networkStatus
+  // 'poll' counts as loading) and bounce this page between the spinner and
+  // the plan card every 3 seconds. We only want `loading` to reflect the
+  // initial fetch.
   const { data, loading, stopPolling } = useQuery(GET_SUBSCRIPTION, {
     pollInterval: 3000, // Poll every 3 seconds for Chargebee webhook to sync
     fetchPolicy: 'network-only',
+    notifyOnNetworkStatusChange: false,
   });
 
   const subscription = data?.activeOrganization?.subscription;
+
+  // Chargebee's hosted-page checkout appends ?id=<hostedPageId>&state=...
+  // to this redirect. Chargebee's own docs recommend retrieving that hosted
+  // page immediately on redirect rather than relying solely on the webhook,
+  // which is asynchronous and — in local development — frequently can't
+  // reach the backend at all. This is a best-effort fallback: if it fails or
+  // the hosted page hasn't finished processing yet, the poll above still
+  // catches the eventual webhook-driven sync.
+  const hostedPageId = searchParams.get('id');
+  const [syncCheckoutSession] = useMutation(SYNC_CHECKOUT_SESSION);
+  const hasSyncedRef = useRef(false);
+  useEffect(() => {
+    if (!hostedPageId || hasSyncedRef.current) return;
+    hasSyncedRef.current = true;
+    syncCheckoutSession({ variables: { hostedPageId } }).catch(() => {
+      // Swallow — polling remains the safety net.
+    });
+  }, [hostedPageId, syncCheckoutSession]);
 
   useEffect(() => {
     // Stop confetti after 3 seconds

--- a/infrastructure/multi-cloud/terraform/azure/environments/dev/terraform.tfvars
+++ b/infrastructure/multi-cloud/terraform/azure/environments/dev/terraform.tfvars
@@ -4,6 +4,7 @@ location            = "Central India"
 container_image     = "dculus/forms-backend"
 container_image_tag = "latest"
 better_auth_url     = ""
+frontend_url        = ""
 
 # Root domain for frontend applications (CORS origins will be auto-generated)
 root_domain         = "dculus.com"

--- a/infrastructure/multi-cloud/terraform/azure/environments/production/terraform.tfvars
+++ b/infrastructure/multi-cloud/terraform/azure/environments/production/terraform.tfvars
@@ -4,6 +4,7 @@ location            = "Central India"
 container_image     = "dculus/forms-backend"
 container_image_tag = "latest"
 better_auth_url     = ""
+frontend_url        = ""
 
 # Root domain for frontend applications (CORS origins will be auto-generated)
 root_domain         = "dculus.com"

--- a/infrastructure/multi-cloud/terraform/azure/environments/staging/terraform.tfvars
+++ b/infrastructure/multi-cloud/terraform/azure/environments/staging/terraform.tfvars
@@ -4,6 +4,7 @@ location            = "Central India"
 container_image     = "dculus/forms-backend"
 container_image_tag = "latest"
 better_auth_url     = "https://dculus-forms-staging-backend.kindocean-e9e3f3f1.eastus.azurecontainerapps.io"
+frontend_url        = ""
 
 # Root domain for frontend applications (CORS origins will be auto-generated)
 root_domain         = "dculus.com"

--- a/infrastructure/multi-cloud/terraform/azure/main.tf
+++ b/infrastructure/multi-cloud/terraform/azure/main.tf
@@ -40,6 +40,11 @@ locals {
   form_viewer_domain = var.environment == "production" ? "viewer.${var.root_domain}" : "viewer-app-${var.environment}.${var.root_domain}"
   admin_app_domain   = var.environment == "production" ? "form-admin-app.${var.root_domain}" : "form-admin-app-${var.environment}.${var.root_domain}"
 
+  # FRONTEND_URL for the backend: used as the Chargebee checkout redirect_url/
+  # cancel_url base. Falls back to the environment's form-app domain so dev/
+  # prod each redirect to their own frontend instead of a shared default.
+  resolved_frontend_url = var.frontend_url != "" ? var.frontend_url : "https://${local.form_app_domain}"
+
   # Production domains are now primary (no separate aliases needed)
   production_domains = []
 
@@ -124,6 +129,11 @@ resource "azurerm_container_app" "backend" {
       env {
         name  = "BETTER_AUTH_URL"
         value = local.resolved_auth_url
+      }
+
+      env {
+        name  = "FRONTEND_URL"
+        value = local.resolved_frontend_url
       }
 
       env {

--- a/infrastructure/multi-cloud/terraform/azure/variables.tf
+++ b/infrastructure/multi-cloud/terraform/azure/variables.tf
@@ -104,6 +104,12 @@ variable "better_auth_url" {
   default     = ""
 }
 
+variable "frontend_url" {
+  description = "Frontend (form-app) base URL, used as the Chargebee checkout redirect_url/cancel_url. Empty string derives it from environment + root_domain (see local.form_app_domain)."
+  type        = string
+  default     = ""
+}
+
 variable "public_s3_access_key" {
   description = "Public S3 bucket access key for file storage"
   type        = string


### PR DESCRIPTION
## Problem

After completing a Chargebee payment for an enterprise pay-to-activate plan:

1. Chargebee redirected back to `http://localhost:3000/subscription/success` even in dev/prod — the redirect base URL was never substituted per environment.
2. The `/subscription/success` page flickered ("blinked") continuously between the spinner and the plan card.
3. The new subscription didn't show up in `/settings/billing` after payment.

## Root causes & fixes

### 1. `FRONTEND_URL` was never set on the deployed backend (infra)
The backend code correctly reads `process.env.FRONTEND_URL || 'http://localhost:3000'` for `redirect_url`/`cancel_url`, but the Azure Container App Terraform never declared that env var — so every deployed environment silently fell back to localhost.

**Fix:** new `frontend_url` Terraform variable wired into the container as `FRONTEND_URL`, defaulting to the environment's form-app domain (`form-app-dev.dculus.com` for dev, `forms.dculus.com` for prod).

### 2. Success page flicker — Apollo Client 4 default change
Apollo Client 4 defaults `notifyOnNetworkStatusChange` to `true`, so the 3s `pollInterval` on `GET_SUBSCRIPTION` flipped `loading` back to `true` on every poll tick, bouncing the page between spinner and content.

**Fix:** `notifyOnNetworkStatusChange: false` on that query.

### 3. No fallback sync on the checkout redirect
Nothing retrieved the Chargebee hosted page when the browser landed on `/subscription/success?id=<hostedPageId>&state=succeeded` — the app relied entirely on webhook delivery (delayed in general, unreachable for localhost).

**Fix:** new `syncCheckoutSession` GraphQL mutation backed by `syncFromHostedPage()` (verifies the hosted page's customer belongs to the calling org, then reuses the idempotent `syncSubscriptionFromWebhook` path). The success page fires it once on mount; webhook-driven polling remains the safety net.

### Diagnostics
Added structured logs: resolved redirect base URL (+ whether `FRONTEND_URL` is set) at both hosted-page creation sites, subscription/customer IDs on webhook receipt, and hosted-page sync outcomes.

## Validation
- `pnpm type-check` — all workspaces clean
- `pnpm test:unit` — all tests pass (new tests for `syncFromHostedPage` and `syncCheckoutSession`)
- `terraform validate` — success

## Post-merge
- Dev/prod Terraform apply must run so `FRONTEND_URL` reaches the containers.
- Dev GitHub environment secret `CHARGEBEE_WEBHOOK_PASSWORD` must match the Chargebee **test-site** webhook password (it currently holds the prod value — this is why dev returned 401 on webhook delivery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a hosted-checkout “fallback sync” that runs once after the checkout success redirect to update subscription status immediately when possible.
  - Added a new GraphQL mutation and result fields to support this sync flow.
  - Enabled configurable `FRONTEND_URL` injection across Azure environments.

- **Bug Fixes**
  - Subscription success polling no longer flickers the loading UI during network status changes.
  - Webhook receipt logging now includes richer event and subscription identifiers.

- **Tests**
  - Expanded backend and frontend test coverage for sync success, not-yet-completed, invalid inputs, and cross-organization/authorization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->