### PR TITLE
Conditional logic: server-side strip of hidden values on submit/update

### DIFF
--- a/apps/backend/src/graphql/resolvers/responses.ts
+++ b/apps/backend/src/graphql/resolvers/responses.ts
@@ -22,6 +22,8 @@ import {
   substituteMentions,
 } from '@dculus/utils';
 import { deserializeFormSchema } from '@dculus/types';
+import { stripConditionallyHiddenValues } from '../../lib/conditionalStrip.js';
+import { getFormSchemaFromHocuspocus } from '../../services/hocuspocus.js';
 import { analyticsService } from '../../services/analyticsService.js';
 import { emitFormSubmitted } from '../../plugins/core/events.js';
 import { checkUsageExceeded } from '../../subscriptions/usageService.js';
@@ -208,6 +210,22 @@ export const responsesResolvers = {
           if (typeof value === 'string' && value.length > 10_000) {
             throw createGraphQLError(`Field "${key}" exceeds the 10,000 character limit`, GRAPHQL_ERROR_CODES.BAD_USER_INPUT);
           }
+        }
+      }
+
+      // Server-side conditional-logic enforcement (defense in depth): strip
+      // values of fields/pages the form's rules hide, evaluated against the
+      // same live schema the viewer was served (Hocuspocus, falling back to
+      // the DB column). The client strips too, but this mutation is public
+      // and callable directly. Runs before BOTH insert paths below.
+      if (input.data && typeof input.data === 'object') {
+        const liveSchema =
+          (await getFormSchemaFromHocuspocus(form.id)) ?? form.formSchema;
+        if (liveSchema) {
+          input.data = stripConditionallyHiddenValues(
+            liveSchema,
+            input.data as Record<string, unknown>
+          );
         }
       }
 
