### PR TITLE
feat(e2e): real-time collaboration for condition rules (two-session sync)

### DIFF
--- a/test/e2e/features/conditional-logic-collab.feature
+++ b/test/e2e/features/conditional-logic-collab.feature
@@ -44,7 +44,7 @@ Feature: Real-time Collaboration for Condition Rules
     And In session "A" I save the condition rule
     And In session "B" I save the condition rule
     Then In both sessions there should be exactly one condition rule card for "Show bonus field?"
-    And In both sessions that rule card's summary should equal one of the two writes
+    And In both sessions that rule card's summary should equal session B's write
 
   Scenario: Cross-session broken reference
     When In session "A" I add a rule showing "cond-bonus" when "Show bonus field?" is equal to "Yes"

--- a/test/e2e/features/conditional-logic-collab.feature
+++ b/test/e2e/features/conditional-logic-collab.feature
@@ -1,0 +1,54 @@
+@skip-ci @builder-ux @collaboration
+Feature: Real-time Collaboration for Condition Rules
+
+  Background:
+    Given I sign in with valid credentials
+    And I save my session
+    When I create a form via GraphQL with conditional logic fields
+    And I open two collaborative builder sessions on the conditions tab
+
+  Scenario: Create syncs
+    When In session "A" I add a rule showing "cond-bonus" when "Show bonus field?" is equal to "Yes"
+    Then In session "B" I should see a condition rule card for "Show bonus field?"
+    And In session "B" the condition card for "Show bonus field?" should show "IF Show bonus field? is equal to “Yes” THEN Show field(s) Bonus Field" in its summary
+
+  Scenario: Toggle and delete syncs
+    When In session "A" I add a rule showing "cond-bonus" when "Show bonus field?" is equal to "Yes"
+    Then In session "B" I should see a condition rule card for "Show bonus field?"
+    When In session "A" I toggle the condition rule for "Show bonus field?"
+    Then In session "B" the condition rule switch state should update to disabled
+    When In session "B" I delete the condition rule for "Show bonus field?"
+    Then In session "A" I should see the conditions empty state
+
+  Scenario: Concurrent edits to different rules survive
+    When In session "A" I add a rule showing "cond-bonus" when "Show bonus field?" is equal to "Yes"
+    And In session "A" I add a rule hiding page "Page 2 — Details" when "Skip details page?" is equal to "Yes"
+    Then In session "B" I should see a condition rule card for "Show bonus field?"
+    And In session "B" I should see a condition rule card for "Skip details page?"
+    When In session "A" I edit the condition rule for "Show bonus field?"
+    And In session "B" I edit the condition rule for "Skip details page?"
+    And In session "A" I update the rule terms at index 0 to field "Show bonus field?", operator "equals", value "No"
+    And In session "B" I update the rule action at index 0 to type "hideField" and target field "cond-bonus"
+    And In session "A" I save the condition rule
+    And In session "B" I save the condition rule
+    Then In session "B" the condition card for "Show bonus field?" should show "IF Show bonus field? is equal to “No” THEN Show field(s) Bonus Field" in its summary
+    And In session "A" the condition card for "Skip details page?" should show "IF Skip details page? is equal to “Yes” THEN Hide field(s) Bonus Field" in its summary
+
+  Scenario: Same-rule concurrent edits resolve last-writer-wins
+    When In session "A" I add a rule showing "cond-bonus" when "Show bonus field?" is equal to "Yes"
+    Then In session "B" I should see a condition rule card for "Show bonus field?"
+    When In session "A" I edit the condition rule for "Show bonus field?"
+    And In session "B" I edit the condition rule for "Show bonus field?"
+    And In session "A" I update the rule terms at index 0 to field "Show bonus field?", operator "equals", value "No"
+    And In session "B" I update the rule terms at index 0 to field "Show bonus field?", operator "notEquals", value "Yes"
+    And In session "A" I save the condition rule
+    And In session "B" I save the condition rule
+    Then In both sessions there should be exactly one condition rule card for "Show bonus field?"
+    And In both sessions that rule card's summary should equal one of the two writes
+
+  Scenario: Cross-session broken reference
+    When In session "A" I add a rule showing "cond-bonus" when "Show bonus field?" is equal to "Yes"
+    Then In session "B" I should see a condition rule card for "Show bonus field?"
+    When In session "A" I open the page builder tab
+    And In session "A" I delete the field "cond-show-bonus" in the builder
+    Then In session "B" I should see a broken reference badge for the rule "Show bonus field?"

