### PR TITLE
Fix rich text editor font-size dropdown and Save/Cancel not persisting

### DIFF
--- a/packages/ui/src/rich-text-editor/LexicalRichTextEditor.tsx
+++ b/packages/ui/src/rich-text-editor/LexicalRichTextEditor.tsx
@@ -137,6 +137,14 @@ function OnChangeHandler({
 
   return (
     <OnChangePlugin
+      // Without this, a pure selection move (e.g. AutoFocusPlugin placing the
+      // caret on mount) fires onChange too. Consumers that gate a "Save/Cancel"
+      // UI on "did the content change" then compare this re-serialized HTML
+      // against the originally-stored string and see a false mismatch (Lexical's
+      // export wraps text in `<span style="white-space: pre-wrap;">` that
+      // hand-authored/legacy content never had) - showing unsaved changes, and
+      // reappearing the same way right after Cancel, before any real edit.
+      ignoreSelectionChange
       onChange={(editorState: EditorState) => {
         editorState.read(() => {
           const htmlString = $generateHtmlFromNodes(editor, null);

--- a/packages/ui/src/rich-text-editor/ToolbarPlugin.tsx
+++ b/packages/ui/src/rich-text-editor/ToolbarPlugin.tsx
@@ -3,6 +3,7 @@ import {
   $getSelection,
   $isRangeSelection,
   $getRoot,
+  $setSelection,
   FORMAT_ELEMENT_COMMAND,
   FORMAT_TEXT_COMMAND,
   SELECTION_CHANGE_COMMAND,
@@ -176,8 +177,8 @@ export function ToolbarPlugin(): JSX.Element {
 
   const applyFontSize = (size: string) => {
     editor.update(() => {
-      let selection = $getSelection();
-      if (!$isRangeSelection(selection)) {
+      const original = $getSelection();
+      if (!$isRangeSelection(original)) {
         return;
       }
       // A collapsed selection (cursor placed but no text highlighted) only
@@ -185,12 +186,17 @@ export function ToolbarPlugin(): JSX.Element {
       // any existing text. Since this toolbar is used to size short blocks of
       // already-typed content, fall back to the whole document so the click
       // visibly (and persistently) applies.
-      if (selection.isCollapsed()) {
-        selection = $getRoot().select();
-      }
+      const wasCollapsed = original.isCollapsed();
+      const caret = wasCollapsed ? original.clone() : null;
+      const selection = wasCollapsed ? $getRoot().select() : original;
       $patchStyleText(selection, {
         'font-size': size,
       });
+      // Restore the caret so the whole-document selection used above doesn't
+      // linger and get replaced by the user's next keystroke.
+      if (caret) {
+        $setSelection(caret);
+      }
     });
     setFontSize(size);
   };

--- a/packages/ui/src/rich-text-editor/ToolbarPlugin.tsx
+++ b/packages/ui/src/rich-text-editor/ToolbarPlugin.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   $getSelection,
   $isRangeSelection,
+  $getRoot,
   FORMAT_ELEMENT_COMMAND,
   FORMAT_TEXT_COMMAND,
   SELECTION_CHANGE_COMMAND,
@@ -15,7 +16,11 @@ import {
   REMOVE_LIST_COMMAND,
 } from '@lexical/list';
 import { $isHeadingNode, $createHeadingNode } from '@lexical/rich-text';
-import { $setBlocksType, $patchStyleText } from '@lexical/selection';
+import {
+  $setBlocksType,
+  $patchStyleText,
+  $getSelectionStyleValueForProperty,
+} from '@lexical/selection';
 import { $findMatchingParent, mergeRegister } from '@lexical/utils';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { 
@@ -107,6 +112,9 @@ export function ToolbarPlugin(): JSX.Element {
       setIsBold(selection.hasFormat('bold'));
       setIsItalic(selection.hasFormat('italic'));
       setIsUnderline(selection.hasFormat('underline'));
+      setFontSize(
+        $getSelectionStyleValueForProperty(selection, 'font-size', '16px')
+      );
     }
   }, [editor]);
 
@@ -168,12 +176,21 @@ export function ToolbarPlugin(): JSX.Element {
 
   const applyFontSize = (size: string) => {
     editor.update(() => {
-      const selection = $getSelection();
-      if ($isRangeSelection(selection)) {
-        $patchStyleText(selection, {
-          'font-size': size,
-        });
+      let selection = $getSelection();
+      if (!$isRangeSelection(selection)) {
+        return;
       }
+      // A collapsed selection (cursor placed but no text highlighted) only
+      // records a pending style for characters typed next - it doesn't touch
+      // any existing text. Since this toolbar is used to size short blocks of
+      // already-typed content, fall back to the whole document so the click
+      // visibly (and persistently) applies.
+      if (selection.isCollapsed()) {
+        selection = $getRoot().select();
+      }
+      $patchStyleText(selection, {
+        'font-size': size,
+      });
     });
     setFontSize(size);
   };


### PR DESCRIPTION
## Summary
- Font size picked from the toolbar dropdown with a collapsed selection (cursor placed, no text highlighted — the normal click-and-pick flow) was a silent no-op: Lexical's `$patchStyleText` only queues a pending style for future typed text in that case, never touching existing content. It now falls back to selecting the whole content when nothing is highlighted, so the click actually applies and persists. Verified with an isolated headless-Lexical test before/after the fix.
- The toolbar's font-size label never read back the real style from the selection (only bold/italic/underline/block-type were synced), so it always showed a stale value.
- Save/Cancel appearing stuck ("Cancel doesn't work"): `OnChangePlugin` fired `onChange` on pure selection moves too (e.g. autofocus placing the caret on mount). Lexical's HTML re-export wraps text differently than hand-authored/legacy content (confirmed empirically — `<h1>text</h1>` becomes `<h1><span style="white-space: pre-wrap;">text</span></h1>`), so the layout editors (L1-L7), which gate Save/Cancel visibility on a raw string comparison against the original stored HTML, treated content as "changed" the instant edit mode opened — before any real edit — and the same mismatch reappeared immediately after clicking Cancel.

This is a shared component (`packages/ui/src/rich-text-editor/`), so the fix applies everywhere it's embedded: the L1-L7 layout title/intro text, rich-text field settings, and the thank-you message editor.

## Changes
- `packages/ui/src/rich-text-editor/ToolbarPlugin.tsx`: collapsed-selection font-size now applies to the whole content instead of no-op'ing; toolbar syncs the real font-size via `$getSelectionStyleValueForProperty`.
- `packages/ui/src/rich-text-editor/LexicalRichTextEditor.tsx`: `OnChangePlugin` now uses `ignoreSelectionChange` so it only fires on genuine content edits.

## Test plan
- [x] Isolated headless Lexical test confirmed the collapsed-selection no-op before the fix, and the fix applying font-size correctly after.
- [x] `pnpm build` passes for form-app, form-viewer, admin-app; `pnpm test:unit` passes for backend and form-viewer.
- [ ] Manual smoke test in the builder: open a Layout tab (L1-L7), enter edit mode, pick a font size without highlighting text, click Save, reload — confirm the size persists. Click Cancel with no edits made and confirm it disappears immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented caret/selection-only updates from being treated as editor content changes, avoiding false “unsaved changes” loops.
  * Improved font-size toolbar behavior when no text is selected by correctly deriving the current selection’s `font-size`.
  * Updated font-size application so it works reliably for collapsed selections, while restoring the caret position afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->