### PR TITLE
E2E: conditional-logic submit-strip data integrity (hidden files, server bypass, EDIT tracking, response copy)

### DIFF
--- a/test/e2e/features/conditional-logic-data-integrity.feature
+++ b/test/e2e/features/conditional-logic-data-integrity.feature
@@ -1,0 +1,112 @@
+Feature: Conditional logic submit-strip data integrity
+
+  # The strip is enforced twice — client (PageRenderer.handleFormComplete) and
+  # server (apps/backend/src/lib/conditionalStrip.ts). These scenarios cover
+  # the surfaces where stripped data matters beyond the response row itself:
+  # file uploads, direct-GraphQL bypass, edit tracking, and response copy.
+
+  # A FileUpload field hidden at submit time must not only be stripped from
+  # the stored response — its File objects must never reach the /upload REST
+  # endpoint at all (uploads happen after the client-side strip gate).
+  Scenario: Hidden file upload field is stripped and never hits the upload endpoint
+    Given I sign in with valid credentials
+    When I create a form via GraphQL with a conditionally hidden file upload field
+    And I publish the form
+    Then the form should be published
+    When I get the form short URL
+    And I navigate to the form viewer with the short URL
+    And I start recording viewer upload requests
+    Then the viewer field "Attachment" should be hidden
+    When I choose viewer radio option "Yes" for "Attach a file?"
+    Then the viewer field "Attachment" should be visible
+    When I attach a text file to the "strip-file" upload field in the viewer
+    And I choose viewer radio option "No" for "Attach a file?"
+    Then the viewer field "Attachment" should be hidden
+    When I submit the conditional logic form in the viewer
+    Then no viewer upload request should have been recorded
+    And the stored response should include values for "strip-attach"
+    And the stored response should not include values for "strip-file"
+
+  # PRIORITY 1 — regression guard for PR #131. submitResponse is a public
+  # mutation; a crafted request that skips the viewer entirely must still have
+  # hidden-field and hidden-page values stripped server-side.
+  Scenario: Server strips hidden values from a direct GraphQL submission bypassing the client
+    Given I sign in with valid credentials
+    When I create a form via GraphQL with conditional logic rules
+    And I publish the form
+    Then the form should be published
+    When I get the form short URL
+    And I navigate to the form viewer with the short URL
+    And I submit a crafted response with hidden field values directly via GraphQL
+    Then the stored response should include values for "cond-show-bonus, cond-skip-details, cond-contact"
+    And the stored response should not include values for "cond-bonus, cond-details"
+
+  # Editing a response so that a previously answered field becomes hidden must
+  # strip its value AND record the removal as a DELETE field change in the
+  # response edit history (updateResponse flows through the same strip gate).
+  Scenario: Editing a response to hide an answered field records a DELETE change
+    Given I sign in with valid credentials
+    When I create a form via GraphQL with conditional logic rules
+    And I publish the form
+    Then the form should be published
+    When I get the form short URL
+    And I navigate to the form viewer with the short URL
+    And I choose viewer radio option "Yes" for "Show bonus field?"
+    And I fill the viewer input "cond-bonus" with "value to be deleted"
+    And I choose viewer radio option "No" for "Skip details page?"
+    And I click next in the viewer
+    And I fill the viewer input "cond-details" with "details kept"
+    And I click next in the viewer
+    And I fill the viewer input "cond-contact" with "contact kept"
+    And I submit the conditional logic form in the viewer
+    Then the stored response should include values for "cond-bonus"
+    When I open the latest response in edit mode
+    And I choose edit-mode radio option "No" for "Show bonus field?"
+    And I save the response edit
+    Then the stored response should not include values for "cond-bonus"
+    And the response edit history should record a "DELETE" change for "cond-bonus"
+
+  # "Send me a copy" configured against a conditionally hidden email field:
+  # the submission must succeed and the stored data must lack the email key
+  # (which is the gate that prevents any copy email from being attempted).
+  Scenario: Send-me-a-copy with a conditionally hidden email field submits cleanly
+    Given I sign in with valid credentials
+    When I create a form via GraphQL with a conditionally hidden response copy email field
+    And I enable respondent-choice response copy for the "copy-email" field
+    And I publish the form
+    Then the form should be published
+    When I get the form short URL
+    And I navigate to the form viewer with the short URL
+    Then the viewer field "Copy Email" should be hidden
+    When I choose viewer radio option "Yes" for "Provide an email?"
+    Then the viewer field "Copy Email" should be visible
+    When I fill the viewer input "copy-email" with "respondent@example.com"
+    And I fill the viewer input "copy-note" with "note kept"
+    And I choose viewer radio option "No" for "Provide an email?"
+    Then the viewer field "Copy Email" should be hidden
+    When I tick the send-me-a-copy checkbox in the viewer
+    And I submit the conditional logic form in the viewer
+    Then the viewer should show the thank you screen without a copy notice
+    And the stored response should include values for "copy-toggle, copy-note"
+    And the stored response should not include values for "copy-email"
+
+  # "Keep while filling": hiding a field must not wipe what was typed — after
+  # navigating away and back and re-showing the field, the value is restored.
+  Scenario: Re-showing a hidden field restores the typed value across page navigation
+    Given I sign in with valid credentials
+    When I create a form via GraphQL with conditional logic rules
+    And I publish the form
+    Then the form should be published
+    When I get the form short URL
+    And I navigate to the form viewer with the short URL
+    And I choose viewer radio option "Yes" for "Show bonus field?"
+    And I fill the viewer input "cond-bonus" with "sticky bonus value"
+    And I choose viewer radio option "No" for "Show bonus field?"
+    Then the viewer field "Bonus Field" should be hidden
+    When I choose viewer radio option "No" for "Skip details page?"
+    And I click next in the viewer
+    Then the viewer field "Details Text" should be visible
+    When I click previous in the viewer
+    And I choose viewer radio option "Yes" for "Show bonus field?"
+    Then the viewer field "Bonus Field" should be visible
+    And the viewer input "cond-bonus" should have value "sticky bonus value"