--- a/test/e2e/steps/conditional-logic-collab.steps.ts
+++ b/test/e2e/steps/conditional-logic-collab.steps.ts
@@ -1,0 +1,403 @@
+/**
+ * Conditional logic collaboration E2E steps
+ */
+
+import { Given, When, Then } from '@cucumber/cucumber';
+import { expect, type Page } from '@playwright/test';
+import { CustomWorld } from '../support/world';
+import { STORAGE_STATE_PATH } from '../support/authStorage';
+import { expectPoll } from '../support/expectPoll';
+
+/**
+ * Get the Playwright Page object for the specified session name
+ */
+function getSessionPage(world: CustomWorld, sessionName: string): Page {
+  const name = sessionName.toLowerCase();
+  if (name.includes('a')) {
+    if (!world.page) throw new Error('Session A page is not initialized');
+    return world.page;
+  }
+  if (name.includes('b')) {
+    if (!world.pageB) throw new Error('Session B page is not initialized');
+    return world.pageB;
+  }
+  throw new Error(`Unknown session: ${sessionName}`);
+}
+
+/**
+ * Open two collaborative builder sessions on the conditions tab
+ */
+Given('I open two collaborative builder sessions on the conditions tab', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  if (!this.currentFormId) throw new Error('No current form id');
+
+  // Navigate session A to conditions tab
+  await this.page.goto(`${this.baseUrl}/dashboard/form/${this.currentFormId}/builder/conditions`);
+  const builderRootA = this.page.getByTestId('collaborative-form-builder');
+  await expect(builderRootA).toBeVisible({ timeout: 45_000 });
+  await expect(this.page.getByTestId('conditions-title')).toBeVisible({ timeout: 15_000 });
+
+  // Launch session B
+  this.contextB = await this.browser!.newContext({
+    storageState: STORAGE_STATE_PATH,
+    baseURL: this.baseUrl,
+    viewport: { width: 1280, height: 720 },
+  });
+  this.pageB = await this.contextB.newPage();
+  
+  // Navigate session B to conditions tab
+  await this.pageB.goto(`${this.baseUrl}/dashboard/form/${this.currentFormId}/builder/conditions`);
+  const builderRootB = this.pageB.getByTestId('collaborative-form-builder');
+  await expect(builderRootB).toBeVisible({ timeout: 45_000 });
+  await expect(this.pageB.getByTestId('conditions-title')).toBeVisible({ timeout: 15_000 });
+
+  // Give a short delay for synchronization setup
+  await this.page.waitForTimeout(2000);
+  await this.pageB.waitForTimeout(2000);
+});
+
+/**
+ * Add a condition rule showing a target field when a trigger is equal to option in specified session
+ */
+When(
+  'In session {string} I add a rule showing {string} when {string} is equal to {string}',
+  async function (this: CustomWorld, session: string, targetFieldId: string, triggerLabel: string, optionValue: string) {
+    const page = getSessionPage(this, session);
+    await page.getByTestId('condition-add-rule').click();
+
+    // IF: trigger field → operator defaults to "is equal to" → option value
+    await page.getByTestId('condition-term-field-0').click();
+    await page.getByRole('option', { name: triggerLabel }).click();
+    await page.getByTestId('condition-term-value-0').click();
+    await page.getByRole('option', { name: optionValue, exact: true }).click();
+
+    // THEN: default action type is "Show field(s)" — tick the target field
+    await page.getByTestId(`condition-action-target-0-${targetFieldId}`).click();
+
+    const save = page.getByTestId('condition-save');
+    await expect(save).toBeEnabled({ timeout: 5_000 });
+    await save.click();
+    await page.waitForTimeout(1000);
+  }
+);
+
+/**
+ * Add a condition rule hiding a page when a trigger is equal to option in specified session
+ */
+When(
+  'In session {string} I add a rule hiding page {string} when {string} is equal to {string}',
+  async function (this: CustomWorld, session: string, pageLabel: string, triggerLabel: string, optionValue: string) {
+    const page = getSessionPage(this, session);
+    await page.getByTestId('condition-add-rule').click();
+
+    // IF: trigger field → operator defaults to "is equal to" → option value
+    await page.getByTestId('condition-term-field-0').click();
+    await page.getByRole('option', { name: triggerLabel }).click();
+    await page.getByTestId('condition-term-value-0').click();
+    await page.getByRole('option', { name: optionValue, exact: true }).click();
+
+    // THEN: action type to Hide page
+    await page.getByTestId('condition-action-type-0').click();
+    await page.getByRole('option', { name: 'Hide page' }).click();
+
+    // Select page
+    await page.getByTestId('condition-action-page-0').click();
+    await page.getByRole('option', { name: pageLabel }).click();
+
+    const save = page.getByTestId('condition-save');
+    await expect(save).toBeEnabled({ timeout: 5_000 });
+    await save.click();
+    await page.waitForTimeout(1000);
+  }
+);
+
+/**
+ * Assert a condition rule card is visible in specified session
+ */
+Then(
+  'In session {string} I should see a condition rule card for {string}',
+  async function (this: CustomWorld, session: string, triggerLabel: string) {
+    const page = getSessionPage(this, session);
+    await expectPoll(async () => {
+      const card = page.locator('[data-testid^="condition-card-"]').filter({ hasText: triggerLabel });
+      return (await card.count()) > 0;
+    }, { message: `Expected to see condition card for ${triggerLabel} in session ${session}`, timeout: 15_000 });
+  }
+);
+
+/**
+ * Assert condition rule card summary in specified session
+ */
+Then(
+  'In session {string} the condition card for {string} should show {string} in its summary',
+  async function (this: CustomWorld, session: string, triggerLabel: string, expectedText: string) {
+    const page = getSessionPage(this, session);
+    const card = page.locator('[data-testid^="condition-card-"]').filter({ hasText: triggerLabel }).first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    
+    const textContent = await card.textContent();
+    if (!textContent) throw new Error('Card textContent is empty');
+    
+    const normalize = (str: string) => str.replace(/[\u201c\u201d]/g, '"').replace(/\s+/g, '').trim();
+    
+    const normalizedActual = normalize(textContent);
+    const normalizedExpected = normalize(expectedText);
+    
+    if (!normalizedActual.includes(normalizedExpected)) {
+      throw new Error(`Expected card summary to contain "${normalizedExpected}", but got "${normalizedActual}"`);
+    }
+  }
+);
+
+/**
+ * Toggle condition rule in specified session
+ */
+When(
+  'In session {string} I toggle the condition rule for {string}',
+  async function (this: CustomWorld, session: string, triggerLabel: string) {
+    const page = getSessionPage(this, session);
+    const card = page.locator('[data-testid^="condition-card-"]').filter({ hasText: triggerLabel }).first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    const toggle = card.locator('[data-testid^="condition-toggle-"]');
+    await toggle.click();
+    await page.waitForTimeout(1000);
+  }
+);
+
+/**
+ * Assert switch state is disabled (rule is toggled off) in specified session
+ */
+Then(
+  'In session {string} the condition rule switch state should update to disabled',
+  async function (this: CustomWorld, session: string) {
+    const page = getSessionPage(this, session);
+    const toggle = page.locator('[data-testid^="condition-toggle-"]').first();
+    await expectPoll(async () => {
+       const isChecked = await toggle.getAttribute('aria-checked');
+       return isChecked === 'false';
+    }, { message: 'Expected switch to update to disabled', timeout: 15_000 });
+  }
+);
+
+/**
+ * Delete condition rule in specified session
+ */
+When(
+  'In session {string} I delete the condition rule for {string}',
+  async function (this: CustomWorld, session: string, triggerLabel: string) {
+    const page = getSessionPage(this, session);
+    const card = page.locator('[data-testid^="condition-card-"]').filter({ hasText: triggerLabel }).first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    const deleteBtn = card.locator('[data-testid^="condition-delete-"]');
+    await deleteBtn.click();
+    await page.waitForTimeout(1000);
+  }
+);
+
+/**
+ * Assert conditions empty state is visible in specified session
+ */
+Then(
+  'In session {string} I should see the conditions empty state',
+  async function (this: CustomWorld, session: string) {
+    const page = getSessionPage(this, session);
+    await expect(page.getByTestId('conditions-empty-state')).toBeVisible({ timeout: 15_000 });
+  }
+);
+
+/**
+ * Edit condition rule in specified session
+ */
+When(
+  'In session {string} I edit the condition rule for {string}',
+  async function (this: CustomWorld, session: string, triggerLabel: string) {
+    const page = getSessionPage(this, session);
+    const card = page.locator('[data-testid^="condition-card-"]').filter({ hasText: triggerLabel }).first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    const editBtn = card.locator('[data-testid^="condition-edit-"]');
+    await editBtn.click();
+  }
+);
+
+/**
+ * Update rule terms in specified session
+ */
+When(
+  'In session {string} I update the rule terms at index {int} to field {string}, operator {string}, value {string}',
+  async function (this: CustomWorld, session: string, index: number, fieldLabel: string, operatorKey: string, value: string) {
+    const page = getSessionPage(this, session);
+    
+    // Select field
+    await page.getByTestId(`condition-term-field-${index}`).click();
+    await page.getByRole('option', { name: fieldLabel }).click();
+
+    // Select operator
+    const operatorLabels: Record<string, string> = {
+      equals: 'is equal to',
+      notEquals: 'is not equal to',
+      contains: 'contains',
+      notContains: 'does not contain',
+      startsWith: 'starts with',
+      endsWith: 'ends with',
+      isEmpty: 'is empty',
+      isFilled: 'is filled',
+      lessThan: 'is less than',
+      greaterThan: 'is greater than',
+      before: 'is before',
+      after: 'is after',
+    };
+    const opLabel = operatorLabels[operatorKey] || operatorKey;
+
+    await page.getByTestId(`condition-term-operator-${index}`).click();
+    await page.getByRole('option', { name: opLabel }).click();
+
+    // Select/fill value
+    const valInput = page.getByTestId(`condition-term-value-${index}`);
+    const tagName = await valInput.evaluate(el => el.tagName.toLowerCase());
+    if (tagName === 'button') {
+      await valInput.click();
+      await page.getByRole('option', { name: value, exact: true }).click();
+    } else {
+      await valInput.fill(value);
+    }
+  }
+);
+
+/**
+ * Update rule action in specified session
+ */
+When(
+  'In session {string} I update the rule action at index {int} to type {string} and target field {string}',
+  async function (this: CustomWorld, session: string, index: number, actionTypeKey: string, targetFieldId: string) {
+    const page = getSessionPage(this, session);
+
+    const actionLabels: Record<string, string> = {
+      showField: 'Show field(s)',
+      hideField: 'Hide field(s)',
+      hidePage: 'Hide page',
+    };
+    const actLabel = actionLabels[actionTypeKey] || actionTypeKey;
+
+    await page.getByTestId(`condition-action-type-${index}`).click();
+    await page.getByRole('option', { name: actLabel }).click();
+
+    const checkbox = page.getByTestId(`condition-action-target-${index}-${targetFieldId}`);
+    const isChecked = await checkbox.isChecked();
+    if (!isChecked) {
+      await checkbox.click();
+    }
+  }
+);
+
+/**
+ * Save condition rule in specified session
+ */
+When(
+  'In session {string} I save the condition rule',
+  async function (this: CustomWorld, session: string) {
+    const page = getSessionPage(this, session);
+    const saveBtn = page.getByTestId('condition-save');
+    await expect(saveBtn).toBeEnabled({ timeout: 5_000 });
+    await saveBtn.click();
+    await page.waitForTimeout(1000);
+  }
+);
+
+/**
+ * Assert exactly one rule card exists in both sessions
+ */
+Then(
+  'In both sessions there should be exactly one condition rule card for {string}',
+  async function (this: CustomWorld, triggerLabel: string) {
+    if (!this.page || !this.pageB) throw new Error('Both pages must be initialized');
+
+    // Wait for sync to settle
+    await this.page.waitForTimeout(1000);
+    await this.pageB.waitForTimeout(1000);
+
+    const countA = await this.page.locator('[data-testid^="condition-card-"]').filter({ hasText: triggerLabel }).count();
+    const countB = await this.pageB.locator('[data-testid^="condition-card-"]').filter({ hasText: triggerLabel }).count();
+
+    expect(countA).toBe(1);
+    expect(countB).toBe(1);
+  }
+);
+
+/**
+ * Assert the rule card matches one of the two writes in both sessions
+ */
+Then(
+  'In both sessions that rule card\'s summary should equal one of the two writes',
+  async function (this: CustomWorld) {
+    if (!this.page || !this.pageB) throw new Error('Both pages must be initialized');
+
+    const cardA = this.page.locator('[data-testid^="condition-card-"]').first();
+    const cardB = this.pageB.locator('[data-testid^="condition-card-"]').first();
+
+    const textA = await cardA.textContent();
+    const textB = await cardB.textContent();
+
+    if (!textA || !textB) throw new Error('Rule card summary text is empty');
+
+    const normalize = (str: string) => str.replace(/[\u201c\u201d]/g, '"').replace(/\s+/g, '').trim();
+
+    const normA = normalize(textA);
+    const normB = normalize(textB);
+
+    // Both sessions must have exactly the SAME content due to Y.js convergence
+    expect(normA).toBe(normB);
+
+    const expected1 = normalize('IF Show bonus field? is equal to "No" THEN Show field(s) Bonus Field');
+    const expected2 = normalize('IF Show bonus field? is not equal to "Yes" THEN Show field(s) Bonus Field');
+
+    const matchesOneOfWrites = normA.includes(expected1) || normA.includes(expected2);
+    expect(matchesOneOfWrites).toBe(true);
+  }
+);
+
+/**
+ * Open the page builder tab in specified session
+ */
+When(
+  'In session {string} I open the page builder tab',
+  async function (this: CustomWorld, session: string) {
+    const page = getSessionPage(this, session);
+    await page.getByTestId('tab-page-builder').click();
+    await page.waitForTimeout(1000);
+  }
+);
+
+/**
+ * Delete a field in the builder in specified session
+ */
+When(
+  'In session {string} I delete the field {string} in the builder',
+  async function (this: CustomWorld, session: string, fieldId: string) {
+    const page = getSessionPage(this, session);
+    const card = page.getByTestId(`draggable-field-${fieldId}`);
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    const deleteBtn = card.getByTitle('Delete field');
+    await deleteBtn.click({ force: true });
+    await expect(card).toHaveCount(0, { timeout: 10_000 });
+    await page.waitForTimeout(1000);
+  }
+);
+
+/**
+ * Assert a broken reference badge exists in specified session
+ */
+Then(
+  'In session {string} I should see a broken reference badge for the rule {string}',
+  async function (this: CustomWorld, session: string, triggerLabel: string) {
+    const page = getSessionPage(this, session);
+    let card = page.locator('[data-testid^="condition-card-"]').filter({ hasText: triggerLabel });
+    if (await card.count() === 0) {
+      card = page.locator('[data-testid^="condition-card-"]').filter({
+        has: page.locator(':text("deleted field"), :text("நீக்கப்பட்ட புலம்")')
+      }).first();
+    }
+    await expect(card).toBeVisible({ timeout: 15_000 });
+    const brokenBadge = card.locator('[data-testid^="condition-broken-"]');
+    await expect(brokenBadge).toBeVisible({ timeout: 15_000 });
+  }
+);

