### PR TITLE
CI/CD: speed up build.yml and harden multi-cloud-deployment.yml

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,46 @@
+name: Setup pnpm workspace
+description: Checkout, Node.js, pnpm, pnpm store cache, install dependencies, and optionally generate the Prisma client
+
+inputs:
+  node-version:
+    description: Node.js version to install
+    required: true
+  run-prisma-generate:
+    description: Whether to run `pnpm db:generate` after install
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+
+    - name: Get pnpm store directory
+      shell: bash
+      run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+    - name: Setup pnpm store cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    - name: Generate Prisma client
+      if: inputs.run-prisma-generate == 'true'
+      shell: bash
+      run: pnpm db:generate

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,5 +1,5 @@
 name: Setup pnpm workspace
-description: Checkout, Node.js, pnpm, pnpm store cache, install dependencies, and optionally generate the Prisma client
+description: Node.js, pnpm, pnpm store cache, install dependencies, and optionally generate the Prisma client. The calling job must check out the repo before this step — a local composite action can't be resolved until the repo is on disk.
 
 inputs:
   node-version:
@@ -13,9 +13,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -91,6 +94,9 @@ jobs:
     needs: build-shared-packages
     timeout-minutes: 10
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -118,6 +124,9 @@ jobs:
     needs: build-shared-packages
     timeout-minutes: 15
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -161,6 +170,9 @@ jobs:
     needs: build-shared-packages
     timeout-minutes: 15
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -274,6 +286,9 @@ jobs:
     needs: build-shared-packages
     timeout-minutes: 10
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -306,6 +321,9 @@ jobs:
     needs: build-shared-packages
     timeout-minutes: 10
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -335,6 +353,9 @@ jobs:
     needs: build-shared-packages
     timeout-minutes: 10
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -402,6 +423,9 @@ jobs:
       E2E_HEADLESS: "true"
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch full history for comprehensive scanning
+          persist-credentials: false
 
       - name: TruffleHog secret scan
         uses: trufflesecurity/trufflehog@v3.95.5
@@ -67,6 +68,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
         with:
@@ -96,6 +99,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
         with:
@@ -126,6 +131,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
         with:
@@ -172,6 +179,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
         with:
@@ -288,6 +297,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
         with:
@@ -323,6 +334,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
         with:
@@ -355,6 +368,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
         with:
@@ -425,6 +440,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
         with:
@@ -551,6 +568,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -696,6 +715,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Extract version from tag
         id: version