--- a/test/e2e/steps/conditional-logic-data-integrity.steps.ts
+++ b/test/e2e/steps/conditional-logic-data-integrity.steps.ts
@@ -1,0 +1,428 @@
+/**
+ * Conditional logic submit-strip data integrity steps
+ *
+ * Covers the surfaces where the submit-time strip matters beyond the stored
+ * response row: file uploads never reaching /upload, the server-side strip on
+ * direct GraphQL submissions (PR #131), DELETE tracking on response edits,
+ * "send me a copy" against a hidden email field, and keep-while-filling
+ * value restoration. Reuses the viewer/publish/stored-response steps from
+ * conditional-logic.steps.ts and its fixture field ids (cond-*).
+ */
+
+import { When, Then } from '@cucumber/cucumber';
+import { expect } from '@playwright/test';
+import type { Page } from 'playwright';
+import { CustomWorld } from '../support/world';
+import { createFormViaGraphQL, fetchLatestResponse } from './helpers';
+
+// Per-scenario state (each scenario runs to completion within one worker)
+let uploadRequestCount = 0;
+let editResponseId: string | null = null;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const baseLayout = () => ({
+  theme: 'light',
+  textColor: '#000000',
+  spacing: 'normal',
+  code: 'L9',
+  content: '<h1>Conditional Strip Integrity Test</h1>',
+  customBackGroundColor: '#ffffff',
+  backgroundImageKey: '',
+  pageMode: 'multipage',
+  isCustomBackgroundColorEnabled: false,
+});
+
+/**
+ * Single page: a Yes/No trigger and a FileUpload target that only shows when
+ * the trigger is "Yes" (default hidden).
+ */
+const hiddenFileUploadSchema = () => ({
+  layout: baseLayout(),
+  isShuffleEnabled: false,
+  pages: [
+    {
+      id: 'strip-page-1',
+      title: 'Attachments',
+      order: 0,
+      fields: [
+        {
+          id: 'strip-attach',
+          type: 'radio_field',
+          label: 'Attach a file?',
+          defaultValue: '',
+          prefix: '',
+          hint: '',
+          options: ['Yes', 'No'],
+          validation: { required: false, type: 'fillable_form_field' },
+        },
+        {
+          id: 'strip-file',
+          type: 'file_upload_field',
+          label: 'Attachment',
+          hint: 'Upload a file.',
+          maxFileSizeMb: 10,
+          maxFiles: 1,
+          allowedMimeTypes: [],
+          validation: { required: false },
+        },
+      ],
+    },
+  ],
+  conditions: [
+    {
+      id: 'rule-show-strip-file',
+      enabled: true,
+      combinator: 'all',
+      terms: [{ fieldId: 'strip-attach', operator: 'equals', value: 'Yes' }],
+      actions: [{ type: 'showField', fieldIds: ['strip-file'] }],
+    },
+  ],
+});
+
+/**
+ * Single page: a Yes/No trigger, an EmailField target that only shows when the
+ * trigger is "Yes" (default hidden), and an always-visible note field. The
+ * scenario points the form's responseCopy settings at the email field.
+ */
+const hiddenCopyEmailSchema = () => ({
+  layout: baseLayout(),
+  isShuffleEnabled: false,
+  pages: [
+    {
+      id: 'copy-page-1',
+      title: 'Copy',
+      order: 0,
+      fields: [
+        {
+          id: 'copy-toggle',
+          type: 'radio_field',
+          label: 'Provide an email?',
+          defaultValue: '',
+          prefix: '',
+          hint: '',
+          options: ['Yes', 'No'],
+          validation: { required: false, type: 'fillable_form_field' },
+        },
+        {
+          id: 'copy-email',
+          type: 'email_field',
+          label: 'Copy Email',
+          defaultValue: '',
+          prefix: '',
+          hint: '',
+          placeholder: 'you@example.com',
+          validation: { required: false, type: 'fillable_form_field' },
+        },
+        {
+          id: 'copy-note',
+          type: 'text_input_field',
+          label: 'Copy Note',
+          defaultValue: '',
+          prefix: '',
+          hint: '',
+          placeholder: 'Note',
+          validation: { required: false, type: 'text_field_validation' },
+        },
+      ],
+    },
+  ],
+  conditions: [
+    {
+      id: 'rule-show-copy-email',
+      enabled: true,
+      combinator: 'all',
+      terms: [{ fieldId: 'copy-toggle', operator: 'equals', value: 'Yes' }],
+      actions: [{ type: 'showField', fieldIds: ['copy-email'] }],
+    },
+  ],
+});
+
+When(
+  'I create a form via GraphQL with a conditionally hidden file upload field',
+  async function (this: CustomWorld) {
+    await createFormViaGraphQL(this, hiddenFileUploadSchema(), 'E2E Cond Hidden FileUpload Test');
+  }
+);
+
+When(
+  'I create a form via GraphQL with a conditionally hidden response copy email field',
+  async function (this: CustomWorld) {
+    await createFormViaGraphQL(this, hiddenCopyEmailSchema(), 'E2E Cond Response Copy Test');
+  }
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 1 — hidden FileUpload never uploads
+// ─────────────────────────────────────────────────────────────────────────────
+
+When('I start recording viewer upload requests', async function (this: CustomWorld) {
+  if (!this.viewerPage) throw new Error('Viewer page is not initialized');
+  uploadRequestCount = 0;
+  this.viewerPage.on('request', (request) => {
+    if (request.method() === 'POST' && new URL(request.url()).pathname.endsWith('/upload')) {
+      uploadRequestCount++;
+    }
+  });
+});
+
+When(
+  'I attach a text file to the {string} upload field in the viewer',
+  async function (this: CustomWorld, fieldId: string) {
+    if (!this.viewerPage) throw new Error('Viewer page is not initialized');
+    await this.viewerPage.evaluate((id) => {
+      const dropZone = document.querySelector(
+        `[data-testid="file-upload-drop-zone-${id}"]`
+      ) as HTMLElement | null;
+      if (!dropZone) throw new Error(`file-upload-drop-zone-${id} not found`);
+      const dt = new DataTransfer();
+      dt.items.add(new File(['strip me'], 'stripped-file.txt', { type: 'text/plain' }));
+      dropZone.dispatchEvent(
+        new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: dt })
+      );
+    }, fieldId);
+    // FileChip renders the file name in a span.truncate — the attach must land
+    await expect(this.viewerPage.locator('span.truncate')).toHaveCount(1, { timeout: 5_000 });
+  }
+);
+
+Then('no viewer upload request should have been recorded', async function (this: CustomWorld) {
+  expect(
+    uploadRequestCount,
+    `expected zero POST /upload requests from the viewer, saw ${uploadRequestCount}`
+  ).toBe(0);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 2 — server-side strip on a direct GraphQL submission (PR #131)
+// ─────────────────────────────────────────────────────────────────────────────
+
+When(
+  'I submit a crafted response with hidden field values directly via GraphQL',
+  async function (this: CustomWorld) {
+    if (!this.viewerPage) throw new Error('Viewer page is not initialized');
+    if (!this.currentFormId) throw new Error('No form created in this scenario');
+
+    // "Show bonus field?" = No hides cond-bonus; "Skip details page?" = Yes
+    // hides page cond-page-2 (cond-details). Both hidden values are injected
+    // anyway — the server must strip them before persisting.
+    const craftedData = {
+      'cond-show-bonus': 'No',
+      'cond-skip-details': 'Yes',
+      'cond-bonus': 'bypass bonus value',
+      'cond-details': 'bypass details value',
+      'cond-contact': 'contact value kept',
+    };
+
+    const response = await this.viewerPage.evaluate(
+      async ({ formId, backendUrl, data }) => {
+        const res = await fetch(backendUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            query: `mutation SubmitResponse($input: SubmitResponseInput!) {
+              submitResponse(input: $input) { id }
+            }`,
+            variables: { input: { formId, data } },
+          }),
+        });
+        return res.json();
+      },
+      { formId: this.currentFormId, backendUrl: this.backendUrl, data: craftedData }
+    );
+
+    if (response.errors) {
+      throw new Error(`Crafted submitResponse failed: ${JSON.stringify(response.errors)}`);
+    }
+    if (!response.data?.submitResponse?.id) {
+      throw new Error(`Crafted submitResponse returned no id: ${JSON.stringify(response)}`);
+    }
+  }
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 3 — EDIT mode records DELETE for a value hidden by the edit
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Container-scoped radio selection, shared by viewer and edit-mode pages. */
+async function chooseRadioOption(page: Page, option: string, fieldLabel: string): Promise<void> {
+  const container = page
+    .locator('form div')
+    .filter({ has: page.getByText(fieldLabel, { exact: true }) })
+    .filter({ has: page.getByRole('radiogroup') })
+    .last();
+  await container.getByRole('radio', { name: option, exact: true }).click();
+  // Give the store sync + evaluator a beat to re-render visibility
+  await page.waitForTimeout(300);
+}
+
+When('I open the latest response in edit mode', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  if (!this.currentFormId) throw new Error('No form created in this scenario');
+
+  const { id } = await fetchLatestResponse(this);
+  editResponseId = id;
+
+  await this.page.goto(
+    `${this.baseUrl}/dashboard/form/${this.currentFormId}/responses/${id}/edit`
+  );
+  // The edit page renders the same form renderer — wait for the trigger radio
+  await expect(this.page.getByRole('radiogroup').first()).toBeVisible({ timeout: 30_000 });
+});
+
+When(
+  'I choose edit-mode radio option {string} for {string}',
+  async function (this: CustomWorld, option: string, fieldLabel: string) {
+    if (!this.page) throw new Error('Page is not initialized');
+    await chooseRadioOption(this.page, option, fieldLabel);
+  }
+);
+
+When('I save the response edit', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+
+  // Walk to the last page (the fixture has up to 3 visible pages), then the
+  // footer button becomes "Update Response" with the viewer-submit-button testid
+  for (let i = 0; i < 5; i++) {
+    if (await this.page.getByTestId('viewer-submit-button').isVisible()) break;
+    await this.page.getByTestId('viewer-next-button').click();
+    await this.page.waitForTimeout(500);
+  }
+  await this.page.getByTestId('viewer-submit-button').click();
+
+  // A successful update navigates to the response's edit-history page
+  await this.page.waitForURL('**/history', { timeout: 30_000 });
+});
+
+Then(
+  'the response edit history should record a {string} change for {string}',
+  async function (this: CustomWorld, changeType: string, fieldId: string) {
+    if (!this.page) throw new Error('Page is not initialized');
+    if (!editResponseId) throw new Error('No response was opened in edit mode');
+
+    const response = await this.page.evaluate(
+      async ({ responseId, backendUrl }) => {
+        const res = await fetch(backendUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            query: `query ResponseEditHistory($responseId: ID!) {
+              responseEditHistory(responseId: $responseId) {
+                id
+                editType
+                fieldChanges { fieldId changeType previousValue newValue }
+              }
+            }`,
+            variables: { responseId },
+          }),
+        });
+        return res.json();
+      },
+      { responseId: editResponseId, backendUrl: this.backendUrl }
+    );
+
+    if (response.errors) {
+      throw new Error(`GraphQL error fetching edit history: ${JSON.stringify(response.errors)}`);
+    }
+
+    const edits: Array<{
+      fieldChanges: Array<{ fieldId: string; changeType: string }>;
+    }> = response.data?.responseEditHistory ?? [];
+    const allChanges = edits.flatMap((edit) => edit.fieldChanges);
+    const match = allChanges.find(
+      (change) => change.fieldId === fieldId && change.changeType === changeType
+    );
+    expect(
+      match,
+      `expected a ${changeType} field change for "${fieldId}" — got: ${JSON.stringify(allChanges)}`
+    ).toBeTruthy();
+  }
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 4 — send-me-a-copy against a conditionally hidden email field
+// ─────────────────────────────────────────────────────────────────────────────
+
+When(
+  'I enable respondent-choice response copy for the {string} field',
+  async function (this: CustomWorld, emailFieldId: string) {
+    if (!this.page) throw new Error('Page is not initialized');
+    if (!this.currentFormId) throw new Error('No form created in this scenario');
+
+    const response = await this.page.evaluate(
+      async ({ formId, backendUrl, fieldId }) => {
+        const res = await fetch(backendUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            query: `mutation UpdateForm($id: ID!, $input: UpdateFormInput!) {
+              updateForm(id: $id, input: $input) {
+                id
+                settings { responseCopy { enabled mode emailFieldId } }
+              }
+            }`,
+            variables: {
+              id: formId,
+              input: {
+                settings: {
+                  responseCopy: {
+                    enabled: true,
+                    mode: 'respondentChoice',
+                    emailFieldId: fieldId,
+                  },
+                },
+              },
+            },
+          }),
+        });
+        return res.json();
+      },
+      { formId: this.currentFormId, backendUrl: this.backendUrl, fieldId: emailFieldId }
+    );
+
+    if (response.errors) {
+      throw new Error(`GraphQL error enabling response copy: ${JSON.stringify(response.errors)}`);
+    }
+    const saved = response.data?.updateForm?.settings?.responseCopy;
+    if (!saved?.enabled || saved.emailFieldId !== emailFieldId) {
+      throw new Error(`Response copy settings not saved: ${JSON.stringify(saved)}`);
+    }
+  }
+);
+
+When('I tick the send-me-a-copy checkbox in the viewer', async function (this: CustomWorld) {
+  if (!this.viewerPage) throw new Error('Viewer page is not initialized');
+  const checkbox = this.viewerPage.getByTestId('send-response-copy-checkbox');
+  await expect(checkbox).toBeVisible({ timeout: 10_000 });
+  await checkbox.click();
+});
+
+Then(
+  'the viewer should show the thank you screen without a copy notice',
+  async function (this: CustomWorld) {
+    if (!this.viewerPage) throw new Error('Viewer page is not initialized');
+    await expect(this.viewerPage.getByTestId('thank-you-display')).toBeVisible({
+      timeout: 30_000,
+    });
+    // The copy email was stripped, so no "a copy was sent to …" note may appear
+    await expect(this.viewerPage.getByTestId('thank-you-copy-notice')).toHaveCount(0);
+  }
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 5 — re-show restores the typed value
+// ─────────────────────────────────────────────────────────────────────────────
+
+Then(
+  'the viewer input {string} should have value {string}',
+  async function (this: CustomWorld, fieldId: string, value: string) {
+    if (!this.viewerPage) throw new Error('Viewer page is not initialized');
+    const input = this.viewerPage.locator(`input[name="${fieldId}"]`);
+    await expect(input).toBeVisible({ timeout: 10_000 });
+    await expect(input).toHaveValue(value, { timeout: 10_000 });
+  }
+);

--- a/test/e2e/steps/conditional-logic-data-integrity.steps.ts
+++ b/test/e2e/steps/conditional-logic-data-integrity.steps.ts
@@ -183,8 +183,10 @@ When(
         new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: dt })
       );
     }, fieldId);