--- a/test/e2e/steps/conditional-logic-collab.steps.ts
+++ b/test/e2e/steps/conditional-logic-collab.steps.ts
@@ -7,6 +7,7 @@ import { expect, type Page } from '@playwright/test';
 import { CustomWorld } from '../support/world';
 import { STORAGE_STATE_PATH } from '../support/authStorage';
 import { expectPoll } from '../support/expectPoll';
+import { attachDiagnostics } from '../support/diagnostics';
 
 /**
  * Get the Playwright Page object for the specified session name
@@ -44,6 +45,7 @@ Given('I open two collaborative builder sessions on the conditions tab', async f
     viewport: { width: 1280, height: 720 },
   });
   this.pageB = await this.contextB.newPage();
+  attachDiagnostics(this, this.pageB, 'pageB');
   
   // Navigate session B to conditions tab
   await this.pageB.goto(`${this.baseUrl}/dashboard/form/${this.currentFormId}/builder/conditions`);
@@ -309,49 +311,56 @@ When(
 Then(
   'In both sessions there should be exactly one condition rule card for {string}',
   async function (this: CustomWorld, triggerLabel: string) {
-    if (!this.page || !this.pageB) throw new Error('Both pages must be initialized');
+    const pageA = this.page;
+    const pageB = this.pageB;
+    if (!pageA || !pageB) throw new Error('Both pages must be initialized');
 
-    // Wait for sync to settle
-    await this.page.waitForTimeout(1000);
-    await this.pageB.waitForTimeout(1000);
+    // Poll until both sessions have exactly one card
+    await expectPoll(async () => {
+      const countA = await pageA.locator('[data-testid^="condition-card-"]').count();
+      const countB = await pageB.locator('[data-testid^="condition-card-"]').count();
+      return countA === 1 && countB === 1;
+    }, { message: 'Expected exactly one condition card in both sessions', timeout: 15_000 });
 
-    const countA = await this.page.locator('[data-testid^="condition-card-"]').filter({ hasText: triggerLabel }).count();
-    const countB = await this.pageB.locator('[data-testid^="condition-card-"]').filter({ hasText: triggerLabel }).count();
-
+    const countA = await pageA.locator('[data-testid^="condition-card-"]').count();
+    const countB = await pageB.locator('[data-testid^="condition-card-"]').count();
     expect(countA).toBe(1);
     expect(countB).toBe(1);
   }
 );
 
 /**
- * Assert the rule card matches one of the two writes in both sessions
+ * Assert the rule card matches B's final write in both sessions
  */
 Then(
   'In both sessions that rule card\'s summary should equal one of the two writes',
   async function (this: CustomWorld) {
-    if (!this.page || !this.pageB) throw new Error('Both pages must be initialized');
+    const pageA = this.page;
+    const pageB = this.pageB;
+    if (!pageA || !pageB) throw new Error('Both pages must be initialized');
 
-    const cardA = this.page.locator('[data-testid^="condition-card-"]').first();
-    const cardB = this.pageB.locator('[data-testid^="condition-card-"]').first();
+    const cardA = pageA.locator('[data-testid^="condition-card-"]').first();
+    const cardB = pageB.locator('[data-testid^="condition-card-"]').first();
+
+    const expectedB = 'IF Show bonus field? is not equal to "Yes" THEN Show field(s) Bonus Field';
+    const normalize = (str: string) => str.replace(/[\u201c\u201d]/g, '"').replace(/\s+/g, '').trim();
+    const normExpected = normalize(expectedB);
+
+    await expectPoll(async () => {
+      const textA = await cardA.textContent();
+      const textB = await cardB.textContent();
+      if (!textA || !textB) return false;
+      const normA = normalize(textA);
+      const normB = normalize(textB);
+      return normA === normB && normA.includes(normExpected);
+    }, { message: 'Expected both rule cards to converge and match Session B\'s write', timeout: 15_000 });
 
     const textA = await cardA.textContent();
     const textB = await cardB.textContent();
-
-    if (!textA || !textB) throw new Error('Rule card summary text is empty');
-
-    const normalize = (str: string) => str.replace(/[\u201c\u201d]/g, '"').replace(/\s+/g, '').trim();
-
-    const normA = normalize(textA);
-    const normB = normalize(textB);
-
-    // Both sessions must have exactly the SAME content due to Y.js convergence
+    const normA = normalize(textA || '');
+    const normB = normalize(textB || '');
     expect(normA).toBe(normB);
-
-    const expected1 = normalize('IF Show bonus field? is equal to "No" THEN Show field(s) Bonus Field');
-    const expected2 = normalize('IF Show bonus field? is not equal to "Yes" THEN Show field(s) Bonus Field');
-
-    const matchesOneOfWrites = normA.includes(expected1) || normA.includes(expected2);
-    expect(matchesOneOfWrites).toBe(true);
+    expect(normA).toContain(normExpected);
   }
 );
 

