### PR TITLE
Show previously used background videos in the Custom Images gallery

### DIFF
--- a/apps/form-app/src/components/form-builder/tabs/layout/BackgroundImageGallery.tsx
+++ b/apps/form-app/src/components/form-builder/tabs/layout/BackgroundImageGallery.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Check, Trash2 } from 'lucide-react';
+import { Check, Trash2, Play } from 'lucide-react';
 import { Button } from '@dculus/ui';
 import { useTranslation } from '../../../../hooks';
 
@@ -9,6 +9,7 @@ interface FormFile {
   url: string;
   originalName: string;
   createdAt: string;
+  mimeType?: string;
 }
 
 interface BackgroundImageGalleryProps {
@@ -53,12 +54,27 @@ export const BackgroundImageGallery: React.FC<BackgroundImageGalleryProps> = ({
                 ? 'border-purple-500 shadow-md'
                 : 'border-[var(--tf-border-medium)] dark:border-gray-600 hover:border-purple-300'
             }`}>
-              <img
-                src={image.url}
-                alt={image.originalName}
-                className="w-full h-20 object-cover"
-              />
-              
+              {image.mimeType?.startsWith('video/') ? (
+                <>
+                  <video
+                    src={image.url}
+                    muted
+                    playsInline
+                    preload="metadata"
+                    className="w-full h-20 object-cover"
+                  />
+                  <div className="absolute inset-0 flex items-center justify-center bg-black/20 pointer-events-none">
+                    <Play className="w-5 h-5 text-white/90" />
+                  </div>
+                </>
+              ) : (
+                <img
+                  src={image.url}
+                  alt={image.originalName}
+                  className="w-full h-20 object-cover"
+                />
+              )}
+
               {/* Selection indicator */}
               {selectedImageKey === image.key && (
                 <div className="absolute top-1 right-1 bg-purple-500 text-white rounded-full p-1">

--- a/apps/form-app/src/components/form-builder/tabs/layout/LayoutSidebar.tsx
+++ b/apps/form-app/src/components/form-builder/tabs/layout/LayoutSidebar.tsx
@@ -55,12 +55,19 @@ export const LayoutSidebar: React.FC<LayoutSidebarProps> = ({
   };
 
   const handleApplyBackgroundImage = () => {
-    if (selectedImageKey) {
-      // No fresh blob available for re-applying an already-uploaded gallery asset, so we
-      // can't sample a new dominant color here — clear the old one rather than showing a
-      // stale/mismatched wash; rendering falls back to the flat tint when this is empty.
-      onLayoutUpdate({ backgroundImageKey: selectedImageKey, backgroundVideoKey: '', backgroundDominantColor: '' });
-    }
+    if (!selectedImageKey) return;
+    const selectedFile = formFilesData?.getFormFiles?.find(
+      (file: { key: string }) => file.key === selectedImageKey
+    );
+    const isVideo = selectedFile?.mimeType?.startsWith('video/');
+    // No fresh blob available for re-applying an already-uploaded gallery asset, so we
+    // can't sample a new dominant color here — clear the old one rather than showing a
+    // stale/mismatched wash; rendering falls back to the flat tint when this is empty.
+    onLayoutUpdate(
+      isVideo
+        ? { backgroundVideoKey: selectedImageKey, backgroundImageKey: '', backgroundDominantColor: '' }
+        : { backgroundImageKey: selectedImageKey, backgroundVideoKey: '', backgroundDominantColor: '' }
+    );
   };
   return (
     <div className="w-80 border-l border-[var(--tf-border-medium)] dark:border-gray-700 flex flex-col h-full">
@@ -197,23 +204,22 @@ export const LayoutSidebar: React.FC<LayoutSidebarProps> = ({
                       onUploadSuccess={handleImageUploadSuccess}
                     />
                     
-                    {/* Gallery of uploaded images — excludes stock videos saved under the same
-                        FormBackground type (those are only ever applied via the Pexels/Pixabay
-                        Videos tab, never through this image-only gallery) */}
+                    {/* Gallery of previously used background images and videos (including
+                        stock videos saved here from the Pexels/Pixabay tabs) */}
                     {formFilesData?.getFormFiles && (
                       <div className="space-y-3">
                         <BackgroundImageGallery
-                          images={formFilesData.getFormFiles.filter(
-                            (file: { mimeType?: string }) => !file.mimeType?.startsWith('video/')
-                          )}
+                          images={formFilesData.getFormFiles}
                           selectedImageKey={selectedImageKey || undefined}
                           onImageSelect={handleImageSelect}
                         />
                       </div>
                     )}
-                    
-                    {/* Apply button for custom images */}
-                    {selectedImageKey && selectedImageKey !== layout.backgroundImageKey && (
+
+                    {/* Apply button for custom images/videos */}
+                    {selectedImageKey &&
+                      selectedImageKey !== layout.backgroundImageKey &&
+                      selectedImageKey !== layout.backgroundVideoKey && (
                       <Button
                         onClick={handleApplyBackgroundImage}
                         className="w-full bg-purple-600 hover:bg-purple-700"

--- a/apps/form-app/src/components/form-builder/tabs/layout/PexelsModal.tsx
+++ b/apps/form-app/src/components/form-builder/tabs/layout/PexelsModal.tsx
@@ -220,7 +220,10 @@ export function PexelsModal({ isOpen, onClose, formId, onImageApplied, onVideoAp
                         className="w-full h-full object-cover"
                       />
 
-                      <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <div className={cn(
+                        'absolute inset-0 bg-black/40 transition-opacity',
+                        uploading && selectedImage?.id === photo.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+                      )}>
                         <div className="absolute inset-0 flex items-center justify-center">
                           <Button
                             onClick={() => handleApplyImage(photo)}
@@ -269,7 +272,10 @@ export function PexelsModal({ isOpen, onClose, formId, onImageApplied, onVideoAp
                         <Play className="h-8 w-8 text-white/90" />
                       </div>
 
-                      <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <div className={cn(
+                        'absolute inset-0 bg-black/40 transition-opacity',
+                        uploading && selectedVideo?.id === video.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+                      )}>
                         <div className="absolute inset-0 flex items-center justify-center">
                           <Button
                             onClick={() => handleApplyVideo(video)}

--- a/apps/form-app/src/components/form-builder/tabs/layout/PixabayModal.tsx
+++ b/apps/form-app/src/components/form-builder/tabs/layout/PixabayModal.tsx
@@ -233,8 +233,11 @@ export function PixabayModal({ isOpen, onClose, formId, onImageApplied, onVideoA
                         className="w-full h-full object-cover"
                       />
                       
-                      {/* Overlay with stats - always visible on hover */}
-                      <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity">
+                      {/* Overlay with stats - visible on hover, or while this item is uploading */}
+                      <div className={cn(
+                        'absolute inset-0 bg-black/40 transition-opacity',
+                        uploading && selectedImage?.id === image.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+                      )}>
                         <div className="absolute top-2 right-2 text-white text-xs space-y-1">
                           <div className="flex items-center gap-1 bg-black/50 rounded px-1">
                             <Eye className="h-3 w-3" />
@@ -249,7 +252,7 @@ export function PixabayModal({ isOpen, onClose, formId, onImageApplied, onVideoA
                             <span>{image.likes.toLocaleString()}</span>
                           </div>
                         </div>
-                        
+
                         {/* Apply button in center */}
                         <div className="absolute inset-0 flex items-center justify-center">
                           <Button
@@ -299,8 +302,11 @@ export function PixabayModal({ isOpen, onClose, formId, onImageApplied, onVideoA
                         <Play className="h-8 w-8 text-white/90" />
                       </div>
 
-                      {/* Overlay with stats - always visible on hover */}
-                      <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity">
+                      {/* Overlay with stats - visible on hover, or while this item is uploading */}
+                      <div className={cn(
+                        'absolute inset-0 bg-black/40 transition-opacity',
+                        uploading && selectedVideo?.id === video.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+                      )}>
                         <div className="absolute top-2 right-2 text-white text-xs space-y-1">
                           <div className="flex items-center gap-1 bg-black/50 rounded px-1">
                             <Eye className="h-3 w-3" />


### PR DESCRIPTION
## Summary
- Videos applied via Pexels/Pixabay are stored under the same `FormBackground` type as custom images, but the Custom Images gallery filtered them out entirely — there was no way to reselect a previously used video without re-browsing stock media.
- The gallery now renders video thumbnails (with a play-icon overlay) alongside images, and the apply logic is type-aware: it sets `backgroundVideoKey` or `backgroundImageKey` depending on the selected file's `mimeType`, and correctly shows/hides the Apply button based on whichever is currently active.
- No upload changes — the upload input still only accepts images; this only surfaces media that's already stored.

## Test plan
- [x] `tsc --noEmit` and `eslint` pass on changed files
- [x] Manually verified in the running app: video thumbnail renders with play icon in Custom Images gallery
- [x] Selecting a video shows the checkmark/selection ring; Apply button correctly hidden when it's already the active background
- [x] Applying a video switches the live preview and sets `backgroundVideoKey` (clearing `backgroundImageKey`)
- [x] Applying an image switches back and sets `backgroundImageKey` (clearing `backgroundVideoKey`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for video backgrounds in the form builder.
  * Video assets now display thumbnails with a play indicator.
  * Custom background selection includes both images and videos.

* **Bug Fixes**
  * Upload progress overlays now remain visible for the item currently uploading in media galleries.
  * Applying a background correctly switches between image and video assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->