### PR TITLE
fix(evaluator): resolve self-hiding page cycles to HIDDEN (closes #148)

### DIFF
--- a/packages/types/src/conditions.evaluator.test.ts
+++ b/packages/types/src/conditions.evaluator.test.ts
@@ -907,4 +907,76 @@ describe('cascading evaluation', () => {
       evaluateConditions(rules, responsesWith({ number: 21 }), schema).hiddenFieldIds.has('date')
     ).toBe(false);
   });
+
+  // ---------------------------------------------------------------------------
+  // Page-cycle resolution: prefer HIDDEN (union of cycle states)
+  // contrast with field-cycle resolution which prefers VISIBLE (intersection)
+  // ---------------------------------------------------------------------------
+
+  it('self-hiding page resolves to HIDDEN (page-cycle prefers hidden)', () => {
+    // Rule: IF select (on p2) equals "hide me" → hidePage p2
+    // Iteration trace:
+    //   State 0: p2 visible → select = "hide me" → rule fires → {p2} hidden
+    //   State 1: p2 hidden → select coerced to undefined → rule deactivates → {}
+    //   State 2 = State 0 → cycle [{p2}, {}] detected
+    //   Pages: union({p2}, {}) = {p2} → p2 HIDDEN ✓
+    const selfHidePage: ConditionalRule = {
+      id: 'self-hide-page',
+      enabled: true,
+      combinator: 'all',
+      terms: [{ fieldId: 'select', operator: 'equals', value: 'hide me' }],
+      actions: [{ type: 'hidePage', pageId: 'p2' }],
+    };
+    const result = evaluateConditions(
+      [selfHidePage],
+      responsesWith({ select: 'hide me' }),
+      schema
+    );
+    expect(result.hiddenPageIds.has('p2')).toBe(true);
+    // p1 is unaffected
+    expect(result.hiddenPageIds.has('p1')).toBe(false);
+  });
+
+  it('self-hiding page + unrelated rule — unrelated page unaffected', () => {
+    const selfHidePage: ConditionalRule = {
+      id: 'self-hide-page',
+      enabled: true,
+      combinator: 'all',
+      terms: [{ fieldId: 'select', operator: 'equals', value: 'hide me' }],
+      actions: [{ type: 'hidePage', pageId: 'p2' }],
+    };
+    // Separate rule that hides p1 when text on p1 is filled
+    const hideP1: ConditionalRule = {
+      id: 'hide-p1',
+      enabled: true,
+      combinator: 'all',
+      terms: [{ fieldId: 'text', operator: 'isFilled' }],
+      actions: [{ type: 'hidePage', pageId: 'p1' }],
+    };
+    // text filled → p1 hidden (stable, no cycle)
+    // select = "hide me" → self-hiding page cycle → p2 hidden
+    const result = evaluateConditions(
+      [selfHidePage, hideP1],
+      responsesWith({ select: 'hide me', text: 'go' }),
+      schema
+    );
+    expect(result.hiddenPageIds.has('p2')).toBe(true);
+    expect(result.hiddenPageIds.has('p1')).toBe(true);
+  });
+
+  it('self-hiding page does NOT hide when trigger value does not match', () => {
+    const selfHidePage: ConditionalRule = {
+      id: 'self-hide-page',
+      enabled: true,
+      combinator: 'all',
+      terms: [{ fieldId: 'select', operator: 'equals', value: 'hide me' }],
+      actions: [{ type: 'hidePage', pageId: 'p2' }],
+    };
+    const result = evaluateConditions(
+      [selfHidePage],
+      responsesWith({ select: 'keep visible' }),
+      schema
+    );
+    expect(result.hiddenPageIds.has('p2')).toBe(false);
+  });
 });