--- a/test/e2e/steps/conditional-logic-collab.steps.ts
+++ b/test/e2e/steps/conditional-logic-collab.steps.ts
@@ -333,7 +333,7 @@ Then(
  * Assert the rule card matches B's final write in both sessions
  */
 Then(
-  'In both sessions that rule card\'s summary should equal one of the two writes',
+  'In both sessions that rule card\'s summary should equal session B\'s write',
   async function (this: CustomWorld) {
     const pageA = this.page;
     const pageB = this.pageB;

--- a/test/e2e/support/hooks.ts
+++ b/test/e2e/support/hooks.ts
@@ -40,10 +40,18 @@ After(async function (this: CustomWorld, scenario) {
       console.log(`Viewer page at URL: ${viewerUrl}`);
     }
 
+    if (this.pageB && !this.pageB.isClosed()) {
+      const pageBScreenshotPath = `test-results/e2e/screenshots/${slug}.pageB.png`;
+      await this.pageB.screenshot({ path: pageBScreenshotPath, fullPage: true }).catch(() => {});
+      console.log(`PageB screenshot saved to: ${pageBScreenshotPath}`);
+      console.log(`PageB at URL: ${this.pageB.url()}`);
+    }
+
     const diagPath = `test-results/e2e/screenshots/${slug}.diagnostics.log`;
     const diagContent = [
       `Main page URL: ${this.page?.url()}`,
       `Viewer page URL: ${viewerUrl ?? '(no viewer page opened)'}`,
+      `PageB URL: ${this.pageB && !this.pageB.isClosed() ? this.pageB.url() : '(no pageB opened)'}`,
       '--- console ---',
       ...this.consoleLogs,
       '--- network failures / 4xx+5xx ---',
@@ -54,7 +62,9 @@ After(async function (this: CustomWorld, scenario) {
   }
 
   await this.page?.close();
+  await this.pageB?.close();
   await this.viewerPage?.close();
   await this.context?.close();
+  await this.contextB?.close();
   await this.browser?.close();
 });

--- a/test/e2e/support/world.ts
+++ b/test/e2e/support/world.ts
@@ -14,6 +14,8 @@ export class CustomWorld {
   /** Set by createFormViaGraphQL — the form the current scenario is exercising */
   currentFormId?: string;
   viewerPage?: Page;
+  contextB?: BrowserContext;
+  pageB?: Page;
   expectedFieldSettings?: Record<string, any>;
   massResponseSuccessCount?: number;
   consoleLogs: string[] = [];


### PR DESCRIPTION
Closes #136. Part of Epic #130.

## Description
This PR adds E2E integration test coverage verifying the real-time collaboration of condition rules between two concurrent builder sessions. It uses Playwright to open two browser contexts (Session A and Session B) pointing to the conditions tab of the same form, and asserts that rule actions immediately sync across sessions (IF/THEN card updates, switch toggle states, deletion, concurrent edits, and cross-session broken reference badges) via Hocuspocus/Y.js.

Scenarios covered:
1. **Create syncs**: add a rule in session A → card appears in session B without reload.
2. **Toggle + delete sync**: disable in A → switch state updates in B; delete in B → card disappears in A.
3. **Concurrent edits to different rules** both survive: A edits rule 1's value while B edits rule 2's target → both changes present in both sessions afterwards.
4. **Same-rule concurrent edit** resolves last-writer-wins without corruption: A and B edit rule 1 near-simultaneously → afterwards both sessions show ONE rule 1 whose content equals one of the two writes.
5. **Cross-session broken reference**: A deletes the trigger field in the Builder tab → B's Conditions tab shows the broken badge without reload.

## Validation
- Verified type check locally.
- Verified all 33 scenarios under conditional logic (standard, data-integrity, triggers, page-edges, and collaboration) pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new end-to-end Gherkin coverage for real-time collaboration in conditional logic, including rule creation syncing across two sessions, cross-session toggling/deletion, concurrent edits to different rules, last-writer-wins conflict behavior, and UI validation for broken references after a referenced field is removed elsewhere.
  * Expanded E2E step coverage to drive two simultaneous builder sessions and assert synchronized condition-card content.
  * Improved failure diagnostics and cleanup by capturing/logging the secondary session’s URL/screenshot and closing the additional page/context safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->