@@ -449,6 +467,20 @@ export const responsesResolvers = {
       const accessCheck = await checkFormAccess(context.auth.user!.id, existingResponse.formId, PermissionLevel.EDITOR);
       if (!accessCheck.hasAccess) {
         throw createGraphQLError('Access denied: You need EDITOR access to update responses for this form', GRAPHQL_ERROR_CODES.NO_ACCESS);
+      }
+
+      // Same conditional-logic enforcement as submitResponse — edits flow
+      // through the identical strip gate, so values cleared by rules are
+      // recorded as DELETE field changes by the edit tracker below
+      if (input.data && typeof input.data === 'object') {
+        const liveSchema =
+          (await getFormSchemaFromHocuspocus(form.id)) ?? form.formSchema;
+        if (liveSchema) {
+          input.data = stripConditionallyHiddenValues(
+            liveSchema,
+            input.data as Record<string, unknown>
+          ) as Record<string, any>;
+        }
       }
 
       // 3. Prepare edit tracking context

--- a/apps/backend/src/lib/__tests__/conditionalStrip.test.ts
+++ b/apps/backend/src/lib/__tests__/conditionalStrip.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { stripConditionallyHiddenValues } from '../conditionalStrip.js';
+
+const baseSchema = (conditions?: unknown[]) => ({
+  layout: {},
+  isShuffleEnabled: false,
+  pages: [
+    {
+      id: 'p1',
+      title: 'Page 1',
+      order: 0,
+      fields: [
+        {
+          id: 'trigger',
+          type: 'radio_field',
+          label: 'Trigger',
+          options: ['Yes', 'No'],
+          validation: { required: false, type: 'fillable_form_field' },
+        },
+        {
+          id: 'bonus',
+          type: 'text_input_field',
+          label: 'Bonus',
+          validation: { required: false, type: 'text_field_validation' },
+        },
+      ],
+    },
+    {
+      id: 'p2',
+      title: 'Details',
+      order: 1,
+      fields: [
+        {
+          id: 'details',
+          type: 'text_input_field',
+          label: 'Details',
+          validation: { required: false, type: 'text_field_validation' },
+        },
+      ],
+    },
+  ],
+  ...(conditions ? { conditions } : {}),
+});
+
+const showBonusRule = {
+  id: 'r-show-bonus',
+  enabled: true,
+  combinator: 'all',
+  terms: [{ fieldId: 'trigger', operator: 'equals', value: 'Yes' }],
+  actions: [{ type: 'showField', fieldIds: ['bonus'] }],
+};
+
+const hideDetailsRule = {
+  id: 'r-hide-details',
+  enabled: true,
+  combinator: 'all',
+  terms: [{ fieldId: 'trigger', operator: 'equals', value: 'No' }],
+  actions: [{ type: 'hidePage', pageId: 'p2' }],
+};
+
+describe('stripConditionallyHiddenValues', () => {
+  it('returns the payload unchanged when the schema has no conditions', () => {
+    const data = { trigger: 'Yes', bonus: 'kept', details: 'kept' };
+    expect(stripConditionallyHiddenValues(baseSchema(), data)).toBe(data);
+  });
+
+  it('strips a default-hidden showField target when its rule does not match', () => {
+    const result = stripConditionallyHiddenValues(baseSchema([showBonusRule]), {
+      trigger: 'No',
+      bonus: 'injected despite being hidden',
+      details: 'kept',
+    });
+    expect(result).toEqual({ trigger: 'No', details: 'kept' });
+  });
+
+  it('keeps the showField target when its rule matches', () => {
+    const result = stripConditionallyHiddenValues(baseSchema([showBonusRule]), {
+      trigger: 'Yes',
+      bonus: 'legitimately visible',
+      details: 'kept',
+    });
+    expect(result).toEqual({
+      trigger: 'Yes',
+      bonus: 'legitimately visible',
+      details: 'kept',
+    });
+  });
+
+  it('strips every field on a conditionally hidden page', () => {
+    const result = stripConditionallyHiddenValues(baseSchema([hideDetailsRule]), {
+      trigger: 'No',
+      details: 'crafted request value for a hidden page',
+    });
+    expect(result).toEqual({ trigger: 'No' });
+  });
+
+  it('passes keys that belong to no schema field through untouched', () => {
+    const result = stripConditionallyHiddenValues(baseSchema([hideDetailsRule]), {
+      trigger: 'No',
+      details: 'stripped',
+      'not-a-schema-field': 'untouched',
+    });
+    expect(result).toEqual({ trigger: 'No', 'not-a-schema-field': 'untouched' });
+  });
+
+  it('never throws on malformed schemas or payloads', () => {
+    const data = { a: 1 };
+    expect(stripConditionallyHiddenValues(null, data)).toBe(data);
+    expect(stripConditionallyHiddenValues('junk', data)).toBe(data);
+    expect(
+      stripConditionallyHiddenValues({ pages: 'junk', conditions: [showBonusRule] }, data)
+    ).toEqual(data);
+    expect(
+      stripConditionallyHiddenValues(baseSchema([null, showBonusRule]), {
+        trigger: 'No',
+        bonus: 'hidden',
+      })
+    ).toEqual({ trigger: 'No' });
+  });
+});

--- a/apps/backend/src/lib/conditionalStrip.ts
+++ b/apps/backend/src/lib/conditionalStrip.ts
@@ -1,0 +1,73 @@
+/**
+ * Server-side conditional-logic enforcement (defense in depth).
+ *
+ * The viewer strips hidden-field values at submit, but submitResponse /
+ * updateResponse are public GraphQL mutations — a crafted request can bypass
+ * the client gate entirely. This applies the same pure evaluator against the
+ * form's schema so persisted responses can never contain values for fields
+ * (or pages) the form's rules hide. See docs/conditional-logic-research.md §5.2
+ * and the locked client-side semantics in docs/conditional-logic-v1-strategy.md §5.
+ */
+
+import {
+  deserializeFormSchema,
+  evaluateConditions,
+  stripHiddenResponses,
+  type FormResponsesByPage,
+} from '@dculus/types';
+
+/**
+ * Strips values of conditionally hidden fields/pages from a flat
+ * fieldId→value response payload, evaluated against the given form schema
+ * (raw JSON as stored in the DB or reconstructed from Hocuspocus).
+ *
+ * - Schemas without conditions return the payload unchanged (fast path).
+ * - Keys that don't belong to any schema field pass through untouched —
+ *   they are not schema-managed, so conditional rules can't apply to them.
+ * - Malformed schemas never throw; the payload is returned as-is.
+ */
+export const stripConditionallyHiddenValues = (
+  rawSchema: unknown,
+  flatData: Record<string, unknown>
+): Record<string, unknown> => {
+  if (!flatData || typeof flatData !== 'object') return flatData;
+  if (!rawSchema || typeof rawSchema !== 'object') return flatData;
+
+  try {
+    // deserializeFormSchema sanitizes conditions at this trust boundary
+    const schema = deserializeFormSchema(rawSchema);
+    if (!schema.conditions || schema.conditions.length === 0) return flatData;
+
+    const fieldToPage = new Map<string, string>();
+    for (const page of schema.pages ?? []) {
+      for (const field of page.fields ?? []) {
+        fieldToPage.set(field.id, page.id);
+      }
+    }
+
+    // Rebuild the page-keyed shape the evaluator works on
+    const byPage: FormResponsesByPage = {};
+    const passthrough: Record<string, unknown> = {};
+    for (const [fieldId, value] of Object.entries(flatData)) {
+      const pageId = fieldToPage.get(fieldId);
+      if (!pageId) {
+        passthrough[fieldId] = value;
+        continue;
+      }
+      (byPage[pageId] ??= {})[fieldId] = value;
+    }
+
+    const visibility = evaluateConditions(schema.conditions, byPage, schema);
+    const stripped = stripHiddenResponses(byPage, visibility);
+
+    const result: Record<string, unknown> = { ...passthrough };
+    for (const pageResponses of Object.values(stripped)) {
+      Object.assign(result, pageResponses);
+    }
+    return result;
+  } catch {
+    // Enforcement must never take submission down — worst case we fall back
+    // to the client-side strip, which is v1's shipped behavior
+    return flatData;
+  }
+};


### PR DESCRIPTION
Part of Epic #130 (§7 — server-side strip, research doc §5.2).

## Why

v1 (PR #129) strips conditionally hidden values client-side only (locked decision §9.10). `submitResponse` is a public mutation and `updateResponse` is callable by any editor — a crafted request could persist values for fields/pages the form's rules hide.

## What

- **`stripConditionallyHiddenValues`** (`apps/backend/src/lib/conditionalStrip.ts`): pure, total helper reusing the shared `evaluateConditions` + `stripHiddenResponses` from `@dculus/types`. Fast-paths schemas without conditions, passes non-schema keys through untouched, never throws (worst case falls back to shipped client-side behavior).
- **`submitResponse`**: strips before *both* insert paths (the `maxResponses` serializable transaction and the normal path), evaluated against the same live schema the viewer was served (`getFormSchemaFromHocuspocus ?? form.formSchema`). Plugins, quiz grading, thank-you, response copy, and exports all see enforced data.
- **`updateResponse`**: same gate before edit tracking, so rule-cleared values are recorded as `DELETE` field changes in edit history.

## Validation

- 6 new unit tests for the helper (default-hidden target, matched-rule keep, hidden-page strip, non-schema passthrough, malformed-schema tolerance, no-conditions fast path)
- Full backend suite: 94 files / 2601 tests green; `pnpm type-check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conditionally hidden field and page values are now removed before responses are submitted or updated.
  * Hidden values are consistently reflected in response edit history.
  * Response processing remains safe when schemas or submitted data are malformed.
  * Unrelated fields continue to be preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->