@@ -874,6 +894,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,16 @@ on:
   push:
     branches: [ main, develop, release ]
     tags: [ 'v*' ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'infrastructure/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'infrastructure/**'
   workflow_dispatch:
 
 concurrency:
@@ -19,10 +27,9 @@ permissions:
 
 env:
   NODE_VERSION: '22.14.0'
-  PNPM_VERSION: '8.15.0'
   REGISTRY: docker.io
   IMAGE_NAME: dculus/forms-backend
-  # Backend URL for production builds 
+  # Backend URL for production builds
   BACKEND_URL: https://dculus-forms-backend.reddune-e5ba9473.eastus.azurecontainerapps.io
   # Viewer URL used for linking out of the builder
   FORM_VIEWER_URL: https://dculus-forms-viewer-app.pages.dev
@@ -36,6 +43,7 @@ jobs:
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -55,39 +63,12 @@ jobs:
   build-shared-packages:
     name: Build Shared Packages
     runs-on: ubuntu-latest
-    needs: security-scan
+    timeout-minutes: 10
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Generate Prisma client
-        run: pnpm db:generate
+          run-prisma-generate: 'true'
 
       - name: Build shared packages
         run: |
@@ -95,61 +76,31 @@ jobs:
           pnpm --filter @dculus/utils build
           pnpm --filter @dculus/ui build
 
-      - name: Cache built packages
-        uses: actions/cache@v4
+      - name: Upload built packages
+        uses: actions/upload-artifact@v4
         with:
+          name: packages-dist
           path: |
             packages/types/dist
             packages/utils/dist
             packages/ui/dist
-            node_modules/.pnpm
-          key: built-packages-${{ github.sha }}
+          retention-days: 1
 
   lint-and-type-check:
     runs-on: ubuntu-latest
     needs: build-shared-packages
+    timeout-minutes: 10
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
+          run-prisma-generate: 'true'
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Download built packages
+        uses: actions/download-artifact@v4
         with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Restore built packages cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            packages/types/dist
-            packages/utils/dist
-            packages/ui/dist
-            node_modules/.pnpm
-          key: built-packages-${{ github.sha }}
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Generate Prisma client
-        run: pnpm db:generate
+          name: packages-dist
+          path: packages
 
       - name: Run linting
         run: pnpm lint
@@ -165,41 +116,18 @@ jobs:
     name: Build Backend
     runs-on: ubuntu-latest
     needs: build-shared-packages
+    timeout-minutes: 15
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
+          run-prisma-generate: 'true'
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Download built packages
+        uses: actions/download-artifact@v4
         with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - name: Restore built packages cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            packages/types/dist
-            packages/utils/dist
-            packages/ui/dist
-            node_modules/.pnpm
-          key: built-packages-${{ github.sha }}
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Generate Prisma client
-        run: pnpm db:generate
-
-      - name: Lint backend
-        run: pnpm --filter backend lint
-
-      - name: Type check backend
-        run: pnpm --filter backend type-check
+          name: packages-dist
+          path: packages
 
       - name: Run unit tests with coverage
         env:
@@ -231,35 +159,18 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: build-shared-packages
+    timeout-minutes: 15
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
+          run-prisma-generate: 'true'
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Download built packages
+        uses: actions/download-artifact@v4
         with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - name: Restore built packages cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            packages/types/dist
-            packages/utils/dist
-            packages/ui/dist
-            node_modules/.pnpm
-          key: built-packages-${{ github.sha }}
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Generate Prisma client
-        run: pnpm db:generate
+          name: packages-dist
+          path: packages
 
       - name: Build backend
         run: pnpm --filter backend build
@@ -361,38 +272,17 @@ jobs:
     name: Build Form App
     runs-on: ubuntu-latest
     needs: build-shared-packages
+    timeout-minutes: 10
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Download built packages
+        uses: actions/download-artifact@v4
         with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - name: Restore built packages cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            packages/types/dist
-            packages/utils/dist
-            packages/ui/dist
-            node_modules/.pnpm
-          key: built-packages-${{ github.sha }}
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Lint form-app
-        run: pnpm --filter form-app lint
-
-      - name: Type check form-app
-        run: pnpm --filter form-app type-check
+          name: packages-dist
+          path: packages
 
       - name: Build form-app with environment variables
         env:
@@ -414,38 +304,17 @@ jobs:
     name: Build Form Viewer
     runs-on: ubuntu-latest
     needs: build-shared-packages
+    timeout-minutes: 10
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Download built packages
+        uses: actions/download-artifact@v4
         with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - name: Restore built packages cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            packages/types/dist
-            packages/utils/dist
-            packages/ui/dist
-            node_modules/.pnpm
-          key: built-packages-${{ github.sha }}
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Lint form-viewer
-        run: pnpm --filter form-viewer lint
-
-      - name: Type check form-viewer
-        run: pnpm --filter form-viewer type-check
+          name: packages-dist
+          path: packages
 
       - name: Run unit tests (form-viewer)
         run: pnpm --filter form-viewer test:unit
@@ -464,38 +333,17 @@ jobs:
     name: Build Admin App
     runs-on: ubuntu-latest
     needs: build-shared-packages
+    timeout-minutes: 10
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Download built packages
+        uses: actions/download-artifact@v4
         with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - name: Restore built packages cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            packages/types/dist
-            packages/utils/dist
-            packages/ui/dist
-            node_modules/.pnpm
-          key: built-packages-${{ github.sha }}
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Lint admin-app
-        run: pnpm --filter admin-app lint
-
-      - name: Type check admin-app
-        run: pnpm --filter admin-app type-check
+          name: packages-dist
+          path: packages
 
       - name: Build admin-app with environment variables
         env:
@@ -513,7 +361,8 @@ jobs:
   e2e-local:
     name: E2E Tests (Local Runner)
     runs-on: ubuntu-latest
-    needs: [build-backend, build-form-app, build-form-viewer]
+    needs: [build-shared-packages, build-backend]
+    timeout-minutes: 20
 
     services:
       postgres:
@@ -553,36 +402,25 @@ jobs:
       E2E_HEADLESS: "true"
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
+          run-prisma-generate: 'true'
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Download built packages
+        uses: actions/download-artifact@v4
         with:
-          version: ${{ env.PNPM_VERSION }}
+          name: packages-dist
+          path: packages
 
-      - name: Restore built packages cache
-        uses: actions/cache@v4
+      - name: Download backend dist
+        uses: actions/download-artifact@v4
         with:
-          path: |
-            packages/types/dist
-            packages/utils/dist
-            packages/ui/dist
-            node_modules/.pnpm
-          key: built-packages-${{ github.sha }}
+          name: backend-dist-${{ github.sha }}
+          path: apps/backend/dist
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Generate Prisma client & run migrations
-        run: |
-          pnpm db:generate
-          pnpm db:migrate:deploy
+      - name: Run migrations
+        run: pnpm db:migrate:deploy
 
       - name: Seed templates (no S3 uploads)
         run: |
@@ -617,7 +455,6 @@ jobs:
 
       - name: Start backend
         run: |
-          pnpm --filter backend build
           node apps/backend/dist/apps/backend/src/index.js &
           echo "BACKEND_PID=$!" >> $GITHUB_ENV
         env:
@@ -661,6 +498,12 @@ jobs:
           done
           echo "❌ Frontends failed to start" && exit 1
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
         run: pnpm exec playwright install chromium --with-deps
 
@@ -680,6 +523,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-form-app, build-form-viewer, build-admin-app, build-backend]
     if: startsWith(github.ref, 'refs/tags/v')
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -691,8 +535,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - name: Download form-app dist
         uses: actions/download-artifact@v4
@@ -824,6 +666,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -908,10 +751,10 @@ jobs:
             ```bash
             # Pull using version tag with v prefix
             docker pull dculus/forms-backend:v${{ steps.version.outputs.version }}
-            
+
             # Or pull latest
             docker pull dculus/forms-backend:latest
-            
+
             # Run with environment file
             docker run -d -p 4000:4000 --env-file .env dculus/forms-backend:v${{ steps.version.outputs.version }}
             ```
@@ -921,7 +764,7 @@ jobs:
             - `dculus/forms-backend:v{{ steps.version.outputs.major }}.{{ steps.version.outputs.minor }}` (e.g., v1.2)
             - `dculus/forms-backend:v{{ steps.version.outputs.major }}` (e.g., v1)
             - `dculus/forms-backend:latest` (always points to the most recent stable release)
-            
+
             **Option 2: Node.js Direct**
             ```bash
             unzip backend-build-v${{ steps.version.outputs.version }}.zip
@@ -1002,6 +845,7 @@ jobs:
       contents: read
       packages: write
       pull-requests: write
+    timeout-minutes: 20
 
     steps:
       - name: Checkout repository
@@ -1108,6 +952,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [security-scan, build-shared-packages, lint-and-type-check, build-backend, integration-tests, build-and-push, e2e-local]
     if: always()
+    timeout-minutes: 5
     steps:
       - name: Generate build summary
         run: |
@@ -1123,7 +968,7 @@ jobs:
           echo "| E2E Tests (Local) | ${{ needs.e2e-local.result == 'success' && '✅' || needs.e2e-local.result == 'skipped' && '⏭️' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Docker Build & Push | ${{ needs.build-and-push.result == 'success' && '✅' || needs.build-and-push.result == 'skipped' && '⏭️ Skipped (tags only)' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          
+
           if [[ "${{ needs.build-and-push.result }}" == "success" ]]; then
             echo "### 🐳 Docker Image Built" >> $GITHUB_STEP_SUMMARY
             echo "✅ Backend Docker image built and pushed to Docker Hub" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/multi-cloud-deployment.yml
+++ b/.github/workflows/multi-cloud-deployment.yml
@@ -34,22 +34,22 @@ on:
       - "infrastructure/multi-cloud/terraform/**"
       - ".github/workflows/multi-cloud-deployment.yml"
   # NOTE: `workflow_run` only supports `branches`/`branches-ignore` filters — there is
-  # no `tags:` key for this event type, so a tag push never reaches this trigger directly.
-  # dev vs production is decided entirely in the `determine-environment` job below, by
-  # regex-matching `github.event.workflow_run.head_branch` against `^v[0-9]+\.[0-9]+`
-  # (true when Build Pipeline itself ran on a tag push, since `head_branch` then carries
-  # the tag name).
+  # no `tags:` key for this event type. A `branches: [main]` filter here would also be
+  # wrong: for a Build Pipeline run triggered by a version-tag push, GitHub reports
+  # `head_branch` as the TAG NAME (e.g. "v1.2.3"), not "main" — verified against this
+  # repo's actual run history, where every workflow_run-triggered deployment run has
+  # head_branch=main and tag-triggered runs never reach this trigger at all. So no
+  # branch filter is applied here; dev vs production is decided entirely in the
+  # `determine-environment` job below, by regex-matching `head_branch` against
+  # `^v[0-9]+\.[0-9]+` for production, "main" for dev, anything else is skipped.
   workflow_run:
     workflows: [ "Build Pipeline" ]
     types:
       - completed
-    branches:
-      - main
 
 permissions:
-  id-token: write # Required for OIDC authentication with Azure
   contents: read # Required for checking out code
-  pull-requests: write # Required for commenting on PRs
+  # id-token: write (Azure OIDC) is granted per-job, only on jobs that call azure/login
 
 # Prevent overlapping Terraform applies against the same environment's state.
 # Grouped by trigger-time context only (job outputs like `determine-environment`
@@ -213,6 +213,9 @@ jobs:
     name: 1.2. Setup Azure Terraform Backend
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      id-token: write # Required for OIDC authentication with Azure
+      contents: read
     needs: determine-environment
     if: needs.determine-environment.outputs.should_deploy == 'true'
     environment: ${{ needs.determine-environment.outputs.environment }}
@@ -449,6 +452,9 @@ jobs:
     name: 4.1. Deploy Core Infrastructure (R2 Storage + Azure Container Apps)
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      id-token: write # Required for OIDC authentication with Azure
+      contents: read
     needs:
       [
         determine-environment,
@@ -675,6 +681,9 @@ jobs:
     name: 5.1. Configure Backend Service Domain DNS
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      id-token: write # Required for OIDC authentication with Azure
+      contents: read
     needs:
       [
         determine-environment,
@@ -769,6 +778,9 @@ jobs:
     name: 5.2. Setup Pages Infrastructure & Domain (form-app)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      id-token: write # Required for OIDC authentication with Azure
+      contents: read
     needs:
       [
         determine-environment,
@@ -1051,6 +1063,9 @@ jobs:
     name: 5.3. Setup Pages Infrastructure & Domain (admin-app)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      id-token: write # Required for OIDC authentication with Azure
+      contents: read
     needs:
       [
         determine-environment,
@@ -1324,6 +1339,9 @@ jobs:
     name: 5.4. Setup Pages Infrastructure & Domain (form-viewer)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      id-token: write # Required for OIDC authentication with Azure
+      contents: read
     needs:
       [
         determine-environment,
@@ -1703,6 +1721,9 @@ jobs:
     name: 7.1. Configure Backend SSL Certificate
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      id-token: write # Required for OIDC authentication with Azure
+      contents: read
     needs:
       [
         determine-environment,

--- a/.github/workflows/multi-cloud-deployment.yml
+++ b/.github/workflows/multi-cloud-deployment.yml
@@ -33,19 +33,30 @@ on:
     paths:
       - "infrastructure/multi-cloud/terraform/**"
       - ".github/workflows/multi-cloud-deployment.yml"
+  # NOTE: `workflow_run` only supports `branches`/`branches-ignore` filters — there is
+  # no `tags:` key for this event type, so a tag push never reaches this trigger directly.
+  # dev vs production is decided entirely in the `determine-environment` job below, by
+  # regex-matching `github.event.workflow_run.head_branch` against `^v[0-9]+\.[0-9]+`
+  # (true when Build Pipeline itself ran on a tag push, since `head_branch` then carries
+  # the tag name).
   workflow_run:
     workflows: [ "Build Pipeline" ]
     types:
       - completed
     branches:
       - main
-    tags:
-      - 'v*'
 
 permissions:
   id-token: write # Required for OIDC authentication with Azure
   contents: read # Required for checking out code
   pull-requests: write # Required for commenting on PRs
+
+# Prevent overlapping Terraform applies against the same environment's state.
+# Grouped by trigger-time context only (job outputs like `determine-environment`
+# aren't available at this scope).
+concurrency:
+  group: multi-cloud-deploy-${{ github.event.workflow_run.head_branch || github.event.inputs.environment || github.ref_name }}
+  cancel-in-progress: false
 
 env:
   TERRAFORM_VERSION: "1.9.8"
@@ -64,6 +75,7 @@ jobs:
   determine-environment:
     name: 1.1. Determine Deployment Environment
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       environment: ${{ steps.set-env.outputs.environment }}
       should_deploy: ${{ steps.set-env.outputs.should_deploy }}
@@ -72,7 +84,19 @@ jobs:
       release_tag: ${{ steps.set-env.outputs.release_tag }}
       release_commit: ${{ steps.resolve-release.outputs.release_commit ||
         steps.set-env.outputs.release_commit }}
+      is_same_repo: ${{ steps.repo-check.outputs.is_same_repo }}
     steps:
+      - name: Check repo trust (fork PR guard)
+        id: repo-check
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "is_same_repo=false" >> $GITHUB_OUTPUT
+            echo "⚠️ PR from a fork (${{ github.event.pull_request.head.repo.full_name }}) — cloud credential steps will be skipped."
+          else
+            echo "is_same_repo=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Determine environment
         id: set-env
         run: |
@@ -188,6 +212,7 @@ jobs:
   setup-azure-backend:
     name: 1.2. Setup Azure Terraform Backend
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: determine-environment
     if: needs.determine-environment.outputs.should_deploy == 'true'
     environment: ${{ needs.determine-environment.outputs.environment }}
@@ -335,6 +360,7 @@ jobs:
   check-docker-image:
     name: 2.1. Validate Docker Image Availability
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [ determine-environment, setup-azure-backend ]
     if: needs.determine-environment.outputs.deploy_azure == 'true'
     outputs:
@@ -374,6 +400,7 @@ jobs:
   run-migrations:
     name: 4.0. Run Database Migrations
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [ determine-environment, setup-azure-backend ]
     if: |
       always() && !cancelled() && !failure() &&
@@ -421,6 +448,7 @@ jobs:
   terraform-infrastructure-deploy:
     name: 4.1. Deploy Core Infrastructure (R2 Storage + Azure Container Apps)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs:
       [
         determine-environment,
@@ -430,6 +458,7 @@ jobs:
       ]
     if: |
       always() && !cancelled() && !failure() &&
+      needs.determine-environment.outputs.is_same_repo == 'true' &&
       (needs.determine-environment.outputs.deploy_cloudflare == 'true' ||
        needs.determine-environment.outputs.deploy_azure == 'true')
     environment: ${{ needs.determine-environment.outputs.environment }}
@@ -645,6 +674,7 @@ jobs:
   terraform-cloudflare-service-domain:
     name: 5.1. Configure Backend Service Domain DNS
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       [
         determine-environment,
@@ -738,6 +768,7 @@ jobs:
   terraform-cloudflare-pages:
     name: 5.2. Setup Pages Infrastructure & Domain (form-app)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       [
         determine-environment,
@@ -834,6 +865,7 @@ jobs:
   deploy-cloudflare-pages-form-app:
     name: 6.1. Build & Deploy Frontend (form-app)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - determine-environment
       - terraform-infrastructure-deploy
@@ -949,13 +981,16 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          CUSTOM_DOMAIN: ${{ needs.terraform-cloudflare-pages.outputs.custom_domain }}
         run: |
-          echo "🔄 Purging Cloudflare cache for immediate visibility..."
+          echo "🔄 Purging Cloudflare cache for $CUSTOM_DOMAIN..."
 
+          # Vite emits content-hashed assets, so only the entry document needs purging —
+          # purge_everything wiped the whole zone (incl. the R2 public CDN and other apps).
           PURGE_RESPONSE=$(curl -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
             -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
             -H "Content-Type: application/json" \
-            --data '{"purge_everything":true}' \
+            --data "{\"files\":[\"https://${CUSTOM_DOMAIN}/\",\"https://${CUSTOM_DOMAIN}/index.html\"]}" \
             --silent \
             --show-error)
 
@@ -972,12 +1007,8 @@ jobs:
           CUSTOM_DOMAIN="${{ needs.terraform-cloudflare-pages.outputs.custom_domain }}"
           echo "🔍 Checking deployment at: $CUSTOM_DOMAIN"
 
-          # Wait for DNS propagation and deployment
-          echo "⏳ Waiting 60 seconds for DNS propagation..."
-          sleep 60
-
-          # Retry health check up to 5 times
-          MAX_RETRIES=5
+          # Poll immediately instead of a fixed upfront wait — exits as soon as ready.
+          MAX_RETRIES=15
           RETRY_COUNT=0
 
           while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
@@ -992,8 +1023,8 @@ jobs:
               echo "⚠️ Health check attempt $RETRY_COUNT/$MAX_RETRIES failed (HTTP $HTTP_CODE)"
 
               if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-                echo "⏳ Waiting 30 seconds before retry..."
-                sleep 30
+                echo "⏳ Waiting 10 seconds before retry..."
+                sleep 10
               fi
             fi
           done
@@ -1019,6 +1050,7 @@ jobs:
   terraform-cloudflare-pages-admin:
     name: 5.3. Setup Pages Infrastructure & Domain (admin-app)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       [
         determine-environment,
@@ -1111,6 +1143,7 @@ jobs:
   deploy-cloudflare-pages-admin-app:
     name: 6.2. Build & Deploy Frontend (admin-app)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - determine-environment
       - terraform-infrastructure-deploy
@@ -1221,13 +1254,16 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          CUSTOM_DOMAIN: ${{ needs.terraform-cloudflare-pages-admin.outputs.custom_domain }}
         run: |
-          echo "🔄 Purging Cloudflare cache for immediate visibility..."
+          echo "🔄 Purging Cloudflare cache for $CUSTOM_DOMAIN..."
 
+          # Vite emits content-hashed assets, so only the entry document needs purging —
+          # purge_everything wiped the whole zone (incl. the R2 public CDN and other apps).
           PURGE_RESPONSE=$(curl -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
             -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
             -H "Content-Type: application/json" \
-            --data '{"purge_everything":true}' \
+            --data "{\"files\":[\"https://${CUSTOM_DOMAIN}/\",\"https://${CUSTOM_DOMAIN}/index.html\"]}" \
             --silent \
             --show-error)
 
@@ -1244,12 +1280,8 @@ jobs:
           CUSTOM_DOMAIN="${{ needs.terraform-cloudflare-pages-admin.outputs.custom_domain }}"
           echo "🔍 Checking deployment at: $CUSTOM_DOMAIN"
 
-          # Wait for DNS propagation and deployment
-          echo "⏳ Waiting 60 seconds for DNS propagation..."
-          sleep 60
-
-          # Retry health check up to 5 times
-          MAX_RETRIES=5
+          # Poll immediately instead of a fixed upfront wait — exits as soon as ready.
+          MAX_RETRIES=15
           RETRY_COUNT=0
 
           while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
@@ -1264,8 +1296,8 @@ jobs:
               echo "⚠️ Health check attempt $RETRY_COUNT/$MAX_RETRIES failed (HTTP $HTTP_CODE)"
 
               if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-                echo "⏳ Waiting 30 seconds before retry..."
-                sleep 30
+                echo "⏳ Waiting 10 seconds before retry..."
+                sleep 10
               fi
             fi
           done
@@ -1291,6 +1323,7 @@ jobs:
   terraform-cloudflare-pages-viewer:
     name: 5.4. Setup Pages Infrastructure & Domain (form-viewer)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       [
         determine-environment,
@@ -1383,6 +1416,7 @@ jobs:
   deploy-cloudflare-pages-viewer-app:
     name: 6.3. Build & Deploy Frontend (form-viewer)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - determine-environment
       - terraform-infrastructure-deploy
@@ -1493,13 +1527,16 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          CUSTOM_DOMAIN: ${{ needs.terraform-cloudflare-pages-viewer.outputs.custom_domain }}
         run: |
-          echo "🔄 Purging Cloudflare cache for immediate visibility..."
+          echo "🔄 Purging Cloudflare cache for $CUSTOM_DOMAIN..."
 
+          # Vite emits content-hashed assets, so only the entry document needs purging —
+          # purge_everything wiped the whole zone (incl. the R2 public CDN and other apps).
           PURGE_RESPONSE=$(curl -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
             -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
             -H "Content-Type: application/json" \
-            --data '{"purge_everything":true}' \
+            --data "{\"files\":[\"https://${CUSTOM_DOMAIN}/\",\"https://${CUSTOM_DOMAIN}/index.html\"]}" \
             --silent \
             --show-error)
 
@@ -1516,12 +1553,8 @@ jobs:
           CUSTOM_DOMAIN="${{ needs.terraform-cloudflare-pages-viewer.outputs.custom_domain }}"
           echo "🔍 Checking deployment at: $CUSTOM_DOMAIN"
 
-          # Wait for DNS propagation and deployment
-          echo "⏳ Waiting 60 seconds for DNS propagation..."
-          sleep 60
-
-          # Retry health check up to 5 times
-          MAX_RETRIES=5
+          # Poll immediately instead of a fixed upfront wait — exits as soon as ready.
+          MAX_RETRIES=15
           RETRY_COUNT=0
 
           while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
@@ -1536,8 +1569,8 @@ jobs:
               echo "⚠️ Health check attempt $RETRY_COUNT/$MAX_RETRIES failed (HTTP $HTTP_CODE)"
 
               if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-                echo "⏳ Waiting 30 seconds before retry..."
-                sleep 30
+                echo "⏳ Waiting 10 seconds before retry..."
+                sleep 10
               fi
             fi
           done
@@ -1563,6 +1596,7 @@ jobs:
   run-form-app-e2e:
     name: 7.2. Run form-app E2E (Cloudflare Pages)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: ${{ needs.determine-environment.outputs.environment }}
     needs:
       - determine-environment
@@ -1668,6 +1702,7 @@ jobs:
   configure-azure-custom-domain:
     name: 7.1. Configure Backend SSL Certificate
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs:
       [
         determine-environment,
@@ -1749,23 +1784,21 @@ jobs:
   health-checks:
     name: 8.1. Run Health Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [ determine-environment, terraform-infrastructure-deploy ]
     if: |
       always() && !cancelled() &&
       needs.determine-environment.outputs.should_deploy == 'true' &&
       needs.terraform-infrastructure-deploy.result == 'success'
     steps:
-      - name: Wait for backend to be ready
-        run: |
-          echo "⏳ Waiting 30 seconds for backend to stabilize..."
-          sleep 30
-
       - name: Check backend health endpoint
         run: |
           HEALTH_URL="${{ needs.terraform-infrastructure-deploy.outputs.health_endpoint }}"
           echo "🏥 Checking health endpoint: $HEALTH_URL"
 
-          MAX_RETRIES=5
+          # Poll immediately instead of a fixed upfront "stabilize" sleep — exits as
+          # soon as ready; same worst-case budget as before (5x15s retries).
+          MAX_RETRIES=10
           RETRY_COUNT=0
 
           while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
@@ -1808,6 +1841,7 @@ jobs:
   deployment-summary:
     name: 9.1. Generate Deployment Summary
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs:
       [
         determine-environment,
@@ -1902,6 +1936,15 @@ jobs:
             echo "- **Pages URL**: [${{ needs.terraform-cloudflare-pages-viewer.outputs.pages_url }}](${{ needs.terraform-cloudflare-pages-viewer.outputs.pages_url }})" >> $GITHUB_STEP_SUMMARY
             echo "- **Backend**: \`https://${{ needs.terraform-cloudflare-service-domain.outputs.service_domain }}\`" >> $GITHUB_STEP_SUMMARY
             echo "- **Status**: ✅ Deployed and health check passed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          # Post-deploy E2E is continue-on-error (doesn't block dev availability on flaky
+          # E2E), so surface a failure here instead of letting it pass silently.
+          if [ "${{ needs.run-form-app-e2e.result }}" != "success" ] && [ "${{ needs.run-form-app-e2e.result }}" != "skipped" ]; then
+            echo "## ⚠️ Post-deploy E2E failed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "The form-app E2E suite against the live deployment did not pass (result: \`${{ needs.run-form-app-e2e.result }}\`). Deployment was not blocked, but this needs a look — check the \`run-form-app-e2e\` job logs." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
           fi
 


### PR DESCRIPTION
## Summary

Two independent GitHub Actions improvements, both scoped to be low-risk:

**`build.yml`** (closes #99) — eliminates duplicated installs/builds and fixes cache anti-patterns that made the pipeline ~9 min/push:
- New `.github/actions/setup` composite action replaces ~25 lines of repeated checkout/node/pnpm/cache/install boilerplate across 8 jobs
- SHA-keyed `actions/cache` (never hit cross-run, also cached `node_modules/.pnpm`) replaced with real `upload-artifact`/`download-artifact` for `packages/*/dist`
- Per-app lint/type-check removed from 4 build jobs — the workspace-wide `lint-and-type-check` job is now the single source of truth
- `e2e-local` downloads the `backend-dist` artifact instead of rebuilding it. Form-app/form-viewer still build from source in that job — their build-job artifacts bake in production `VITE_*` URLs via Vite, which would silently break E2E if reused
- Playwright browsers now cached; `security-scan` no longer serially blocks `build-shared-packages`; `paths-ignore` added for docs/infra-only changes; `timeout-minutes` on all jobs; dropped the redundant `PNPM_VERSION` env var (now autodetected from `packageManager`)

**`multi-cloud-deployment.yml`** (partial #101 — safe subset only) — every main push runs a ~45 min full Terraform deploy across 6 state backends; the full infra/app-delivery split is the biggest time win but needs a redesign of how downstream jobs get Terraform outputs when a job is skipped, so it's deliberately **not** attempted here. This PR lands only the zero-Terraform-state-risk items:
- `concurrency` group to stop overlapping deploys racing the same Terraform state
- Targeted Cloudflare cache purges instead of `purge_everything` (previously nuked the R2 CDN and every other app's cache on each deploy)
- Immediate poll loops instead of fixed sleep-then-retry health checks (same worst-case budget, near-zero best case)
- Removed the dead `tags:` filter under `workflow_run` (not a supported key for that event — was a silent no-op) with a comment documenting the real branch/tag promotion logic
- Fork PRs now get a clear skip instead of a confusing Azure OIDC failure
- Post-deploy E2E failures surfaced in the deployment summary (still non-blocking per job design — separately, `main` already gained a hard-fail change for this job in a concurrent commit, which this PR preserves)
- `timeout-minutes` on all 16 jobs

Not touched: Terraform file layout/modules, state addressing, the image-update mechanism, and the imperative `setup-azure-backend` bootstrap.

## Test plan

- [x] Both workflow files pass `python3 -c "import yaml; yaml.safe_load(...)"` 
- [x] `actionlint` on both files shows zero new findings vs the pre-change baseline (diffed to confirm — only 2 pre-existing, unrelated findings remain in `build.yml`)
- [x] Local pre-push hook (lint + build all apps + backend unit tests) passes
- [ ] Push a trivial branch and confirm `build.yml` produces/consumes the `packages-dist` artifact, each app lints/type-checks exactly once, `e2e-local` downloads backend dist instead of rebuilding, and a docs-only PR doesn't trigger the pipeline
- [ ] Trigger `multi-cloud-deployment.yml` via `workflow_dispatch` on a non-prod path first to confirm the concurrency group, targeted purge, and poll-loop health checks behave correctly before relying on them for a real dev deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI/CD Improvements**
  * Added a reusable setup action to standardize Node/pnpm setup, dependency installation, pnpm caching, and optional Prisma client generation.
  * Updated workflow triggers/permissions and removed unnecessary pipeline redundancy by sharing prebuilt artifacts across build/test/e2e jobs.
  * Added timeouts across long-running jobs and streamlined E2E-local steps (including deploy/migration ordering).
  * Improved multi-cloud deployment reliability with safer concurrency controls, corrected trigger behavior, and more efficient health-check polling.
  * Narrowed Cloudflare Pages cache purging to targeted paths and improved deployment summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->