-    // FileChip renders the file name in a span.truncate — the attach must land
-    await expect(this.viewerPage.locator('span.truncate')).toHaveCount(1, { timeout: 5_000 });
+    // The attach must land — the file chip shows the attached file's name
+    await expect(
+      this.viewerPage.getByText('stripped-file.txt', { exact: true })
+    ).toBeVisible({ timeout: 5_000 });
   }
 );
 

--- a/test/e2e/steps/conditional-logic.steps.ts
+++ b/test/e2e/steps/conditional-logic.steps.ts
@@ -9,9 +9,7 @@
 import { When, Then } from '@cucumber/cucumber';
 import { expect } from '@playwright/test';
 import { CustomWorld } from '../support/world';
-import { createFormViaGraphQL } from './helpers';
-
-let currentFormId: string | null = null;
+import { createFormViaGraphQL, fetchLatestResponse } from './helpers';
 
 const conditionalLogicFields = () => ({
   layout: {
@@ -124,7 +122,7 @@ const conditionalLogicSchemaWithRules = () => ({
 When(
   'I create a form via GraphQL with conditional logic rules',
   async function (this: CustomWorld) {
-    currentFormId = await createFormViaGraphQL(
+    await createFormViaGraphQL(
       this,
       conditionalLogicSchemaWithRules(),
       'E2E Conditional Logic Test'
@@ -135,7 +133,7 @@ When(
 When(
   'I create a form via GraphQL with conditional logic fields',
   async function (this: CustomWorld) {
-    currentFormId = await createFormViaGraphQL(
+    await createFormViaGraphQL(
       this,
       conditionalLogicFields(),
       'E2E Conditional Builder Test'
@@ -211,42 +209,10 @@ When(
 // Stored-response assertions (submit-time strip)
 // ─────────────────────────────────────────────────────────────────────────────
 
-async function fetchLatestResponseData(world: CustomWorld): Promise<Record<string, unknown>> {
-  if (!world.page) throw new Error('Page is not initialized');
-  if (!currentFormId) throw new Error('No form created in this scenario');
-
-  const response = await world.page.evaluate(
-    async ({ formId, backendUrl }) => {
-      const res = await fetch(backendUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          query: `query ResponsesByForm($formId: ID!) {
-            responsesByForm(formId: $formId, page: 1, limit: 1) {
-              data { id data }
-            }
-          }`,
-          variables: { formId },
-        }),
-      });
-      return res.json();
-    },
-    { formId: currentFormId, backendUrl: world.backendUrl }
-  );
-
-  if (response.errors) {
-    throw new Error(`GraphQL error fetching responses: ${JSON.stringify(response.errors)}`);
-  }
-  const first = response.data?.responsesByForm?.data?.[0];
-  if (!first) throw new Error('No stored response found for the form');
-  return first.data as Record<string, unknown>;
-}
-
 Then(
   'the stored response should include values for {string}',
   async function (this: CustomWorld, fieldIdsCsv: string) {
-    const data = await fetchLatestResponseData(this);
+    const { data } = await fetchLatestResponse(this);
     for (const fieldId of fieldIdsCsv.split(',').map((s) => s.trim())) {
       expect(
         data[fieldId],
@@ -259,7 +225,7 @@ Then(
 Then(
   'the stored response should not include values for {string}',
   async function (this: CustomWorld, fieldIdsCsv: string) {
-    const data = await fetchLatestResponseData(this);
+    const { data } = await fetchLatestResponse(this);
     for (const fieldId of fieldIdsCsv.split(',').map((s) => s.trim())) {
       expect(
         data[fieldId],

--- a/test/e2e/steps/helpers/common.ts
+++ b/test/e2e/steps/helpers/common.ts
@@ -150,9 +150,49 @@ export async function createFormViaGraphQL(
 
   const formId = response.data.createForm.id;
   world.newFormTitle = formTitle;
+  world.currentFormId = formId;
   await world.page.goto(`${world.baseUrl}/dashboard/form/${formId}`);
   await expect(world.page.getByTestId('app-sidebar')).toBeVisible({ timeout: 30_000 });
   return formId;
+}
+
+/**
+ * Fetches the most recently submitted response for the scenario's form
+ * (world.currentFormId) via the authenticated builder page. Returns the
+ * response row's id and its stored data payload.
+ */
+export async function fetchLatestResponse(
+  world: CustomWorld
+): Promise<{ id: string; data: Record<string, unknown> }> {
+  if (!world.page) throw new Error('Page is not initialized');
+  if (!world.currentFormId) throw new Error('No form created in this scenario');
+
+  const response = await world.page.evaluate(
+    async ({ formId, backendUrl }) => {
+      const res = await fetch(backendUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          query: `query ResponsesByForm($formId: ID!) {
+            responsesByForm(formId: $formId, page: 1, limit: 1) {
+              data { id data }
+            }
+          }`,
+          variables: { formId },
+        }),
+      });
+      return res.json();
+    },
+    { formId: world.currentFormId, backendUrl: world.backendUrl }
+  );
+
+  if (response.errors) {
+    throw new Error(`GraphQL error fetching responses: ${JSON.stringify(response.errors)}`);
+  }
+  const first = response.data?.responsesByForm?.data?.[0];
+  if (!first) throw new Error('No stored response found for the form');
+  return { id: first.id as string, data: first.data as Record<string, unknown> };
 }
 
 /**

--- a/test/e2e/support/world.ts
+++ b/test/e2e/support/world.ts
@@ -11,6 +11,8 @@ export class CustomWorld {
   readonly backendUrl: string;
   newFormTitle?: string;
   formShortUrl?: string;
+  /** Set by createFormViaGraphQL — the form the current scenario is exercising */
+  currentFormId?: string;
   viewerPage?: Page;
   expectedFieldSettings?: Record<string, any>;
   massResponseSuccessCount?: number;


### PR DESCRIPTION
Closes #134. Part of Epic #130.

Test-only story: adds five Cucumber + Playwright scenarios in a new `conditional-logic-data-integrity.feature` covering the surfaces where the conditional-logic submit-strip (client gate in `PageRenderer.handleFormComplete` + server gate in `apps/backend/src/lib/conditionalStrip.ts`, PR #131) matters beyond the stored response row.

## Scenarios

1. **Hidden FileUpload never uploads** — attach a file while the field is visible, flip the trigger so it hides, submit. Asserts the stored response has no `strip-file` key **and** zero `POST /upload` requests were made from the viewer (request listener registered right after viewer navigation, so it would also catch eager uploads at attach time).
2. **Server-side strip bypassing the client (priority 1)** — submits `submitResponse` directly via `fetch` from the (unauthenticated) viewer page context with values injected for a rule-hidden field *and* a rule-hidden page. Asserts both are stripped from the stored response while visible values persist — the end-to-end regression guard for PR #131.
3. **EDIT mode records DELETE** — submit with a visible bonus value, open `/dashboard/form/:formId/responses/:responseId/edit` as the owner, flip the trigger so the field hides, save. Asserts via the `responseEditHistory` GraphQL query that the field change is recorded with `changeType: DELETE`, and the stored response no longer has the key.
4. **Send-me-a-copy with a hidden email field** — `responseCopy` mode `respondentChoice` pointed at a conditionally hidden email field; hide it, tick "Send me a copy", submit. Asserts the thank-you screen shows without a copy notice and the stored data lacks the email key (the gate that prevents any copy email attempt). The integration-test SMTP harness isn't reachable from the E2E suite, so the stored-data gate is the assertion, per the issue.
5. **Re-show restores typed input** — type → hide → navigate away and back → un-hide → the input still holds the typed value ("keep while filling").

## Refactor (first commit)

`createFormViaGraphQL` now records the created form on `world.currentFormId`, and the latest-stored-response fetch moved to a shared `fetchLatestResponse` helper (also returning the response id) so the new step file reuses the existing `the stored response should (not) include values for` steps instead of duplicating them.

## Verification

- All 5 new scenarios green individually against the local stack
- Full E2E suite green: 69 scenarios / 961 steps passed
- `pnpm type-check`, `pnpm --filter @dculus/types test` (74), `pnpm --filter backend test` (2601) all green
- No product bugs surfaced — all scenarios pass against current `main` behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for conditional-logic data integrity across hidden fields and multiple surfaces.
  * Verified hidden file uploads are not sent to the upload endpoint and hidden values are excluded from stored responses.
  * Confirmed server-side protection for bypass attempts using direct submissions.
  * Added validations for response edit history, send-me-a-copy behavior when data is hidden, and restoring previously entered values when fields reappear.

* **Refactor**
  * Updated end-to-end helpers to track the current form and retrieve the latest submitted response more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->