--- a/packages/types/src/conditions.ts
+++ b/packages/types/src/conditions.ts
@@ -361,10 +361,15 @@ export const stripHiddenResponses = (
  *   evaluating terms, so hiding a trigger auto-deactivates dependent rules.
  * - Matched rules apply their actions in list order — later rules win on
  *   conflict. Fixed-point iteration stops when the visibility state stabilizes
- *   or a previously seen state repeats (an oscillating show/hide cycle). On a
- *   cycle, an item that oscillates within the cycle resolves to visible; only
- *   items hidden in every cycle state stay hidden. Resolution is per item, so
- *   the outcome is deterministic and independent of unrelated rules or cycles.
+ *   or a previously seen state repeats (an oscillating show/hide cycle). Cycle
+ *   resolution is per-item-type:
+ *     • Fields: intersection of cycle states → VISIBLE when oscillating.
+ *       Contradictory field rules are usually a misconfiguration; visibility is
+ *       the safer default.
+ *     • Pages: union of cycle states → HIDDEN when oscillating. A self-hiding
+ *       page rule (trigger field on the same page as the action) is intentional
+ *       by design — the user wants the page gone. The PageRenderer clamp guard
+ *       handles the resulting "current page hidden" state safely.
  * - A page is also hidden when it has ≥1 field and all of them are hidden
  *   (auto-skip, §9.8). Terms referencing unknown/deleted fields are false;
  *   disabled, term-less, or action-less rules are inactive (§9.9).
@@ -516,12 +521,12 @@ export const evaluateConditions = (
     if (firstSeenAt !== undefined) {
       const cycle = history.slice(firstSeenAt);
       current = {
+        // Fields: intersection → prefer VISIBLE (contradictory rules = misconfiguration)
         fields: new Set(
           [...next.fields].filter((id) => cycle.every((s) => s.fields.has(id)))
         ),
-        pages: new Set(
-          [...next.pages].filter((id) => cycle.every((s) => s.pages.has(id)))
-        ),
+        // Pages: union → prefer HIDDEN (self-hiding page rule is intentional)
+        pages: new Set(cycle.flatMap((s) => [...s.pages])),
       };
       break;
     }

--- a/test/e2e/features/conditional-logic-page-edges.feature
+++ b/test/e2e/features/conditional-logic-page-edges.feature
@@ -23,19 +23,17 @@ Feature: Conditional logic page-rule and navigation edge cases
     Then I should be on viewer page 3 of 4
     And the viewer field "Text B" should be visible
 
-  # Scenario: 2. Self-hiding current page (clamp to previous)
-  #   # NOTE: This scenario is skipped because of a product bug in the pure evaluator (packages/types/src/conditions.ts).
-  #   # Hiding your own trigger's page creates an oscillation loop which the cycle resolver resolves to VISIBLE.
-  #   # Therefore, page 2 remains visible, and clamping to page 1 never happens.
-  #   # Tracked in issue #148 (https://github.com/dculussoftwares/dculus-forms/issues/148).
-  #   Then I should be on viewer page 1 of 4
-  #   When I click next in the viewer
-  #   Then I should be on viewer page 2 of 4
-  #   And the viewer field "Text A" should be visible
-  #   When I fill the viewer input "edge-a" with "hide me"
-  #   Then I should be on viewer page 1 of 3
-  #   And the viewer field "Skip page 1?" should be visible
-
+  Scenario: 2. Self-hiding current page (clamp to previous)
+    # Verifies fix for bug #148: a page that hides itself via a trigger field on
+    # the same page must resolve to HIDDEN (union cycle policy) and clamp the user
+    # back to the previous visible page.
+    Then I should be on viewer page 1 of 4
+    When I click next in the viewer
+    Then I should be on viewer page 2 of 4
+    And the viewer field "Text A" should be visible
+    When I fill the viewer input "edge-a" with "hide me"
+    Then I should be on viewer page 1 of 3
+    And the viewer field "Skip page 1?" should be visible
 
 
   Scenario: 3. Back navigation across a skipped page keeps answers

--- a/test/e2e/steps/conditional-logic.steps.ts
+++ b/test/e2e/steps/conditional-logic.steps.ts
@@ -575,7 +575,16 @@ When(
     const input = this.viewerPage.locator(`input[name="${fieldId}"]`);
     await expect(input).toBeVisible({ timeout: 10_000 });
     await input.fill(value);
-    await input.blur();
+    // blur() flushes React's onBlur/onChange so the evaluator re-runs.
+    // When filling triggers a self-hiding page rule the input disappears from
+    // the DOM before blur() resolves — that is the expected behaviour, so we
+    // absorb the locator-not-found error here without masking real failures
+    // (fill() already proved the element existed and the value was accepted).
+    try {
+      await input.blur();
+    } catch {
+      // element disappeared due to conditional visibility change — expected
+    }
     await this.viewerPage.waitForTimeout(300);
   }
 );
@@ -716,7 +725,13 @@ When(
     const input = this.viewerPage.locator(`input[name="${fieldId}"]`);
     await expect(input).toBeVisible({ timeout: 10_000 });
     await input.fill('');
-    await input.blur();
+    // Same blur() safety as the fill step — clearing can also trigger page
+    // visibility changes that remove the input before blur() resolves.
+    try {
+      await input.blur();
+    } catch {
+      // element disappeared due to conditional visibility change — expected
+    }
     await this.viewerPage.waitForTimeout(300);
   }
 );


