### PR TITLE
Builder rail: per-step health badges — field count, circular-ref warning, Finish status (v1.5)

### DIFF
--- a/apps/form-app/src/components/form-builder/conditions/ConditionsTab.tsx
+++ b/apps/form-app/src/components/form-builder/conditions/ConditionsTab.tsx
@@ -1,10 +1,11 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { GitBranch, Plus, Sparkles } from 'lucide-react';
 import { Button, Input, toastSuccess } from '@dculus/ui';
-import { ConditionalRule, detectConditionCycles } from '@dculus/types';
+import { ConditionalRule } from '@dculus/types';
 import { useFormBuilderStore } from '../../../store/useFormBuilderStore';
 import { useFormPermissions } from '../../../hooks/useFormPermissions';
 import { useTranslation } from '../../../hooks/useTranslation';
+import { useConditionCycles } from '../../../hooks/useConditionCycles';
 import { ConditionRuleCard } from './ConditionRuleCard';
 import { ConditionRuleEditor } from './ConditionRuleEditor';
 
@@ -30,10 +31,7 @@ export const ConditionsTab: React.FC<{ onDescribeWithAI: (description: string) =
   const permissions = useFormPermissions();
   const canEdit = permissions.canEditFields();
 
-  const circularRuleIds = useMemo(() => {
-    const cycles = detectConditionCycles(conditions, { pages });
-    return new Set(cycles.flatMap((c) => c.ruleIds));
-  }, [conditions, pages]);
+  const circularRuleIds = useConditionCycles(conditions, pages);
 
   const openCreate = () => {
     setEditingRule(null);

--- a/apps/form-app/src/components/form-builder/tabs/TabNavigation.tsx
+++ b/apps/form-app/src/components/form-builder/tabs/TabNavigation.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router';
-import { Palette, FileText, Eye, GitBranch, Settings, CheckCircle, Users } from 'lucide-react';
-import { Button, Tabs, TabsList, TabsTrigger } from '@dculus/ui';
+import { Palette, FileText, Eye, GitBranch, Settings, CheckCircle, Users, AlertTriangle } from 'lucide-react';
+import { Button, Tabs, TabsList, TabsTrigger, Badge } from '@dculus/ui';
 import { cn } from '@dculus/utils';
 import { useTranslation } from '../../../hooks/useTranslation';
 
@@ -71,6 +71,12 @@ interface TabNavigationProps {
   collaboratorCount?: number;
   className?: string;
   position?: 'top' | 'bottom' | 'inline';
+  /** Total placed fields across all pages — rendered as a count badge on the Build step. See #167. */
+  buildFieldCount?: number;
+  /** Whether any condition rule has a circular reference — rendered as a warning badge on the Logic step. See #167. */
+  logicHasWarning?: boolean;
+  /** Whether the Thank You message has been customized (vs. still default) — rendered on the Finish step. See #167. */
+  finishIsCustomized?: boolean;
 }
 
 export const TabNavigation: React.FC<TabNavigationProps> = ({
@@ -79,6 +85,9 @@ export const TabNavigation: React.FC<TabNavigationProps> = ({
   collaboratorCount = 0,
   className = '',
   position = 'bottom',
+  buildFieldCount,
+  logicHasWarning = false,
+  finishIsCustomized = false,
 }) => {
   const navigate = useNavigate();
   const { formId } = useParams<{ formId: string }>();
@@ -152,6 +161,49 @@ export const TabNavigation: React.FC<TabNavigationProps> = ({
                 >
                   <tab.icon className="w-3.5 h-3.5 shrink-0" />
                   <span>{tab.label}</span>
+                  {tab.id === 'page-builder' && typeof buildFieldCount === 'number' && (
+                    <Badge
+                      variant="outline"
+                      className="px-1.5 py-0 text-[10px] leading-4 min-w-[1.25rem] justify-center"
+                      title={t(
+                        buildFieldCount === 1
+                          ? 'badges.build.fieldCount.single'
+                          : 'badges.build.fieldCount.multiple',
+                        { values: { count: buildFieldCount } }
+                      )}
+                      data-testid="tab-badge-build-count"
+                    >
+                      {buildFieldCount}
+                    </Badge>
+                  )}
+                  {tab.id === 'conditions' && logicHasWarning && (
+                    <Badge
+                      variant="outline"
+                      className="gap-0.5 px-1.5 py-0 text-[10px] leading-4 bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-400 dark:border-amber-800"
+                      title={t('badges.logic.warning')}
+                      data-testid="tab-badge-logic-warning"
+                    >
+                      <AlertTriangle className="w-2.5 h-2.5 text-amber-600 dark:text-amber-400" />
+                    </Badge>
+                  )}
+                  {tab.id === 'finish' && (
+                    <Badge
+                      variant={finishIsCustomized ? 'accent' : 'outline'}
+                      className={cn(
+                        'px-1.5 py-0 text-[10px] leading-4',
+                        !finishIsCustomized &&
+                          'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-400 dark:border-amber-800'
+                      )}
+                      title={
+                        finishIsCustomized
+                          ? t('badges.finish.customized')
+                          : t('badges.finish.default')
+                      }
+                      data-testid="tab-badge-finish-status"
+                    >
+                      {finishIsCustomized ? t('badges.finish.customized') : t('badges.finish.default')}
+                    </Badge>
+                  )}
                 </TabsTrigger>
               </React.Fragment>
             ))}

--- a/apps/form-app/src/components/form-builder/tabs/TabNavigation.tsx
+++ b/apps/form-app/src/components/form-builder/tabs/TabNavigation.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router';
 import { Palette, FileText, Eye, GitBranch, Settings, CheckCircle, Users, AlertTriangle } from 'lucide-react';
-import { Button, Tabs, TabsList, TabsTrigger, Badge } from '@dculus/ui';
+import { Button, Tabs, TabsList, TabsTrigger, badgeVariants } from '@dculus/ui';
 import { cn } from '@dculus/utils';
 import { useTranslation } from '../../../hooks/useTranslation';
 
@@ -162,9 +162,11 @@ export const TabNavigation: React.FC<TabNavigationProps> = ({
                   <tab.icon className="w-3.5 h-3.5 shrink-0" />
                   <span>{tab.label}</span>
                   {tab.id === 'page-builder' && typeof buildFieldCount === 'number' && (
-                    <Badge
-                      variant="outline"
-                      className="px-1.5 py-0 text-[10px] leading-4 min-w-[1.25rem] justify-center"
+                    <span
+                      className={cn(
+                        badgeVariants({ variant: 'outline' }),
+                        'px-1.5 py-0 text-[10px] leading-4 min-w-[1.25rem] justify-center'
+                      )}
                       title={t(
                         buildFieldCount === 1
                           ? 'badges.build.fieldCount.single'
@@ -174,22 +176,25 @@ export const TabNavigation: React.FC<TabNavigationProps> = ({
                       data-testid="tab-badge-build-count"
                     >
                       {buildFieldCount}
-                    </Badge>
+                    </span>
                   )}
                   {tab.id === 'conditions' && logicHasWarning && (
-                    <Badge
-                      variant="outline"
-                      className="gap-0.5 px-1.5 py-0 text-[10px] leading-4 bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-400 dark:border-amber-800"
+                    <span
+                      className={cn(
+                        badgeVariants({ variant: 'outline' }),
+                        'gap-0.5 px-1.5 py-0 text-[10px] leading-4 bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-400 dark:border-amber-800'
+                      )}
                       title={t('badges.logic.warning')}
                       data-testid="tab-badge-logic-warning"
                     >
                       <AlertTriangle className="w-2.5 h-2.5 text-amber-600 dark:text-amber-400" />
-                    </Badge>
+                      <span className="sr-only">{t('badges.logic.warning')}</span>
+                    </span>
                   )}
                   {tab.id === 'finish' && (
-                    <Badge
-                      variant={finishIsCustomized ? 'accent' : 'outline'}
+                    <span
                       className={cn(
+                        badgeVariants({ variant: finishIsCustomized ? 'accent' : 'outline' }),
                         'px-1.5 py-0 text-[10px] leading-4',
                         !finishIsCustomized &&
                           'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-400 dark:border-amber-800'
@@ -202,7 +207,7 @@ export const TabNavigation: React.FC<TabNavigationProps> = ({
                       data-testid="tab-badge-finish-status"
                     >
                       {finishIsCustomized ? t('badges.finish.customized') : t('badges.finish.default')}
-                    </Badge>
+                    </span>
                   )}
                 </TabsTrigger>
               </React.Fragment>

--- a/apps/form-app/src/hooks/useConditionCycles.ts
+++ b/apps/form-app/src/hooks/useConditionCycles.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import { ConditionalRule, FormPage, detectConditionCycles } from '@dculus/types';
+
+/**
+ * Shared cycle-detection selector — used by both ConditionsTab (per-rule circular
+ * badges) and the builder rail (Logic tab warning badge) so there's a single
+ * source of truth for what counts as a circular reference. See issue #167.
+ */
+export const useConditionCycles = (
+  conditions: ConditionalRule[],
+  pages: FormPage[]
+): Set<string> => {
+  return useMemo(() => {
+    const cycles = detectConditionCycles(conditions, { pages });
+    return new Set(cycles.flatMap((c) => c.ruleIds));
+  }, [conditions, pages]);
+};

--- a/apps/form-app/src/locales/en/tabNavigation.json
+++ b/apps/form-app/src/locales/en/tabNavigation.json
@@ -35,5 +35,20 @@
   },
   "aria": {
     "switchToTab": "Switch to {{label}} tab - {{description}}"
+  },
+  "badges": {
+    "build": {
+      "fieldCount": {
+        "single": "{{count}} field placed",
+        "multiple": "{{count}} fields placed"
+      }
+    },
+    "logic": {
+      "warning": "One or more condition rules have a circular reference"
+    },
+    "finish": {
+      "default": "Default",
+      "customized": "Customized"
+    }
   }
 }

--- a/apps/form-app/src/locales/ta/tabNavigation.json
+++ b/apps/form-app/src/locales/ta/tabNavigation.json
@@ -35,5 +35,20 @@
   },
   "aria": {
     "switchToTab": "{{label}} தாவலுக்கு மாறவும் - {{description}}"
+  },
+  "badges": {
+    "build": {
+      "fieldCount": {
+        "single": "{{count}} புலம் வைக்கப்பட்டது",
+        "multiple": "{{count}} புலங்கள் வைக்கப்பட்டன"
+      }
+    },
+    "logic": {
+      "warning": "ஒன்று அல்லது அதற்கு மேற்பட்ட நிபந்தனை விதிகளில் வட்ட குறிப்பு உள்ளது"
+    },
+    "finish": {
+      "default": "இயல்பு",
+      "customized": "தனிப்பயனாக்கப்பட்டது"
+    }
   }
 }

--- a/apps/form-app/src/pages/CollaborativeFormBuilder.tsx
+++ b/apps/form-app/src/pages/CollaborativeFormBuilder.tsx
@@ -41,6 +41,7 @@ import { ConditionsTab } from '../components/form-builder/conditions/ConditionsT
 import { useDragAndDrop } from '../hooks/useDragAndDrop';
 import { useCollisionDetection } from '../hooks/useCollisionDetection';
 import { useFieldCreation } from '../hooks/useFieldCreation';
+import { useConditionCycles } from '../hooks/useConditionCycles';
 import { GET_FORM_BY_ID } from '../graphql/queries';
 import { UPDATE_FORM } from '../graphql/mutations';
 import AIEditDrawer from '../components/form-builder/AIEditDrawer';
@@ -101,6 +102,7 @@ const CollaborativeFormBuilder: React.FC<CollaborativeFormBuilderProps> = ({
     isCollaborationFailed,
     pages,
     selectedPageId,
+    conditions,
 
     initializeCollaboration,
     disconnectCollaboration,
@@ -116,6 +118,17 @@ const CollaborativeFormBuilder: React.FC<CollaborativeFormBuilderProps> = ({
 
     updateLayout,
   } = useFormBuilderStore();
+
+  // Builder rail health badges — Build field count, Logic circular-ref warning,
+  // Finish default-vs-customized status. See #167.
+  const totalFieldCount = useMemo(
+    () => pages.reduce((sum, p) => sum + p.fields.length, 0),
+    [pages]
+  );
+  const circularRuleIds = useConditionCycles(conditions, pages);
+  const logicHasWarning = circularRuleIds.size > 0;
+  const thankYou = formData?.form?.settings?.thankYou;
+  const finishIsCustomized = Boolean(thankYou?.enabled && thankYou?.message?.trim().length);
 
   const { createFieldData } = useFieldCreation();
   const collisionDetectionStrategy = useCollisionDetection();
@@ -494,6 +507,9 @@ const CollaborativeFormBuilder: React.FC<CollaborativeFormBuilderProps> = ({
                   isConnected={isConnected}
                   collaboratorCount={0}
                   position="inline"
+                  buildFieldCount={totalFieldCount}
+                  logicHasWarning={logicHasWarning}
+                  finishIsCustomized={finishIsCustomized}
                 />
               }
             />

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,5 @@
 export { Button, buttonVariants } from "./button"
-export { Badge } from "./badge"
+export { Badge, badgeVariants } from "./badge"
 export { Chip } from "./chip"
 export { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "./accordion"
 export { Progress } from "./progress"

--- a/test/e2e/features/conditional-logic.feature
+++ b/test/e2e/features/conditional-logic.feature
@@ -162,5 +162,9 @@ Feature: Conditional Logic (show/hide fields and pages)
     When I add a rule showing "cond-bonus" when "Show bonus field?" is equal to "Yes"
     Then I should see a condition rule card for "Show bonus field?"
     And I should not see a circular reference warning badge for the rule "Show bonus field?"
+    And I should not see a logic rail warning badge
     When I add a self-hiding rule for field "cond-bonus" when filled
     Then I should see a circular reference warning badge for the rule "Bonus Field"
+    And I should see a logic rail warning badge
+    When I disable the rule causing the circular reference
+    Then I should not see a logic rail warning badge

--- a/test/e2e/steps/conditional-logic.steps.ts
+++ b/test/e2e/steps/conditional-logic.steps.ts
@@ -1527,3 +1527,28 @@ Then(
     await expect(badge).toHaveCount(0, { timeout: 5_000 });
   }
 );
+
+// Builder rail Logic warning badge — see #167. Reuses the same rule-cycle setup as
+// the per-card circular-reference badge above; asserts the rail-level indicator too.
+Then('I should see a logic rail warning badge', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  const badge = this.page.getByTestId('tab-badge-logic-warning');
+  await expect(badge).toBeVisible({ timeout: 10_000 });
+});
+
+Then('I should not see a logic rail warning badge', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  const badge = this.page.getByTestId('tab-badge-logic-warning');
+  await expect(badge).toHaveCount(0, { timeout: 5_000 });
+});
+
+When('I disable the rule causing the circular reference', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  const card = this.page
+    .locator('[data-testid^="condition-card-"]')
+    .filter({ has: this.page.locator('[data-testid^="condition-circular-"]') })
+    .first();
+  const toggle = card.locator('[data-testid^="condition-toggle-"]');
+  await toggle.click();
+  await this.page.waitForTimeout(500);
+});


### PR DESCRIPTION
## Summary
- Adds three always-visible health indicators to the builder journey rail (see epic #170): a **Build** field-count badge, a **Logic** circular-reference warning badge, and a **Finish** default-vs-customized badge.
- Extracted `detectConditionCycles` cycle computation into a shared `useConditionCycles` hook, used by both `ConditionsTab` (per-rule badges) and `CollaborativeFormBuilder` (rail badge) — no duplicated cycle-detection logic.
- Badges reuse `packages/ui/src/badge.tsx`'s existing `Badge`/`badgeVariants` and the amber + `AlertTriangle` pattern already used in `ConditionRuleCard.tsx` for circular-reference warnings.
- Extended the existing `Circular-reference warning badge` E2E scenario in `conditional-logic.feature` to also assert the rail badge appears/disappears, reusing the existing rule-cycle test fixture (no new fixture).
- Added en/ta translations for the new badge labels.

## Test plan
- [x] `pnpm type-check` passes across the full workspace
- [x] `pnpm lint` passes (0 errors)
- [x] E2E: extended `Circular-reference warning badge` scenario passed cleanly (verified in a full local suite run — 79/83 scenarios passed, the 4 failures were pre-existing/unrelated `response-filters.feature` flakes)
- [x] Pre-push hook (build + backend/form-viewer unit tests) passed

Closes #167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status badges to the form builder navigation rail:
    * Field counts for the Build step.
    * Circular-logic warnings for the Conditions step.
    * Default or Customized status for the Finish step.
  * Added localized badge text in English and Tamil.

* **Bug Fixes**
  * Improved detection and display of circular conditional-logic warnings.

* **Tests**
  * Added end-to-end coverage for displaying and clearing logic warning badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->