### PR TITLE
Speed up E2E test suite: reuse browser per worker, parallelize CI frontend builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -518,19 +518,30 @@ jobs:
           done
           echo "❌ Backend failed to start" && exit 1
 
-      - name: Build & serve form-app (localhost:3000)
+      - name: Build form-app & form-viewer (parallel)
         run: |
-          VITE_API_URL=http://localhost:4000 \
-          VITE_GRAPHQL_URL=http://localhost:4000/graphql \
-          VITE_FORM_VIEWER_URL=http://localhost:5173 \
-          pnpm --filter form-app build
-          pnpm --filter form-app preview --port 3000 --host &
+          set -e
+          (
+            VITE_API_URL=http://localhost:4000 \
+            VITE_GRAPHQL_URL=http://localhost:4000/graphql \
+            VITE_FORM_VIEWER_URL=http://localhost:5173 \
+            pnpm --filter form-app build
+          ) &
+          FORM_APP_PID=$!
 
-      - name: Build & serve form-viewer (localhost:5173)
+          (
+            VITE_API_URL=http://localhost:4000 \
+            VITE_GRAPHQL_URL=http://localhost:4000/graphql \
+            pnpm --filter form-viewer build
+          ) &
+          FORM_VIEWER_PID=$!
+
+          wait $FORM_APP_PID
+          wait $FORM_VIEWER_PID
+
+      - name: Serve form-app & form-viewer
         run: |
-          VITE_API_URL=http://localhost:4000 \
-          VITE_GRAPHQL_URL=http://localhost:4000/graphql \
-          pnpm --filter form-viewer build
+          pnpm --filter form-app preview --port 3000 --host &
           pnpm --filter form-viewer preview --port 5173 --host &
 
       - name: Wait for frontends

--- a/test/e2e/cucumber.js
+++ b/test/e2e/cucumber.js
@@ -9,7 +9,7 @@ module.exports = {
     format: ['progress'],
     paths: ['test/e2e/features/**/*.feature'],
     publishQuiet: true,
-    parallel: 3,
+    parallel: 4,
     retry: 3,
   },
 };

--- a/test/e2e/support/hooks.ts
+++ b/test/e2e/support/hooks.ts
@@ -1,5 +1,5 @@
-import { Before, After, setDefaultTimeout } from '@cucumber/cucumber';
-import { chromium } from 'playwright';
+import { Before, After, BeforeAll, AfterAll, setDefaultTimeout } from '@cucumber/cucumber';
+import { chromium, type Browser } from 'playwright';
 import { writeFileSync, mkdirSync } from 'fs';
 import { CustomWorld } from './world';
 import { hasStoredAuthState, STORAGE_STATE_PATH } from './authStorage';
@@ -7,8 +7,20 @@ import { attachDiagnostics } from './diagnostics';
 
 setDefaultTimeout(120 * 1000);
 
+// One browser per parallel worker process, reused across all scenarios that worker runs.
+// Per-scenario isolation still comes from a fresh BrowserContext (and thus storage/cookies) below.
+let sharedBrowser: Browser;
+
+BeforeAll(async function () {
+  sharedBrowser = await chromium.launch({ headless: process.env.E2E_HEADLESS !== 'false' });
+});
+
+AfterAll(async function () {
+  await sharedBrowser?.close();
+});
+
 Before(async function (this: CustomWorld) {
-  this.browser = await chromium.launch({ headless: this.headless });
+  this.browser = sharedBrowser;
   this.context = await this.browser.newContext({
     baseURL: this.baseUrl,
     storageState: hasStoredAuthState() ? STORAGE_STATE_PATH : undefined,
@@ -66,5 +78,5 @@ After(async function (this: CustomWorld, scenario) {
   await this.viewerPage?.close();
   await this.context?.close();
   await this.contextB?.close();
-  await this.browser?.close();
+  // Note: browser is shared across scenarios in this worker (see BeforeAll) — do not close it here.
 });


### PR DESCRIPTION
## Summary
- The cucumber `Before` hook launched a brand-new Chromium browser process for every scenario (~106 scenarios) instead of once per parallel worker. Switch to `BeforeAll`/`AfterAll` to launch one browser per worker; scenarios still get a fresh `BrowserContext` for isolation.
- Bump `parallel` from 3 to 4 in `test/e2e/cucumber.js`, now safe since browser launches no longer scale with scenario count.
- In the `e2e-local` CI job, form-app and form-viewer builds ran as two sequential steps; they now build concurrently in one step.

## Test plan
- [x] `npx tsc --noEmit -p test/e2e/tsconfig.json` — no new errors from `hooks.ts` changes
- [x] `pnpm build` (form-app, form-viewer, admin-app, backend) — passes
- [ ] Confirm `e2e-local` CI job wall-clock time drops and all scenarios still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test execution by running more scenarios in parallel.
  * Reduced test overhead by sharing a browser across scenarios while preserving isolated test contexts.
  * Retained failure diagnostics, including screenshots and related troubleshooting details.

* **Chores**
  * Streamlined local end-to-end builds by building both front-end applications in parallel before starting preview servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->