### PR TITLE
Replace flat background wash with dominant-color tint sampled from media

### DIFF
--- a/apps/backend/src/services/formService.ts
+++ b/apps/backend/src/services/formService.ts
@@ -111,6 +111,7 @@ export const createForm = async (
       customBackGroundColor: '#ffffff',
       customCTAButtonName: 'Get Started',
       backgroundImageKey: '',
+      backgroundDominantColor: '',
       pageMode: PageModeType.MULTIPAGE,
       isCustomBackgroundColorEnabled: false
     },

--- a/apps/backend/src/services/hocuspocus.ts
+++ b/apps/backend/src/services/hocuspocus.ts
@@ -559,6 +559,7 @@ export const getFormSchemaFromHocuspocus = async (
         convertedLayout.customCTAButtonName = layout.get('customCTAButtonName');
         convertedLayout.backgroundImageKey = layout.get('backgroundImageKey');
         convertedLayout.backgroundVideoKey = layout.get('backgroundVideoKey');
+        convertedLayout.backgroundDominantColor = layout.get('backgroundDominantColor');
         convertedLayout.pageMode = layout.get('pageMode');
         convertedLayout.isCustomBackgroundColorEnabled =
           layout.get('isCustomBackgroundColorEnabled') || false;
@@ -783,6 +784,7 @@ export const initializeHocuspocusDocument = async (
     );
     layoutMap.set('backgroundImageKey', layout.backgroundImageKey || '');
     layoutMap.set('backgroundVideoKey', layout.backgroundVideoKey || '');
+    layoutMap.set('backgroundDominantColor', layout.backgroundDominantColor || '');
     layoutMap.set('pageMode', layout.pageMode || 'multipage');
     layoutMap.set(
       'isCustomBackgroundColorEnabled',

--- a/apps/form-app/src/components/form-builder/tabs/layout/LayoutSidebar.tsx
+++ b/apps/form-app/src/components/form-builder/tabs/layout/LayoutSidebar.tsx
@@ -56,7 +56,10 @@ export const LayoutSidebar: React.FC<LayoutSidebarProps> = ({
 
   const handleApplyBackgroundImage = () => {
     if (selectedImageKey) {
-      onLayoutUpdate({ backgroundImageKey: selectedImageKey, backgroundVideoKey: '' });
+      // No fresh blob available for re-applying an already-uploaded gallery asset, so we
+      // can't sample a new dominant color here — clear the old one rather than showing a
+      // stale/mismatched wash; rendering falls back to the flat tint when this is empty.
+      onLayoutUpdate({ backgroundImageKey: selectedImageKey, backgroundVideoKey: '', backgroundDominantColor: '' });
     }
   };
   return (
@@ -275,7 +278,7 @@ export const LayoutSidebar: React.FC<LayoutSidebarProps> = ({
             {(layout.backgroundImageKey || layout.backgroundVideoKey) && (
               <Button
                 variant="outline"
-                onClick={() => canEditLayout && onLayoutUpdate({ backgroundImageKey: '', backgroundVideoKey: '' })}
+                onClick={() => canEditLayout && onLayoutUpdate({ backgroundImageKey: '', backgroundVideoKey: '', backgroundDominantColor: '' })}
                 disabled={!canEditLayout}
                 className="w-full"
               >
@@ -303,8 +306,8 @@ export const LayoutSidebar: React.FC<LayoutSidebarProps> = ({
         isOpen={isPexelsModalOpen}
         onClose={() => setIsPexelsModalOpen(false)}
         formId={formId}
-        onImageApplied={(imageKey) => onLayoutUpdate({ backgroundImageKey: imageKey, backgroundVideoKey: '' })}
-        onVideoApplied={(videoKey) => onLayoutUpdate({ backgroundVideoKey: videoKey, backgroundImageKey: '' })}
+        onImageApplied={(imageKey, dominantColor) => onLayoutUpdate({ backgroundImageKey: imageKey, backgroundVideoKey: '', backgroundDominantColor: dominantColor })}
+        onVideoApplied={(videoKey, dominantColor) => onLayoutUpdate({ backgroundVideoKey: videoKey, backgroundImageKey: '', backgroundDominantColor: dominantColor })}
         onUploadSuccess={handleImageUploadSuccess}
       />
 
@@ -312,8 +315,8 @@ export const LayoutSidebar: React.FC<LayoutSidebarProps> = ({
         isOpen={isPixabayModalOpen}
         onClose={() => setIsPixabayModalOpen(false)}
         formId={formId}
-        onImageApplied={(imageKey) => onLayoutUpdate({ backgroundImageKey: imageKey, backgroundVideoKey: '' })}
-        onVideoApplied={(videoKey) => onLayoutUpdate({ backgroundVideoKey: videoKey, backgroundImageKey: '' })}
+        onImageApplied={(imageKey, dominantColor) => onLayoutUpdate({ backgroundImageKey: imageKey, backgroundVideoKey: '', backgroundDominantColor: dominantColor })}
+        onVideoApplied={(videoKey, dominantColor) => onLayoutUpdate({ backgroundVideoKey: videoKey, backgroundImageKey: '', backgroundDominantColor: dominantColor })}
         onUploadSuccess={handleImageUploadSuccess}
       />
     </div>

--- a/apps/form-app/src/components/form-builder/tabs/layout/PexelsModal.tsx
+++ b/apps/form-app/src/components/form-builder/tabs/layout/PexelsModal.tsx
@@ -17,8 +17,8 @@ interface PexelsModalProps {
   isOpen: boolean;
   onClose: () => void;
   formId: string;
-  onImageApplied: (imageKey: string) => void;
-  onVideoApplied: (videoKey: string) => void;
+  onImageApplied: (imageKey: string, dominantColor: string) => void;
+  onVideoApplied: (videoKey: string, dominantColor: string) => void;
   onUploadSuccess: () => void;
 }
 
@@ -89,7 +89,7 @@ export function PexelsModal({ isOpen, onClose, formId, onImageApplied, onVideoAp
     try {
       const uploadResult = await downloadPexelsImage(photo.src.large2x, formId);
       toastSuccess(t('imageAppliedSuccess'));
-      onImageApplied(uploadResult.key);
+      onImageApplied(uploadResult.key, uploadResult.dominantColor);
       onUploadSuccess();
       setSelectedImage(null);
       onClose();
@@ -111,7 +111,7 @@ export function PexelsModal({ isOpen, onClose, formId, onImageApplied, onVideoAp
     try {
       const uploadResult = await downloadPexelsVideo(video, formId);
       toastSuccess(t('videoAppliedSuccess'));
-      onVideoApplied(uploadResult.key);
+      onVideoApplied(uploadResult.key, uploadResult.dominantColor);
       onUploadSuccess();
       setSelectedVideo(null);
       onClose();

--- a/apps/form-app/src/components/form-builder/tabs/layout/PixabayModal.tsx
+++ b/apps/form-app/src/components/form-builder/tabs/layout/PixabayModal.tsx
@@ -17,8 +17,8 @@ interface PixabayModalProps {
   isOpen: boolean;
   onClose: () => void;
   formId: string;
-  onImageApplied: (imageKey: string) => void;
-  onVideoApplied: (videoKey: string) => void;
+  onImageApplied: (imageKey: string, dominantColor: string) => void;
+  onVideoApplied: (videoKey: string, dominantColor: string) => void;
   onUploadSuccess: () => void;
 }
 
@@ -89,7 +89,7 @@ export function PixabayModal({ isOpen, onClose, formId, onImageApplied, onVideoA
     try {
       const uploadResult = await downloadPixabayImage(image.fullHDURL ?? image.largeImageURL, formId);
       toastSuccess(t('imageAppliedSuccess'));
-      onImageApplied(uploadResult.key);
+      onImageApplied(uploadResult.key, uploadResult.dominantColor);
       onUploadSuccess();
       setSelectedImage(null);
       onClose();
@@ -111,7 +111,7 @@ export function PixabayModal({ isOpen, onClose, formId, onImageApplied, onVideoA
     try {
       const uploadResult = await downloadPixabayVideo(video, formId);
       toastSuccess(t('videoAppliedSuccess'));
-      onVideoApplied(uploadResult.key);
+      onVideoApplied(uploadResult.key, uploadResult.dominantColor);
       onUploadSuccess();
       setSelectedVideo(null);
       onClose();

--- a/apps/form-app/src/services/pexelsService.ts
+++ b/apps/form-app/src/services/pexelsService.ts
@@ -1,5 +1,6 @@
 import { uploadFileHTTP, UploadError } from './fileUploadService';
 import { getApiBaseUrl } from '../lib/config';
+import { computeDominantColorFromImageBlob, computeDominantColorFromVideoBlob } from '../utils/dominantColor';
 
 export interface PexelsPhoto {
   id: number;
@@ -37,6 +38,10 @@ interface UploadResult {
   type: string;
 }
 
+// dominantColor is sampled once here (client already has the fetched blob in hand)
+// and persisted on FormLayout — never recomputed per render/visitor.
+type BackgroundUploadResult = UploadResult & { dominantColor: string };
+
 export async function searchPexelsImages(
   query: string = 'background',
   page: number = 1,
@@ -62,7 +67,7 @@ export async function searchPexelsImages(
 export async function downloadPexelsImage(
   imageUrl: string,
   formId: string
-): Promise<UploadResult> {
+): Promise<BackgroundUploadResult> {
   const imageResponse = await fetch(imageUrl);
   if (!imageResponse.ok) {
     throw new Error('Failed to fetch image from Pexels');
@@ -72,7 +77,12 @@ export async function downloadPexelsImage(
   const filename = `pexels-${Date.now()}.jpg`;
   const file = new File([imageBlob], filename, { type: imageBlob.type || 'image/jpeg' });
 
-  return uploadFileHTTP(file, 'FormBackground', formId);
+  const [uploadResult, dominantColor] = await Promise.all([
+    uploadFileHTTP(file, 'FormBackground', formId),
+    computeDominantColorFromImageBlob(imageBlob).catch(() => ''),
+  ]);
+
+  return { ...uploadResult, dominantColor };
 }
 
 export interface PexelsVideoFile {
@@ -143,7 +153,7 @@ const MAX_VIDEO_DOWNLOAD_BYTES = 20 * 1024 * 1024;
 export async function downloadPexelsVideo(
   video: PexelsVideo,
   formId: string
-): Promise<UploadResult> {
+): Promise<BackgroundUploadResult> {
   const videoFile = selectSmallestVideoFile(video.video_files);
   if (!videoFile) {
     throw new Error('No downloadable video file found for this Pexels video');
@@ -177,5 +187,10 @@ export async function downloadPexelsVideo(
   const filename = `pexels-${Date.now()}.mp4`;
   const file = new File([videoBlob], filename, { type: videoBlob.type || 'video/mp4' });
 
-  return uploadFileHTTP(file, 'FormBackground', formId);
+  const [uploadResult, dominantColor] = await Promise.all([
+    uploadFileHTTP(file, 'FormBackground', formId),
+    computeDominantColorFromVideoBlob(videoBlob).catch(() => ''),
+  ]);
+
+  return { ...uploadResult, dominantColor };
 }

--- a/apps/form-app/src/services/pixabayService.ts
+++ b/apps/form-app/src/services/pixabayService.ts
@@ -1,5 +1,6 @@
 import { uploadFileHTTP } from './fileUploadService';
 import { getApiBaseUrl } from '../lib/config';
+import { computeDominantColorFromImageBlob, computeDominantColorFromVideoBlob } from '../utils/dominantColor';
 
 interface PixabayImage {
   id: number;
@@ -51,10 +52,14 @@ interface UploadResult {
   type: string;
 }
 
+// dominantColor is sampled once here (client already has the fetched blob in hand)
+// and persisted on FormLayout — never recomputed per render/visitor.
+type BackgroundUploadResult = UploadResult & { dominantColor: string };
+
 export async function downloadPixabayImage(
   imageUrl: string,
   formId: string
-): Promise<UploadResult> {
+): Promise<BackgroundUploadResult> {
   // Fetch the image
   const imageResponse = await fetch(imageUrl);
   if (!imageResponse.ok) {
@@ -67,10 +72,12 @@ export async function downloadPixabayImage(
   // Create a File object from the blob
   const file = new File([imageBlob], filename, { type: imageBlob.type });
 
-  // Use the existing upload service
-  const result = await uploadFileHTTP(file, 'FormBackground', formId);
+  const [uploadResult, dominantColor] = await Promise.all([
+    uploadFileHTTP(file, 'FormBackground', formId),
+    computeDominantColorFromImageBlob(imageBlob).catch(() => ''),
+  ]);
 
-  return result;
+  return { ...uploadResult, dominantColor };
 }
 
 interface PixabayVideoRendition {
@@ -138,7 +145,7 @@ function selectSmallestVideoRendition(videos: PixabayVideo['videos']): PixabayVi
 export async function downloadPixabayVideo(
   video: PixabayVideo,
   formId: string
-): Promise<UploadResult> {
+): Promise<BackgroundUploadResult> {
   const rendition = selectSmallestVideoRendition(video.videos);
   if (!rendition) {
     throw new Error('No downloadable video rendition found for this Pixabay video');
@@ -153,7 +160,12 @@ export async function downloadPixabayVideo(
   const filename = `pixabay-${Date.now()}.mp4`;
   const file = new File([videoBlob], filename, { type: videoBlob.type || 'video/mp4' });
 
-  return uploadFileHTTP(file, 'FormBackground', formId);
+  const [uploadResult, dominantColor] = await Promise.all([
+    uploadFileHTTP(file, 'FormBackground', formId),
+    computeDominantColorFromVideoBlob(videoBlob).catch(() => ''),
+  ]);
+
+  return { ...uploadResult, dominantColor };
 }
 
 export type { PixabayImage, PixabayResponse, PixabayVideo, PixabayVideoResponse };

--- a/apps/form-app/src/store/collaboration/CollaborationManager.ts
+++ b/apps/form-app/src/store/collaboration/CollaborationManager.ts
@@ -491,6 +491,8 @@ export class CollaborationManager {
           layoutMap.get('customCTAButtonName') || DEFAULT_LAYOUT.customCTAButtonName,
         backgroundImageKey: layoutMap.get('backgroundImageKey') || DEFAULT_LAYOUT.backgroundImageKey,
         backgroundVideoKey: layoutMap.get('backgroundVideoKey') || DEFAULT_LAYOUT.backgroundVideoKey,
+        backgroundDominantColor:
+          layoutMap.get('backgroundDominantColor') || DEFAULT_LAYOUT.backgroundDominantColor,
         pageMode: layoutMap.get('pageMode') || DEFAULT_LAYOUT.pageMode,
         isCustomBackgroundColorEnabled:
           layoutMap.get('isCustomBackgroundColorEnabled') ?? DEFAULT_LAYOUT.isCustomBackgroundColorEnabled,

--- a/apps/form-app/src/store/helpers/defaultLayout.ts
+++ b/apps/form-app/src/store/helpers/defaultLayout.ts
@@ -14,6 +14,7 @@ export const DEFAULT_LAYOUT: FormLayout = {
   customCTAButtonName: 'Get Started',
   backgroundImageKey: '',
   backgroundVideoKey: '',
+  backgroundDominantColor: '',
   pageMode: PageModeType.MULTIPAGE,
   isCustomBackgroundColorEnabled: false,
 };

--- a/apps/form-app/src/utils/dominantColor.ts
+++ b/apps/form-app/src/utils/dominantColor.ts
@@ -1,0 +1,139 @@
+/**
+ * Client-side dominant-color extraction for background media (image/video).
+ * Computed once at apply-time and persisted on FormLayout.backgroundDominantColor,
+ * never recomputed per render/visitor.
+ */
+
+const SAMPLE_SIZE = 50; // downscale target for canvas sampling — small enough to be fast, large enough to be representative
+const BUCKET_STEP = 24; // quantization step per RGB channel for the histogram approach
+const VIDEO_SEEK_TIMEOUT_MS = 5000;
+
+function toHex(value: number): string {
+  return Math.round(value).toString(16).padStart(2, '0');
+}
+
+/**
+ * Lightweight histogram-based "poor man's color-thief": bucket pixels by rounding
+ * each RGB channel to the nearest BUCKET_STEP, count frequency per bucket, and
+ * return the highest-frequency bucket's average color. Not a full k-means palette —
+ * good enough for a tint wash.
+ */
+function computeDominantColor(data: Uint8ClampedArray): string {
+  const buckets = new Map<string, { r: number; g: number; b: number; count: number }>();
+
+  for (let i = 0; i < data.length; i += 4) {
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+    const key = `${Math.round(r / BUCKET_STEP)}-${Math.round(g / BUCKET_STEP)}-${Math.round(b / BUCKET_STEP)}`;
+
+    const bucket = buckets.get(key);
+    if (bucket) {
+      bucket.r += r;
+      bucket.g += g;
+      bucket.b += b;
+      bucket.count += 1;
+    } else {
+      buckets.set(key, { r, g, b, count: 1 });
+    }
+  }
+
+  let winner: { r: number; g: number; b: number; count: number } | undefined;
+  for (const bucket of buckets.values()) {
+    if (!winner || bucket.count > winner.count) {
+      winner = bucket;
+    }
+  }
+
+  if (!winner) return '';
+
+  const r = winner.r / winner.count;
+  const g = winner.g / winner.count;
+  const b = winner.b / winner.count;
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function sampleFromCanvasSource(source: CanvasImageSource): string {
+  const canvas = document.createElement('canvas');
+  canvas.width = SAMPLE_SIZE;
+  canvas.height = SAMPLE_SIZE;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return '';
+
+  ctx.drawImage(source, 0, 0, SAMPLE_SIZE, SAMPLE_SIZE);
+  const { data } = ctx.getImageData(0, 0, SAMPLE_SIZE, SAMPLE_SIZE);
+  return computeDominantColor(data);
+}
+
+/**
+ * Samples the dominant color from an image blob. Uses a blob: URL (same-origin)
+ * rather than the remote source URL directly, so canvas sampling never hits a
+ * CORS-tainted-canvas SecurityError regardless of the source CDN's CORS policy.
+ */
+export async function computeDominantColorFromImageBlob(blob: Blob): Promise<string> {
+  const objectUrl = URL.createObjectURL(blob);
+  try {
+    const img = new Image();
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = () => reject(new Error('Failed to load image for color sampling'));
+      img.src = objectUrl;
+    });
+    return sampleFromCanvasSource(img);
+  } catch {
+    return '';
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+/**
+ * Samples the dominant color from a video blob by seeking to a representative
+ * frame (10% into the clip, to avoid black/blank opening frames) and drawing it
+ * to canvas. The video element is briefly attached to the DOM (near-invisible) —
+ * some browsers won't decode frames for an element that's never been in the document.
+ */
+export async function computeDominantColorFromVideoBlob(blob: Blob): Promise<string> {
+  const objectUrl = URL.createObjectURL(blob);
+  const video = document.createElement('video');
+  video.muted = true;
+  video.playsInline = true;
+  video.style.position = 'absolute';
+  video.style.width = '1px';
+  video.style.height = '1px';
+  video.style.opacity = '0';
+  video.style.pointerEvents = 'none';
+
+  try {
+    document.body.appendChild(video);
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Timed out waiting for video metadata')), VIDEO_SEEK_TIMEOUT_MS);
+      video.onloadedmetadata = () => {
+        clearTimeout(timeout);
+        resolve();
+      };
+      video.onerror = () => {
+        clearTimeout(timeout);
+        reject(new Error('Failed to load video for color sampling'));
+      };
+      video.src = objectUrl;
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Timed out waiting for video seek')), VIDEO_SEEK_TIMEOUT_MS);
+      video.onseeked = () => {
+        clearTimeout(timeout);
+        resolve();
+      };
+      video.currentTime = Math.min(1, (video.duration || 1) * 0.1);
+    });
+
+    return sampleFromCanvasSource(video);
+  } catch {
+    return '';
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+    video.remove();
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -145,6 +145,7 @@ export interface FormLayout {
   customCTAButtonName?: string; // Custom call to action name
   backgroundImageKey: string; // Image key of layout background image
   backgroundVideoKey?: string; // Video key of layout background video (mutually exclusive with backgroundImageKey)
+  backgroundDominantColor?: string; // Hex color sampled from the applied background image/video, used for the outer-area wash
   pageMode: PageModeType; // Page navigation mode
   isCustomBackgroundColorEnabled?: boolean; // Toggle between custom color overlay vs blur background
 }

--- a/packages/types/src/validation.ts
+++ b/packages/types/src/validation.ts
@@ -706,6 +706,13 @@ export const formLayoutValidationSchema = z
       .string()
       .max(200, 'Background video key is too long')
       .optional(),
+    backgroundDominantColor: z
+      .string()
+      .refine(
+        (v) => v === '' || /^#[0-9A-Fa-f]{6}$/.test(v),
+        'Invalid hex color format'
+      )
+      .optional(),
     pageMode: z.enum(['multipage']),
   })
   // Only one background source is ever active at a time — the builder UI clears the

--- a/packages/ui/src/layouts/L1ClassicLayout.tsx
+++ b/packages/ui/src/layouts/L1ClassicLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, RendererMode } from '@dculus/utils';
+import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
 import { LexicalRichTextEditor } from '../rich-text-editor/LexicalRichTextEditor';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
@@ -113,13 +113,16 @@ export const L1ClassicLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && !hasVideoBackground && layout?.backgroundImageKey && cdnEndpoint && (
+            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
-                  backdropFilter: 'blur(250px)',
-                  WebkitBackdropFilter: 'blur(250px)',
-                  backgroundColor: 'rgba(0, 0, 0, 0.1)'
+                  backdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
+                  WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
+                  backgroundColor: layout?.backgroundDominantColor
+                    ? hexToRgba(layout.backgroundDominantColor, 0.1)
+                    : 'rgba(0, 0, 0, 0.1)',
+                  transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
             )}
@@ -266,13 +269,16 @@ export const L1ClassicLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && !hasVideoBackground && layout?.backgroundImageKey && cdnEndpoint && (
+            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
-                  backdropFilter: 'blur(250px)',
-                  WebkitBackdropFilter: 'blur(250px)',
-                  backgroundColor: 'rgba(0, 0, 0, 0.1)'
+                  backdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
+                  WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
+                  backgroundColor: layout?.backgroundDominantColor
+                    ? hexToRgba(layout.backgroundDominantColor, 0.1)
+                    : 'rgba(0, 0, 0, 0.1)',
+                  transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
             )}

--- a/packages/ui/src/layouts/L1ClassicLayout.tsx
+++ b/packages/ui/src/layouts/L1ClassicLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
+import { getImageUrl, mixWithWhite, RendererMode } from '@dculus/utils';
 import { LexicalRichTextEditor } from '../rich-text-editor/LexicalRichTextEditor';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
@@ -73,6 +73,11 @@ export const L1ClassicLayout: React.FC<LayoutProps> = ({
         backgroundColor: layout.customBackGroundColor,
         transition: 'background-color 0.5s ease-in-out'
       }
+    : layout?.backgroundDominantColor
+    ? {
+        backgroundColor: mixWithWhite(layout.backgroundDominantColor, 0.6),
+        transition: 'background-color 0.5s ease-in-out'
+      }
     : hasVideoBackground
     ? { transition: 'all 0.5s ease-in-out' }
     : layout?.backgroundImageKey && cdnEndpoint
@@ -99,7 +104,7 @@ export const L1ClassicLayout: React.FC<LayoutProps> = ({
             style={outerBackgroundStyle}
           >
             {/* Video background layer - fills the outer area, no blur (unlike images) */}
-            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
+            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
               <video
                 key={videoUrl}
                 autoPlay
@@ -113,15 +118,13 @@ export const L1ClassicLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+            {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
                   backdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
                   WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
-                  backgroundColor: layout?.backgroundDominantColor
-                    ? hexToRgba(layout.backgroundDominantColor, 0.1)
-                    : 'rgba(0, 0, 0, 0.1)',
+                  backgroundColor: 'rgba(0, 0, 0, 0.1)',
                   transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
@@ -255,7 +258,7 @@ export const L1ClassicLayout: React.FC<LayoutProps> = ({
             style={outerBackgroundStyle}
           >
             {/* Video background layer - fills the outer area, no blur (unlike images) */}
-            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
+            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
               <video
                 key={videoUrl}
                 autoPlay
@@ -269,15 +272,13 @@ export const L1ClassicLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+            {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
                   backdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
                   WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
-                  backgroundColor: layout?.backgroundDominantColor
-                    ? hexToRgba(layout.backgroundDominantColor, 0.1)
-                    : 'rgba(0, 0, 0, 0.1)',
+                  backgroundColor: 'rgba(0, 0, 0, 0.1)',
                   transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>

--- a/packages/ui/src/layouts/L2ModernLayout.tsx
+++ b/packages/ui/src/layouts/L2ModernLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, RendererMode } from '@dculus/utils';
+import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
 import { LexicalRichTextEditor } from '../rich-text-editor/LexicalRichTextEditor';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
@@ -110,13 +110,16 @@ export const L2ModernLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && !hasVideoBackground && layout?.backgroundImageKey && cdnEndpoint && (
+            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
-                  backdropFilter: 'blur(250px)',
-                  WebkitBackdropFilter: 'blur(250px)',
-                  backgroundColor: 'rgba(0, 0, 0, 0.1)'
+                  backdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
+                  WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
+                  backgroundColor: layout?.backgroundDominantColor
+                    ? hexToRgba(layout.backgroundDominantColor, 0.1)
+                    : 'rgba(0, 0, 0, 0.1)',
+                  transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
             )}
@@ -263,13 +266,16 @@ export const L2ModernLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && !hasVideoBackground && layout?.backgroundImageKey && cdnEndpoint && (
+            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
-                  backdropFilter: 'blur(250px)',
-                  WebkitBackdropFilter: 'blur(250px)',
-                  backgroundColor: 'rgba(0, 0, 0, 0.1)'
+                  backdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
+                  WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
+                  backgroundColor: layout?.backgroundDominantColor
+                    ? hexToRgba(layout.backgroundDominantColor, 0.1)
+                    : 'rgba(0, 0, 0, 0.1)',
+                  transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
             )}

--- a/packages/ui/src/layouts/L2ModernLayout.tsx
+++ b/packages/ui/src/layouts/L2ModernLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
+import { getImageUrl, mixWithWhite, RendererMode } from '@dculus/utils';
 import { LexicalRichTextEditor } from '../rich-text-editor/LexicalRichTextEditor';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
@@ -70,6 +70,11 @@ export const L2ModernLayout: React.FC<LayoutProps> = ({
         backgroundColor: layout.customBackGroundColor,
         transition: 'background-color 0.5s ease-in-out'
       }
+    : layout?.backgroundDominantColor
+    ? {
+        backgroundColor: mixWithWhite(layout.backgroundDominantColor, 0.6),
+        transition: 'background-color 0.5s ease-in-out'
+      }
     : hasVideoBackground
     ? { transition: 'all 0.5s ease-in-out' }
     : layout?.backgroundImageKey && cdnEndpoint
@@ -96,7 +101,7 @@ export const L2ModernLayout: React.FC<LayoutProps> = ({
             style={outerBackgroundStyle}
           >
             {/* Video background layer - fills the outer area, no blur (unlike images) */}
-            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
+            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
               <video
                 key={videoUrl}
                 autoPlay
@@ -110,15 +115,13 @@ export const L2ModernLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+            {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
                   backdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
                   WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
-                  backgroundColor: layout?.backgroundDominantColor
-                    ? hexToRgba(layout.backgroundDominantColor, 0.1)
-                    : 'rgba(0, 0, 0, 0.1)',
+                  backgroundColor: 'rgba(0, 0, 0, 0.1)',
                   transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
@@ -252,7 +255,7 @@ export const L2ModernLayout: React.FC<LayoutProps> = ({
             style={outerBackgroundStyle}
           >
             {/* Video background layer - fills the outer area, no blur (unlike images) */}
-            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
+            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
               <video
                 key={videoUrl}
                 autoPlay
@@ -266,15 +269,13 @@ export const L2ModernLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+            {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
                   backdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
                   WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
-                  backgroundColor: layout?.backgroundDominantColor
-                    ? hexToRgba(layout.backgroundDominantColor, 0.1)
-                    : 'rgba(0, 0, 0, 0.1)',
+                  backgroundColor: 'rgba(0, 0, 0, 0.1)',
                   transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>

--- a/packages/ui/src/layouts/L3CardLayout.tsx
+++ b/packages/ui/src/layouts/L3CardLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, RendererMode } from '@dculus/utils';
+import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
 import { LexicalRichTextEditor } from '../rich-text-editor/LexicalRichTextEditor';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
@@ -110,13 +110,16 @@ export const L3CardLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && !hasVideoBackground && layout?.backgroundImageKey && cdnEndpoint && (
+            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
-                  backdropFilter: 'blur(250px)',
-                  WebkitBackdropFilter: 'blur(250px)',
-                  backgroundColor: 'rgba(0, 0, 0, 0.1)'
+                  backdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
+                  WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
+                  backgroundColor: layout?.backgroundDominantColor
+                    ? hexToRgba(layout.backgroundDominantColor, 0.1)
+                    : 'rgba(0, 0, 0, 0.1)',
+                  transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
             )}
@@ -254,13 +257,16 @@ export const L3CardLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && !hasVideoBackground && layout?.backgroundImageKey && cdnEndpoint && (
+            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
-                  backdropFilter: 'blur(250px)',
-                  WebkitBackdropFilter: 'blur(250px)',
-                  backgroundColor: 'rgba(0, 0, 0, 0.1)'
+                  backdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
+                  WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
+                  backgroundColor: layout?.backgroundDominantColor
+                    ? hexToRgba(layout.backgroundDominantColor, 0.1)
+                    : 'rgba(0, 0, 0, 0.1)',
+                  transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
             )}

--- a/packages/ui/src/layouts/L3CardLayout.tsx
+++ b/packages/ui/src/layouts/L3CardLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
+import { getImageUrl, mixWithWhite, RendererMode } from '@dculus/utils';
 import { LexicalRichTextEditor } from '../rich-text-editor/LexicalRichTextEditor';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
@@ -70,6 +70,11 @@ export const L3CardLayout: React.FC<LayoutProps> = ({
         backgroundColor: layout.customBackGroundColor,
         transition: 'background-color 0.5s ease-in-out'
       }
+    : layout?.backgroundDominantColor
+    ? {
+        backgroundColor: mixWithWhite(layout.backgroundDominantColor, 0.6),
+        transition: 'background-color 0.5s ease-in-out'
+      }
     : hasVideoBackground
     ? { transition: 'all 0.5s ease-in-out' }
     : layout?.backgroundImageKey && cdnEndpoint
@@ -96,7 +101,7 @@ export const L3CardLayout: React.FC<LayoutProps> = ({
             style={outerBackgroundStyle}
           >
             {/* Video background layer - fills the outer area, no blur (unlike images) */}
-            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
+            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
               <video
                 key={videoUrl}
                 autoPlay
@@ -110,15 +115,13 @@ export const L3CardLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+            {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
                   backdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
                   WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
-                  backgroundColor: layout?.backgroundDominantColor
-                    ? hexToRgba(layout.backgroundDominantColor, 0.1)
-                    : 'rgba(0, 0, 0, 0.1)',
+                  backgroundColor: 'rgba(0, 0, 0, 0.1)',
                   transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
@@ -243,7 +246,7 @@ export const L3CardLayout: React.FC<LayoutProps> = ({
             style={outerBackgroundStyle}
           >
             {/* Video background layer - fills the outer area, no blur (unlike images) */}
-            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
+            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
               <video
                 key={videoUrl}
                 autoPlay
@@ -257,15 +260,13 @@ export const L3CardLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+            {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
                   backdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
                   WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(250px)',
-                  backgroundColor: layout?.backgroundDominantColor
-                    ? hexToRgba(layout.backgroundDominantColor, 0.1)
-                    : 'rgba(0, 0, 0, 0.1)',
+                  backgroundColor: 'rgba(0, 0, 0, 0.1)',
                   transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>

--- a/packages/ui/src/layouts/L4MinimalLayout.tsx
+++ b/packages/ui/src/layouts/L4MinimalLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
+import { getImageUrl, mixWithWhite, RendererMode } from '@dculus/utils';
 import { LexicalRichTextEditor } from '../rich-text-editor/LexicalRichTextEditor';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
@@ -70,6 +70,11 @@ export const L4MinimalLayout: React.FC<LayoutProps> = ({
         backgroundColor: layout.customBackGroundColor,
         transition: 'background-color 0.5s ease-in-out'
       }
+    : layout?.backgroundDominantColor
+    ? {
+        backgroundColor: mixWithWhite(layout.backgroundDominantColor, 0.6),
+        transition: 'background-color 0.5s ease-in-out'
+      }
     : hasVideoBackground
     ? { transition: 'all 0.5s ease-in-out' }
     : layout?.backgroundImageKey && cdnEndpoint
@@ -96,7 +101,7 @@ export const L4MinimalLayout: React.FC<LayoutProps> = ({
             style={outerBackgroundStyle}
           >
             {/* Video background layer - fills the outer area, no blur (unlike images) */}
-            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
+            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
               <video
                 key={videoUrl}
                 autoPlay
@@ -110,15 +115,13 @@ export const L4MinimalLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+            {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
                   backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
                   WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
-                  backgroundColor: layout?.backgroundDominantColor
-                    ? hexToRgba(layout.backgroundDominantColor, 0.05)
-                    : 'rgba(255, 255, 255, 0.05)',
+                  backgroundColor: 'rgba(255, 255, 255, 0.05)',
                   transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
@@ -252,7 +255,7 @@ export const L4MinimalLayout: React.FC<LayoutProps> = ({
             style={outerBackgroundStyle}
           >
             {/* Video background layer - fills the outer area, no blur (unlike images) */}
-            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
+            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
               <video
                 key={videoUrl}
                 autoPlay
@@ -266,15 +269,13 @@ export const L4MinimalLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+            {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
                   backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
                   WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
-                  backgroundColor: layout?.backgroundDominantColor
-                    ? hexToRgba(layout.backgroundDominantColor, 0.05)
-                    : 'rgba(255, 255, 255, 0.05)',
+                  backgroundColor: 'rgba(255, 255, 255, 0.05)',
                   transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>

--- a/packages/ui/src/layouts/L4MinimalLayout.tsx
+++ b/packages/ui/src/layouts/L4MinimalLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, RendererMode } from '@dculus/utils';
+import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
 import { LexicalRichTextEditor } from '../rich-text-editor/LexicalRichTextEditor';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
@@ -110,13 +110,16 @@ export const L4MinimalLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && !hasVideoBackground && layout?.backgroundImageKey && cdnEndpoint && (
+            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
-                  backdropFilter: 'blur(50px)',
-                  WebkitBackdropFilter: 'blur(50px)',
-                  backgroundColor: 'rgba(255, 255, 255, 0.05)'
+                  backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                  WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                  backgroundColor: layout?.backgroundDominantColor
+                    ? hexToRgba(layout.backgroundDominantColor, 0.05)
+                    : 'rgba(255, 255, 255, 0.05)',
+                  transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
             )}
@@ -263,13 +266,16 @@ export const L4MinimalLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && !hasVideoBackground && layout?.backgroundImageKey && cdnEndpoint && (
+            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
-                  backdropFilter: 'blur(50px)',
-                  WebkitBackdropFilter: 'blur(50px)',
-                  backgroundColor: 'rgba(255, 255, 255, 0.05)'
+                  backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                  WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                  backgroundColor: layout?.backgroundDominantColor
+                    ? hexToRgba(layout.backgroundDominantColor, 0.05)
+                    : 'rgba(255, 255, 255, 0.05)',
+                  transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
             )}

--- a/packages/ui/src/layouts/L4MinimalLayout.tsx
+++ b/packages/ui/src/layouts/L4MinimalLayout.tsx
@@ -137,7 +137,10 @@ export const L4MinimalLayout: React.FC<LayoutProps> = ({
                 {/* Two chunks layout - 50/50 split */}
                 <div className="relative z-10 h-full flex flex-col sm:flex-row">
                   {/* First chunk - IMAGE CHUNK - Background image display area (50%) */}
-                  <div className="hidden sm:flex flex-1 items-center justify-center relative">
+                  {/* Shown on mobile too when there's a dominant-color wash — the wash lives in the
+                      outer area, which has no other display surface, so hiding this chunk on
+                      narrow viewports would make the applied media invisible there. */}
+                  <div className={`${layout?.backgroundDominantColor ? 'flex' : 'hidden sm:flex'} flex-1 items-center justify-center relative`}>
                     {/* Background image/video showcase only in this chunk */}
                     {hasVideoBackground ? (
                       <video

--- a/packages/ui/src/layouts/L5SplitLayout.tsx
+++ b/packages/ui/src/layouts/L5SplitLayout.tsx
@@ -221,7 +221,10 @@ export const L5SplitLayout: React.FC<LayoutProps> = ({
                   </div>
                   
                   {/* Second chunk - IMAGE CHUNK - Background image display area (50%) */}
-                  <div className="hidden sm:flex flex-1 items-center justify-center relative">
+                  {/* Shown on mobile too when there's a dominant-color wash — the wash lives in the
+                      outer area, which has no other display surface, so hiding this chunk on
+                      narrow viewports would make the applied media invisible there. */}
+                  <div className={`${layout?.backgroundDominantColor ? 'flex' : 'hidden sm:flex'} flex-1 items-center justify-center relative`}>
                     {/* Background image/video showcase only in this chunk */}
                     {hasVideoBackground ? (
                       <video

--- a/packages/ui/src/layouts/L5SplitLayout.tsx
+++ b/packages/ui/src/layouts/L5SplitLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
+import { getImageUrl, mixWithWhite, RendererMode } from '@dculus/utils';
 import { LexicalRichTextEditor } from '../rich-text-editor/LexicalRichTextEditor';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
@@ -70,6 +70,11 @@ export const L5SplitLayout: React.FC<LayoutProps> = ({
         backgroundColor: layout.customBackGroundColor,
         transition: 'background-color 0.5s ease-in-out'
       }
+    : layout?.backgroundDominantColor
+    ? {
+        backgroundColor: mixWithWhite(layout.backgroundDominantColor, 0.6),
+        transition: 'background-color 0.5s ease-in-out'
+      }
     : hasVideoBackground
     ? { transition: 'all 0.5s ease-in-out' }
     : layout?.backgroundImageKey && cdnEndpoint
@@ -96,7 +101,7 @@ export const L5SplitLayout: React.FC<LayoutProps> = ({
             style={outerBackgroundStyle}
           >
             {/* Video background layer - fills the outer area, no blur (unlike images) */}
-            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
+            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
               <video
                 key={videoUrl}
                 autoPlay
@@ -110,15 +115,13 @@ export const L5SplitLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+            {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
                   backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
                   WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
-                  backgroundColor: layout?.backgroundDominantColor
-                    ? hexToRgba(layout.backgroundDominantColor, 0.05)
-                    : 'rgba(255, 255, 255, 0.05)',
+                  backgroundColor: 'rgba(255, 255, 255, 0.05)',
                   transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
@@ -252,7 +255,7 @@ export const L5SplitLayout: React.FC<LayoutProps> = ({
             style={outerBackgroundStyle}
           >
             {/* Video background layer - fills the outer area, no blur (unlike images) */}
-            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
+            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
               <video
                 key={videoUrl}
                 autoPlay
@@ -266,15 +269,13 @@ export const L5SplitLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+            {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
                   backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
                   WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
-                  backgroundColor: layout?.backgroundDominantColor
-                    ? hexToRgba(layout.backgroundDominantColor, 0.05)
-                    : 'rgba(255, 255, 255, 0.05)',
+                  backgroundColor: 'rgba(255, 255, 255, 0.05)',
                   transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>

--- a/packages/ui/src/layouts/L5SplitLayout.tsx
+++ b/packages/ui/src/layouts/L5SplitLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, RendererMode } from '@dculus/utils';
+import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
 import { LexicalRichTextEditor } from '../rich-text-editor/LexicalRichTextEditor';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
@@ -110,13 +110,16 @@ export const L5SplitLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && !hasVideoBackground && layout?.backgroundImageKey && cdnEndpoint && (
+            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
-                  backdropFilter: 'blur(50px)',
-                  WebkitBackdropFilter: 'blur(50px)',
-                  backgroundColor: 'rgba(255, 255, 255, 0.05)'
+                  backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                  WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                  backgroundColor: layout?.backgroundDominantColor
+                    ? hexToRgba(layout.backgroundDominantColor, 0.05)
+                    : 'rgba(255, 255, 255, 0.05)',
+                  transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
             )}
@@ -263,13 +266,16 @@ export const L5SplitLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && !hasVideoBackground && layout?.backgroundImageKey && cdnEndpoint && (
+            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
-                  backdropFilter: 'blur(50px)',
-                  WebkitBackdropFilter: 'blur(50px)',
-                  backgroundColor: 'rgba(255, 255, 255, 0.05)'
+                  backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                  WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                  backgroundColor: layout?.backgroundDominantColor
+                    ? hexToRgba(layout.backgroundDominantColor, 0.05)
+                    : 'rgba(255, 255, 255, 0.05)',
+                  transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
             )}

--- a/packages/ui/src/layouts/L6WizardLayout.tsx
+++ b/packages/ui/src/layouts/L6WizardLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
+import { getImageUrl, mixWithWhite, RendererMode } from '@dculus/utils';
 import { LexicalRichTextEditor } from '../rich-text-editor/LexicalRichTextEditor';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
@@ -69,6 +69,11 @@ export const L6WizardLayout: React.FC<LayoutProps> = ({
         backgroundColor: layout.customBackGroundColor,
         transition: 'background-color 0.5s ease-in-out'
       }
+    : layout?.backgroundDominantColor
+    ? {
+        backgroundColor: mixWithWhite(layout.backgroundDominantColor, 0.6),
+        transition: 'background-color 0.5s ease-in-out'
+      }
     : hasVideoBackground
     ? { transition: 'all 0.5s ease-in-out' }
     : layout?.backgroundImageKey && cdnEndpoint
@@ -92,7 +97,7 @@ export const L6WizardLayout: React.FC<LayoutProps> = ({
           style={outerBackgroundStyle}
         >
           {/* Video background layer - fills the outer area, no blur (unlike images) */}
-          {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
+          {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
             <video
               key={videoUrl}
               autoPlay
@@ -106,15 +111,13 @@ export const L6WizardLayout: React.FC<LayoutProps> = ({
           )}
 
           {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-          {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+          {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
             <div
               className="absolute inset-0"
               style={{
                 backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
                 WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
-                backgroundColor: layout?.backgroundDominantColor
-                  ? hexToRgba(layout.backgroundDominantColor, 0.05)
-                  : 'rgba(255, 255, 255, 0.05)',
+                backgroundColor: 'rgba(255, 255, 255, 0.05)',
                 transition: 'background-color 0.5s ease-in-out'
               }}
             ></div>

--- a/packages/ui/src/layouts/L6WizardLayout.tsx
+++ b/packages/ui/src/layouts/L6WizardLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, RendererMode } from '@dculus/utils';
+import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
 import { LexicalRichTextEditor } from '../rich-text-editor/LexicalRichTextEditor';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
@@ -106,13 +106,16 @@ export const L6WizardLayout: React.FC<LayoutProps> = ({
           )}
 
           {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-          {!layout?.isCustomBackgroundColorEnabled && !hasVideoBackground && layout?.backgroundImageKey && cdnEndpoint && (
+          {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
             <div
               className="absolute inset-0"
               style={{
-                backdropFilter: 'blur(50px)',
-                WebkitBackdropFilter: 'blur(50px)',
-                backgroundColor: 'rgba(255, 255, 255, 0.05)'
+                backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                backgroundColor: layout?.backgroundDominantColor
+                  ? hexToRgba(layout.backgroundDominantColor, 0.05)
+                  : 'rgba(255, 255, 255, 0.05)',
+                transition: 'background-color 0.5s ease-in-out'
               }}
             ></div>
           )}

--- a/packages/ui/src/layouts/L7SingleLayout.tsx
+++ b/packages/ui/src/layouts/L7SingleLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, mixWithWhite, RendererMode } from '@dculus/utils';
+import { getImageUrl, RendererMode } from '@dculus/utils';
 import { LexicalRichTextEditor } from '../rich-text-editor/LexicalRichTextEditor';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
@@ -70,11 +70,6 @@ export const L7SingleLayout: React.FC<LayoutProps> = ({
         backgroundColor: layout.customBackGroundColor,
         transition: 'background-color 0.5s ease-in-out'
       }
-    : layout?.backgroundDominantColor
-    ? {
-        backgroundColor: mixWithWhite(layout.backgroundDominantColor, 0.6),
-        transition: 'background-color 0.5s ease-in-out'
-      }
     : hasVideoBackground
     ? { transition: 'all 0.5s ease-in-out' }
     : layout?.backgroundImageKey && cdnEndpoint
@@ -101,7 +96,7 @@ export const L7SingleLayout: React.FC<LayoutProps> = ({
             style={outerBackgroundStyle}
           >
             {/* Video background layer - fills the outer area, no blur (unlike images) */}
-            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
+            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
               <video
                 key={videoUrl}
                 autoPlay
@@ -115,7 +110,7 @@ export const L7SingleLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
@@ -230,7 +225,7 @@ export const L7SingleLayout: React.FC<LayoutProps> = ({
             style={outerBackgroundStyle}
           >
             {/* Video background layer - fills the outer area, no blur (unlike images) */}
-            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
+            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
               <video
                 key={videoUrl}
                 autoPlay
@@ -244,7 +239,7 @@ export const L7SingleLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{

--- a/packages/ui/src/layouts/L7SingleLayout.tsx
+++ b/packages/ui/src/layouts/L7SingleLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
+import { getImageUrl, mixWithWhite, RendererMode } from '@dculus/utils';
 import { LexicalRichTextEditor } from '../rich-text-editor/LexicalRichTextEditor';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
@@ -70,6 +70,11 @@ export const L7SingleLayout: React.FC<LayoutProps> = ({
         backgroundColor: layout.customBackGroundColor,
         transition: 'background-color 0.5s ease-in-out'
       }
+    : layout?.backgroundDominantColor
+    ? {
+        backgroundColor: mixWithWhite(layout.backgroundDominantColor, 0.6),
+        transition: 'background-color 0.5s ease-in-out'
+      }
     : hasVideoBackground
     ? { transition: 'all 0.5s ease-in-out' }
     : layout?.backgroundImageKey && cdnEndpoint
@@ -96,7 +101,7 @@ export const L7SingleLayout: React.FC<LayoutProps> = ({
             style={outerBackgroundStyle}
           >
             {/* Video background layer - fills the outer area, no blur (unlike images) */}
-            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
+            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
               <video
                 key={videoUrl}
                 autoPlay
@@ -110,15 +115,13 @@ export const L7SingleLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+            {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
                   backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
                   WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
-                  backgroundColor: layout?.backgroundDominantColor
-                    ? hexToRgba(layout.backgroundDominantColor, 0.05)
-                    : 'rgba(255, 255, 255, 0.05)',
+                  backgroundColor: 'rgba(255, 255, 255, 0.05)',
                   transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
@@ -227,7 +230,7 @@ export const L7SingleLayout: React.FC<LayoutProps> = ({
             style={outerBackgroundStyle}
           >
             {/* Video background layer - fills the outer area, no blur (unlike images) */}
-            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
+            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
               <video
                 key={videoUrl}
                 autoPlay
@@ -241,15 +244,13 @@ export const L7SingleLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+            {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
                   backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
                   WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
-                  backgroundColor: layout?.backgroundDominantColor
-                    ? hexToRgba(layout.backgroundDominantColor, 0.05)
-                    : 'rgba(255, 255, 255, 0.05)',
+                  backgroundColor: 'rgba(255, 255, 255, 0.05)',
                   transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>

--- a/packages/ui/src/layouts/L7SingleLayout.tsx
+++ b/packages/ui/src/layouts/L7SingleLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, RendererMode } from '@dculus/utils';
+import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
 import { LexicalRichTextEditor } from '../rich-text-editor/LexicalRichTextEditor';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
@@ -110,13 +110,16 @@ export const L7SingleLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && !hasVideoBackground && layout?.backgroundImageKey && cdnEndpoint && (
+            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
-                  backdropFilter: 'blur(50px)',
-                  WebkitBackdropFilter: 'blur(50px)',
-                  backgroundColor: 'rgba(255, 255, 255, 0.05)'
+                  backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                  WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                  backgroundColor: layout?.backgroundDominantColor
+                    ? hexToRgba(layout.backgroundDominantColor, 0.05)
+                    : 'rgba(255, 255, 255, 0.05)',
+                  transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
             )}
@@ -238,13 +241,16 @@ export const L7SingleLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && !hasVideoBackground && layout?.backgroundImageKey && cdnEndpoint && (
+            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
-                  backdropFilter: 'blur(50px)',
-                  WebkitBackdropFilter: 'blur(50px)',
-                  backgroundColor: 'rgba(255, 255, 255, 0.05)'
+                  backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                  WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                  backgroundColor: layout?.backgroundDominantColor
+                    ? hexToRgba(layout.backgroundDominantColor, 0.05)
+                    : 'rgba(255, 255, 255, 0.05)',
+                  transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
             )}

--- a/packages/ui/src/layouts/L8ImageLayout.tsx
+++ b/packages/ui/src/layouts/L8ImageLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
+import { getImageUrl, mixWithWhite, RendererMode } from '@dculus/utils';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
 
@@ -36,6 +36,11 @@ export const L8ImageLayout: React.FC<LayoutProps> = ({
         backgroundColor: layout.customBackGroundColor,
         transition: 'background-color 0.5s ease-in-out'
       }
+    : layout?.backgroundDominantColor
+    ? {
+        backgroundColor: mixWithWhite(layout.backgroundDominantColor, 0.6),
+        transition: 'background-color 0.5s ease-in-out'
+      }
     : hasVideoBackground
     ? { transition: 'all 0.5s ease-in-out' }
     : layout?.backgroundImageKey && cdnEndpoint
@@ -62,7 +67,7 @@ export const L8ImageLayout: React.FC<LayoutProps> = ({
             style={outerBackgroundStyle}
           >
             {/* Video background layer - fills the outer area, no blur (unlike images) */}
-            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
+            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
               <video
                 key={videoUrl}
                 autoPlay
@@ -76,15 +81,13 @@ export const L8ImageLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+            {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
                   backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
                   WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
-                  backgroundColor: layout?.backgroundDominantColor
-                    ? hexToRgba(layout.backgroundDominantColor, 0.05)
-                    : 'rgba(255, 255, 255, 0.05)',
+                  backgroundColor: 'rgba(255, 255, 255, 0.05)',
                   transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
@@ -145,7 +148,7 @@ export const L8ImageLayout: React.FC<LayoutProps> = ({
             style={outerBackgroundStyle}
           >
             {/* Video background layer - fills the outer area, no blur (unlike images) */}
-            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
+            {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
               <video
                 key={videoUrl}
                 autoPlay
@@ -159,15 +162,13 @@ export const L8ImageLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+            {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
                   backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
                   WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
-                  backgroundColor: layout?.backgroundDominantColor
-                    ? hexToRgba(layout.backgroundDominantColor, 0.05)
-                    : 'rgba(255, 255, 255, 0.05)',
+                  backgroundColor: 'rgba(255, 255, 255, 0.05)',
                   transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>

--- a/packages/ui/src/layouts/L8ImageLayout.tsx
+++ b/packages/ui/src/layouts/L8ImageLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, RendererMode } from '@dculus/utils';
+import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
 
@@ -76,13 +76,16 @@ export const L8ImageLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && !hasVideoBackground && layout?.backgroundImageKey && cdnEndpoint && (
+            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
-                  backdropFilter: 'blur(50px)',
-                  WebkitBackdropFilter: 'blur(50px)',
-                  backgroundColor: 'rgba(255, 255, 255, 0.05)'
+                  backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                  WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                  backgroundColor: layout?.backgroundDominantColor
+                    ? hexToRgba(layout.backgroundDominantColor, 0.05)
+                    : 'rgba(255, 255, 255, 0.05)',
+                  transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
             )}
@@ -156,13 +159,16 @@ export const L8ImageLayout: React.FC<LayoutProps> = ({
             )}
 
             {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-            {!layout?.isCustomBackgroundColorEnabled && !hasVideoBackground && layout?.backgroundImageKey && cdnEndpoint && (
+            {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
               <div
                 className="absolute inset-0"
                 style={{
-                  backdropFilter: 'blur(50px)',
-                  WebkitBackdropFilter: 'blur(50px)',
-                  backgroundColor: 'rgba(255, 255, 255, 0.05)'
+                  backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                  WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                  backgroundColor: layout?.backgroundDominantColor
+                    ? hexToRgba(layout.backgroundDominantColor, 0.05)
+                    : 'rgba(255, 255, 255, 0.05)',
+                  transition: 'background-color 0.5s ease-in-out'
                 }}
               ></div>
             )}

--- a/packages/ui/src/layouts/L9PagesLayout.tsx
+++ b/packages/ui/src/layouts/L9PagesLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
+import { getImageUrl, mixWithWhite, RendererMode } from '@dculus/utils';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
 
@@ -35,6 +35,11 @@ export const L9PagesLayout: React.FC<LayoutProps> = ({
         backgroundColor: layout.customBackGroundColor,
         transition: 'background-color 0.5s ease-in-out'
       }
+    : layout?.backgroundDominantColor
+    ? {
+        backgroundColor: mixWithWhite(layout.backgroundDominantColor, 0.6),
+        transition: 'background-color 0.5s ease-in-out'
+      }
     : hasVideoBackground
     ? { transition: 'all 0.5s ease-in-out' }
     : layout?.backgroundImageKey && cdnEndpoint
@@ -60,7 +65,7 @@ export const L9PagesLayout: React.FC<LayoutProps> = ({
           style={outerBackgroundStyle}
         >
           {/* Video background layer - fills the outer area, no blur (unlike images) */}
-          {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
+          {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
             <video
               key={videoUrl}
               autoPlay
@@ -74,15 +79,13 @@ export const L9PagesLayout: React.FC<LayoutProps> = ({
           )}
 
           {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-          {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+          {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
             <div
               className="absolute inset-0"
               style={{
                 backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
                 WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
-                backgroundColor: layout?.backgroundDominantColor
-                  ? hexToRgba(layout.backgroundDominantColor, 0.05)
-                  : 'rgba(255, 255, 255, 0.05)',
+                backgroundColor: 'rgba(255, 255, 255, 0.05)',
                 transition: 'background-color 0.5s ease-in-out'
               }}
             ></div>

--- a/packages/ui/src/layouts/L9PagesLayout.tsx
+++ b/packages/ui/src/layouts/L9PagesLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, RendererMode } from '@dculus/utils';
+import { getImageUrl, hexToRgba, RendererMode } from '@dculus/utils';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
 
@@ -74,13 +74,16 @@ export const L9PagesLayout: React.FC<LayoutProps> = ({
           )}
 
           {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-          {!layout?.isCustomBackgroundColorEnabled && !hasVideoBackground && layout?.backgroundImageKey && cdnEndpoint && (
+          {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
             <div
               className="absolute inset-0"
               style={{
-                backdropFilter: 'blur(50px)',
-                WebkitBackdropFilter: 'blur(50px)',
-                backgroundColor: 'rgba(255, 255, 255, 0.05)'
+                backdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                WebkitBackdropFilter: hasVideoBackground ? undefined : 'blur(50px)',
+                backgroundColor: layout?.backgroundDominantColor
+                  ? hexToRgba(layout.backgroundDominantColor, 0.05)
+                  : 'rgba(255, 255, 255, 0.05)',
+                transition: 'background-color 0.5s ease-in-out'
               }}
             ></div>
           )}

--- a/packages/ui/src/layouts/L9PagesLayout.tsx
+++ b/packages/ui/src/layouts/L9PagesLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PageRenderer } from '../renderers/PageRenderer';
-import { getImageUrl, mixWithWhite, RendererMode } from '@dculus/utils';
+import { getImageUrl, RendererMode } from '@dculus/utils';
 import { useBackgroundVideo } from '../hooks/useBackgroundVideo';
 import { LayoutProps } from '../types';
 
@@ -35,11 +35,6 @@ export const L9PagesLayout: React.FC<LayoutProps> = ({
         backgroundColor: layout.customBackGroundColor,
         transition: 'background-color 0.5s ease-in-out'
       }
-    : layout?.backgroundDominantColor
-    ? {
-        backgroundColor: mixWithWhite(layout.backgroundDominantColor, 0.6),
-        transition: 'background-color 0.5s ease-in-out'
-      }
     : hasVideoBackground
     ? { transition: 'all 0.5s ease-in-out' }
     : layout?.backgroundImageKey && cdnEndpoint
@@ -65,7 +60,7 @@ export const L9PagesLayout: React.FC<LayoutProps> = ({
           style={outerBackgroundStyle}
         >
           {/* Video background layer - fills the outer area, no blur (unlike images) */}
-          {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (
+          {hasVideoBackground && !layout?.isCustomBackgroundColorEnabled && (
             <video
               key={videoUrl}
               autoPlay
@@ -79,7 +74,7 @@ export const L9PagesLayout: React.FC<LayoutProps> = ({
           )}
 
           {/* Minimal backdrop blur overlay on top of background image in outer area - only when not using custom color */}
-          {!layout?.isCustomBackgroundColorEnabled && !layout?.backgroundDominantColor && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
+          {!layout?.isCustomBackgroundColorEnabled && (hasVideoBackground || (layout?.backgroundImageKey && cdnEndpoint)) && (
             <div
               className="absolute inset-0"
               style={{

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -189,14 +189,15 @@ export function getImageUrl(s3Key: string, cdnEndpoint: string): string {
  * so callers can pass a possibly-empty/unset value without a separate guard.
  */
 export function hexToRgba(hex: string, alpha: number): string {
+  const safeAlpha = Number.isFinite(alpha) ? Math.min(1, Math.max(0, alpha)) : 0;
   const match = /^#([0-9A-Fa-f]{6})$/.exec(hex);
   if (!match) {
-    return `rgba(0, 0, 0, ${alpha})`;
+    return `rgba(0, 0, 0, ${safeAlpha})`;
   }
   const r = parseInt(match[1].slice(0, 2), 16);
   const g = parseInt(match[1].slice(2, 4), 16);
   const b = parseInt(match[1].slice(4, 6), 16);
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  return `rgba(${r}, ${g}, ${b}, ${safeAlpha})`;
 }
 
 /**
@@ -205,6 +206,7 @@ export function hexToRgba(hex: string, alpha: number): string {
  * valid hex color, so callers can pass a possibly-empty/unset value without a separate guard.
  */
 export function mixWithWhite(hex: string, ratio: number): string {
+  const safeRatio = Number.isFinite(ratio) ? Math.min(1, Math.max(0, ratio)) : 0;
   const match = /^#([0-9A-Fa-f]{6})$/.exec(hex);
   if (!match) {
     return `rgb(245, 245, 245)`;
@@ -212,7 +214,7 @@ export function mixWithWhite(hex: string, ratio: number): string {
   const r = parseInt(match[1].slice(0, 2), 16);
   const g = parseInt(match[1].slice(2, 4), 16);
   const b = parseInt(match[1].slice(4, 6), 16);
-  const mix = (channel: number) => Math.round(channel + (255 - channel) * ratio);
+  const mix = (channel: number) => Math.round(channel + (255 - channel) * safeRatio);
   return `rgb(${mix(r)}, ${mix(g)}, ${mix(b)})`;
 }
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -200,6 +200,23 @@ export function hexToRgba(hex: string, alpha: number): string {
 }
 
 /**
+ * Blends a "#rrggbb" hex color toward white by `ratio` (0-1), producing the pale/pastel
+ * wash used behind media backgrounds. Returns a light neutral gray if the input isn't a
+ * valid hex color, so callers can pass a possibly-empty/unset value without a separate guard.
+ */
+export function mixWithWhite(hex: string, ratio: number): string {
+  const match = /^#([0-9A-Fa-f]{6})$/.exec(hex);
+  if (!match) {
+    return `rgb(245, 245, 245)`;
+  }
+  const r = parseInt(match[1].slice(0, 2), 16);
+  const g = parseInt(match[1].slice(2, 4), 16);
+  const b = parseInt(match[1].slice(4, 6), 16);
+  const mix = (channel: number) => Math.round(channel + (255 - channel) * ratio);
+  return `rgb(${mix(r)}, ${mix(g)}, ${mix(b)})`;
+}
+
+/**
  * Strips HTML tags from text and truncates with ellipsis
  * @param html - HTML string to process
  * @param maxLength - Maximum length before truncation (default: 50)

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -184,6 +184,22 @@ export function getImageUrl(s3Key: string, cdnEndpoint: string): string {
 }
 
 /**
+ * Converts a "#rrggbb" hex color to an "rgba(r, g, b, alpha)" string.
+ * Returns a neutral black at the given alpha if the input isn't a valid hex color,
+ * so callers can pass a possibly-empty/unset value without a separate guard.
+ */
+export function hexToRgba(hex: string, alpha: number): string {
+  const match = /^#([0-9A-Fa-f]{6})$/.exec(hex);
+  if (!match) {
+    return `rgba(0, 0, 0, ${alpha})`;
+  }
+  const r = parseInt(match[1].slice(0, 2), 16);
+  const g = parseInt(match[1].slice(2, 4), 16);
+  const b = parseInt(match[1].slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+/**
  * Strips HTML tags from text and truncates with ellipsis
  * @param html - HTML string to process
  * @param maxLength - Maximum length before truncation (default: 50)


### PR DESCRIPTION
## Summary
- Images currently get a generic flat tint (black at 0.1 alpha for L1-L3, white at 0.05 for L4-L9) behind the outer-area blur overlay; videos get **no overlay at all**. Sample the dominant color from the actual applied image/video (client-side canvas histogram, no new npm dependency) and use it to tint that same overlay for both media types across all 9 layouts — closer to the Microsoft Forms reference behavior.
- Computed **once**, at apply-time in the Pexels/Pixabay download functions (they already fetch the blob before upload — no second network round-trip), and persisted as a new `FormLayout.backgroundDominantColor` field. Never recomputed per render/visitor.
- Falls back to the previous flat tint whenever the field is empty (existing forms created before this ships, or the "Custom" gallery re-apply path which has no fresh blob to sample from) — zero visual regression for forms that never get a computed color.
- Threaded the new field through every sync point `backgroundVideoKey` already established (types, Zod schema, `DEFAULT_LAYOUT`, `CollaborationManager`, both `hocuspocus.ts` reconstruction paths, `formService.ts` defaults) — verified via `grep -rn backgroundVideoKey` to make sure nothing was missed.

## Test plan
- [x] `pnpm type-check` / `pnpm build` clean across `types`, `utils`, `ui`, `form-app`, `backend`
- [x] `pnpm lint` clean on all touched files
- [x] `pnpm test:unit` — 2626/2626 passing; coverage 78.18% branches (≥78% threshold)
- [x] Live-tested in browser: applied a Pexels image and video to a real form, confirmed the wash tint visually matches the media's dominant color (verified the actual computed `rgba(...)` value, not the old flat fallback)
- [x] Confirmed the "Use custom background color" toggle still overrides the wash (unchanged gating logic)
- [x] Confirmed the wash renders correctly in **form-viewer** via the published form — this is the path that silently breaks if a `hocuspocus.ts` sync point is missed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When applying background images/videos (including Pexels and Pixabay), the app computes a dominant color and saves it in the form layout.
  * Layouts can use this dominant color to style outer-area backgrounds and adjust backdrop blur behavior when custom background color is disabled.
* **Bug Fixes**
  * Dominant color now persists correctly through initialization and collaboration updates.
  * Changing or clearing background media properly resets the related dominant color.
* **Validation**
  * Dominant color accepts only an empty value or a valid `#RRGGBB` hex color.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->