### PR TITLE
Raise background video quality: HD renditions, 45MB cap

### DIFF
--- a/apps/backend/src/services/__tests__/fileUploadService.test.ts
+++ b/apps/backend/src/services/__tests__/fileUploadService.test.ts
@@ -274,6 +274,31 @@ describe('File Upload Service', () => {
       expect(result.mimeType).toBe('video/mp4');
     });
 
+    it('should allow a FormBackground video at exactly the 45MB cap', async () => {
+      mockSend.mockResolvedValue({});
+      const exactlyAtCap = 45 * 1024 * 1024;
+      const mockFile = createMockFile('exact.mp4', 'video/mp4', exactlyAtCap);
+
+      const result = await uploadFile({
+        file: mockFile,
+        type: 'FormBackground',
+      });
+
+      expect(result.mimeType).toBe('video/mp4');
+    });
+
+    it('should throw when a FormBackground video is exactly 1 byte over the 45MB cap', async () => {
+      const justOverCap = 45 * 1024 * 1024 + 1;
+      const mockFile = createMockFile('just-over.mp4', 'video/mp4', justOverCap);
+
+      await expect(
+        uploadFile({
+          file: mockFile,
+          type: 'FormBackground',
+        })
+      ).rejects.toThrow('File size');
+    });
+
     it('should handle S3 upload errors', async () => {
       const loggerError = vi.spyOn(logger, 'error').mockImplementation(() => {});
       mockSend.mockRejectedValue(new Error('S3 upload failed'));

--- a/apps/backend/src/services/__tests__/fileUploadService.test.ts
+++ b/apps/backend/src/services/__tests__/fileUploadService.test.ts
@@ -249,8 +249,8 @@ describe('File Upload Service', () => {
       ).rejects.toThrow('File type video/mp4 is not allowed');
     });
 
-    it('should throw when a FormBackground video exceeds the 20MB video cap', async () => {
-      const largeVideoSize = 21 * 1024 * 1024; // 21MB
+    it('should throw when a FormBackground video exceeds the 45MB video cap', async () => {
+      const largeVideoSize = 46 * 1024 * 1024; // 46MB
       const mockFile = createMockFile('large.mp4', 'video/mp4', largeVideoSize);
 
       await expect(
@@ -261,9 +261,9 @@ describe('File Upload Service', () => {
       ).rejects.toThrow('File size');
     });
 
-    it('should allow a FormBackground video just under the 20MB cap', async () => {
+    it('should allow a FormBackground video just under the 45MB cap', async () => {
       mockSend.mockResolvedValue({});
-      const justUnderCap = 19 * 1024 * 1024; // 19MB — under cap, over the 5MB image cap
+      const justUnderCap = 44 * 1024 * 1024; // 44MB — under cap, over the 5MB image cap
       const mockFile = createMockFile('ok.mp4', 'video/mp4', justUnderCap);
 
       const result = await uploadFile({

--- a/apps/backend/src/services/fileUploadService.ts
+++ b/apps/backend/src/services/fileUploadService.ts
@@ -55,7 +55,10 @@ const ALLOWED_IMAGE_TYPES = [
 const ALLOWED_VIDEO_TYPES = ['video/mp4', 'video/webm'];
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB (for image uploads; FormResponse uses multer limit)
-const MAX_VIDEO_FILE_SIZE = 20 * 1024 * 1024; // 20MB for FormBackground video uploads
+// 45MB for FormBackground video uploads (HD renditions) — kept below the route-level multer
+// ceiling (50MB, see upload.ts) so oversized uploads still fail via this controlled error path
+// (mapped to 413/FILE_TOO_LARGE) rather than multer's raw LIMIT_FILE_SIZE error.
+const MAX_VIDEO_FILE_SIZE = 45 * 1024 * 1024;
 const MAX_PDF_TEMPLATE_SIZE = 10 * 1024 * 1024; // 10MB for uploaded base PDFs (PdfTemplateAsset)
 
 /**

--- a/apps/backend/src/services/fileUploadService.ts
+++ b/apps/backend/src/services/fileUploadService.ts
@@ -256,7 +256,7 @@ export async function uploadFile(
 
     // Check file size — FormResponse relies on multer's 50 MB limit (enforced before this point);
     // PdfTemplateAsset is capped at MAX_PDF_TEMPLATE_SIZE (10 MB);
-    // FormBackground videos are capped at MAX_VIDEO_FILE_SIZE (20 MB);
+    // FormBackground videos are capped at MAX_VIDEO_FILE_SIZE (45 MB);
     // all other upload types (including FormBackground images) are capped at MAX_FILE_SIZE (5 MB)
     if (type === 'PdfTemplateAsset') {
       if (buffer.length > MAX_PDF_TEMPLATE_SIZE) {

--- a/apps/form-app/src/services/pexelsService.ts
+++ b/apps/form-app/src/services/pexelsService.ts
@@ -123,14 +123,14 @@ export async function searchPexelsVideos(
   return response.json();
 }
 
-// Picks the smallest mp4 rendition at/above ~640px width, so the client-side
-// fetch + re-upload to R2 stays small — falls back to the smallest rendition
-// available if nothing meets that width.
-function selectSmallestVideoFile(files: PexelsVideoFile[]): PexelsVideoFile | undefined {
+// Picks the highest-quality mp4 rendition at/below 1920px width (avoids unnecessary 4K), so
+// background videos look sharp without ballooning storage — falls back to the smallest
+// rendition available if every one exceeds that width.
+function selectBestVideoFile(files: PexelsVideoFile[]): PexelsVideoFile | undefined {
   const mp4Files = files.filter((f) => f.file_type === 'video/mp4');
   const candidates = mp4Files.length > 0 ? mp4Files : files;
-  const sorted = [...candidates].sort((a, b) => a.width - b.width);
-  return sorted.find((f) => f.width >= 640) || sorted[0];
+  const sorted = [...candidates].sort((a, b) => b.width - a.width);
+  return sorted.find((f) => f.width <= 1920) || sorted[sorted.length - 1];
 }
 
 // Keep in sync with the backend's MAX_VIDEO_FILE_SIZE (fileUploadService.ts). Pexels doesn't
@@ -138,13 +138,13 @@ function selectSmallestVideoFile(files: PexelsVideoFile[]): PexelsVideoFile | un
 // proxy for size — a long or high-bitrate clip at the chosen width can still exceed the cap.
 // Checking the real blob size here avoids fetching-then-uploading a doomed multi-MB file only
 // to have the backend reject it after the fact.
-const MAX_VIDEO_DOWNLOAD_BYTES = 20 * 1024 * 1024;
+const MAX_VIDEO_DOWNLOAD_BYTES = 45 * 1024 * 1024;
 
 export async function downloadPexelsVideo(
   video: PexelsVideo,
   formId: string
 ): Promise<UploadResult> {
-  const videoFile = selectSmallestVideoFile(video.video_files);
+  const videoFile = selectBestVideoFile(video.video_files);
   if (!videoFile) {
     throw new Error('No downloadable video file found for this Pexels video');
   }

--- a/apps/form-app/src/services/pixabayService.ts
+++ b/apps/form-app/src/services/pixabayService.ts
@@ -126,20 +126,20 @@ export async function searchPixabayVideos(
   return response.json();
 }
 
-const MAX_VIDEO_DOWNLOAD_BYTES = 20 * 1024 * 1024; // keep in sync with backend MAX_VIDEO_FILE_SIZE
+const MAX_VIDEO_DOWNLOAD_BYTES = 45 * 1024 * 1024; // keep in sync with backend MAX_VIDEO_FILE_SIZE
 
-// Picks the smallest rendition that fits under the upload cap — Pixabay reports
+// Picks the highest-quality rendition that fits under the upload cap — Pixabay reports
 // an exact byte size per rendition, so we don't need to guess.
-function selectSmallestVideoRendition(videos: PixabayVideo['videos']): PixabayVideoRendition {
-  const renditions = [videos.tiny, videos.small, videos.medium, videos.large].filter(Boolean);
-  return renditions.find((r) => r.size <= MAX_VIDEO_DOWNLOAD_BYTES) || renditions[0];
+function selectBestVideoRendition(videos: PixabayVideo['videos']): PixabayVideoRendition {
+  const renditions = [videos.large, videos.medium, videos.small, videos.tiny].filter(Boolean);
+  return renditions.find((r) => r.size <= MAX_VIDEO_DOWNLOAD_BYTES) || renditions[renditions.length - 1];
 }
 
 export async function downloadPixabayVideo(
   video: PixabayVideo,
   formId: string
 ): Promise<UploadResult> {
-  const rendition = selectSmallestVideoRendition(video.videos);
+  const rendition = selectBestVideoRendition(video.videos);
   if (!rendition) {
     throw new Error('No downloadable video rendition found for this Pixabay video');
   }


### PR DESCRIPTION
## Summary
- The stock-video picker deliberately downloaded the smallest Pexels/Pixabay rendition (~640px, 20MB cap) to keep client-fetch + re-upload small. Change the selection to target the **highest-quality** rendition instead: Pexels now sorts descending and picks the largest rendition ≤1920px width (avoids unnecessary 4K); Pixabay now iterates `[large, medium, small, tiny]` and picks the first that fits the new cap.
- Raised `MAX_VIDEO_FILE_SIZE` from 20MB → 45MB, kept below the route's 50MB multer ceiling (`upload.ts`) so oversized uploads still fail through the existing controlled error path (mapped to 413/`FILE_TOO_LARGE`) rather than multer's raw error.
- Independent of #183 (dominant-color wash) — different risk profile (storage cost, upload/load time), no shared code paths beyond the same download functions.

## Test plan
- [x] `pnpm type-check` / `pnpm build` clean (backend, form-app)
- [x] `pnpm lint` clean on touched files
- [x] `pnpm test:unit` — 2626/2626 passing; coverage 78.17% branches (≥78% threshold); updated the two `fileUploadService.test.ts` cases that asserted the old 20MB cap
- [x] Live-tested: applied a Pexels video, confirmed the actual uploaded resolution (`video.videoWidth`) came back at 1366×570 — a clear step up from the old ~640px target — and that a deliberately oversized clip still correctly triggers the `FILE_TOO_LARGE` toast rather than a raw 500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the maximum allowed background video upload size to 45 MB.
  * Improved downloaded video quality by selecting the highest-quality rendition within the size limit (with smart fallbacks).

* **Bug Fixes**
  * Strengthened validation for oversized videos and updated all download/upload limits to 45 MB.
  * Added boundary coverage to ensure videos at the exact limit are accepted and just over the limit are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->