### PR DESCRIPTION
## Summary

Fixes the oscillation-to-visible bug in the pure evaluator for pages with self-referential `hidePage` rules.

Closes #148
Part of Epic #130

---

## Root cause

A page whose `hidePage` action is triggered by a field on the **same page** creates a negative-feedback oscillation:

| Iteration | Page state | Trigger field reads | Rule fires? | Next state |
|-----------|-----------|---------------------|-------------|------------|
| 0 | visible | `"hide me"` | ✓ | `{p2}` hidden |
| 1 | hidden | `undefined` (coerced) | ✗ | `{}` visible |
| 2 | = State 0 | … | cycle | detected |

The old **intersection** policy resolved the cycle as `{p2} ∩ {} = {}` → page stays **visible** ❌

## Fix — differential cycle policy

| Item type | Cycle policy | Rationale |
|-----------|-------------|-----------|
| Fields | Intersection → **VISIBLE** | Contradictory field rules are usually a misconfiguration |
| Pages | **Union → HIDDEN** | A self-hiding page rule is intentional — the author configured `hidePage` on purpose. `PageRenderer` already has a clamp guard for the "current page hidden" case. |

**Core change:** one line in `conditions.ts` cycle resolver:
```diff
- pages: new Set([...next.pages].filter((id) => cycle.every((s) => s.pages.has(id))))
+ pages: new Set(cycle.flatMap((s) => [...s.pages]))
```

## Changes

- **`packages/types/src/conditions.ts`** — one-line cycle resolver change + updated JSDoc  
- **`packages/types/src/conditions.evaluator.test.ts`** — 3 new unit tests for page-cycle resolution (77 total, all passing)  
- **`test/e2e/features/conditional-logic-page-edges.feature`** — Scenario 2 re-enabled with live assertions  
- **`test/e2e/steps/conditional-logic.steps.ts`** — `blur()` wrapped in try/catch in fill/clear steps (when the page hides itself the input disappears mid-blur — that is correct behaviour, not an error)  

## Verification

- ✅ Unit tests: 77/77 pass (`pnpm --filter @dculus/types test`)  
- ✅ Build: `pnpm --filter @dculus/types build` clean  
- ✅ E2E: all 5 page-edge scenarios pass (including re-enabled Scenario 2)  
- ✅ Pre-push hooks: backend tests, form-viewer tests, all 3 app builds green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conditional page navigation when a page hides itself, ensuring the flow moves to the correct available page.
  * Updated cycle handling so oscillating page visibility resolves consistently, while fields retain their existing behavior.
  * Prevented errors when conditional logic removes an input during interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->