### PR TITLE
fix(pdf-templates): grab cursor on selected field drag area

### DIFF
--- a/apps/form-app/src/index.css
+++ b/apps/form-app/src/index.css
@@ -219,6 +219,24 @@ svg.lucide {
   --moveable-line-thickness: 1.5px;
 }
 
+/* pdfme designer: replace the ambiguous 4-arrow "move" cursor on a field's
+   drag target with a Figma/Miro-style grab/grabbing hand. `.selectable` is
+   pdfme's own class for the draggable schema wrapper (@pdfme/ui's Wrapper
+   component, in the installed @pdfme/ui dist bundle) - it and its content
+   descendants set `cursor: pointer` / `cursor: default` inline, so this
+   needs !important to win. Resize handles and the rotation control are
+   separate `.moveable-control` elements portaled to document.body (not
+   descendants of `.selectable`) and keep pdfme's own direction-specific
+   cursors untouched. */
+[data-pdf-designer-canvas] .selectable,
+[data-pdf-designer-canvas] .selectable * {
+  cursor: grab !important;
+}
+[data-pdf-designer-canvas] .selectable:active,
+[data-pdf-designer-canvas] .selectable:active * {
+  cursor: grabbing !important;
+}
+
 /* pdfme ruler guide lines (includes our injected column guides — see
    canvasGuides.ts): hidden while idle, shown while moving/resizing elements
    (data-guides-visible on the canvas wrapper) or when hovering a ruler. */


### PR DESCRIPTION
## Summary
- Replaces pdfme's default pointer/move cursor on a selected PDF template field's interior with a `grab`/`grabbing` hand cursor (Figma/Miro-style), making the drag affordance clearer than the ambiguous 4-arrow icon.
- Resize handles and the rotation control are untouched — they're separate `.moveable-control` elements portaled to `document.body`, not descendants of `.selectable`, so they keep pdfme's own direction-specific cursors.

## Test plan
- [x] Verified live via Playwright against the dev server: hovering a selected field's interior shows `grab`, dragging shows `grabbing` and the field still moves with the mouse
- [x] Confirmed resize handles (8 directions) still show their own resize cursors and still resize correctly
- [x] Confirmed rotation control cursor untouched
- [x] No console errors; stylesheet compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved cursor feedback in the PDF designer canvas.
  * Selectable elements now display a grab cursor and switch to grabbing while being moved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->