### PR TITLE
Automations: Prisma models + migration

### DIFF
--- a/apps/backend/prisma/migrations/20260724120000_add_automation_models/migration.sql
+++ b/apps/backend/prisma/migrations/20260724120000_add_automation_models/migration.sql
@@ -1,0 +1,93 @@
+-- CreateTable: Automation
+-- IF NOT EXISTS: dev environments may already have these tables via `prisma db push`
+CREATE TABLE IF NOT EXISTS "automation" (
+    "id" TEXT NOT NULL,
+    "formId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'DRAFT',
+    "triggerType" TEXT NOT NULL,
+    "triggerConfig" JSONB,
+    "graph" JSONB NOT NULL,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "automation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: AutomationRun
+CREATE TABLE IF NOT EXISTS "automation_run" (
+    "id" TEXT NOT NULL,
+    "automationId" TEXT NOT NULL,
+    "responseId" TEXT,
+    "automationVersion" INTEGER NOT NULL,
+    "graphSnapshot" JSONB NOT NULL,
+    "status" TEXT NOT NULL,
+    "currentNodeId" TEXT,
+    "context" JSONB NOT NULL,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+
+    CONSTRAINT "automation_run_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: AutomationStepRun
+CREATE TABLE IF NOT EXISTS "automation_step_run" (
+    "id" TEXT NOT NULL,
+    "runId" TEXT NOT NULL,
+    "nodeId" TEXT NOT NULL,
+    "nodeType" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "output" JSONB,
+    "errorMessage" TEXT,
+    "attempt" INTEGER NOT NULL DEFAULT 1,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "finishedAt" TIMESTAMP(3),
+
+    CONSTRAINT "automation_step_run_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "automation_formId_idx" ON "automation"("formId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "automation_organizationId_idx" ON "automation"("organizationId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "automation_formId_status_idx" ON "automation"("formId", "status");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "automation_run_automationId_idx" ON "automation_run"("automationId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "automation_run_responseId_idx" ON "automation_run"("responseId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "automation_run_status_idx" ON "automation_run"("status");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "automation_run_automationId_startedAt_idx" ON "automation_run"("automationId", "startedAt");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "automation_step_run_runId_idx" ON "automation_step_run"("runId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "automation_step_run_runId_nodeId_idx" ON "automation_step_run"("runId", "nodeId");
+
+-- AddForeignKey (idempotent — silently skips if constraint already exists)
+DO $$ BEGIN
+  ALTER TABLE "automation" ADD CONSTRAINT "automation_formId_fkey"
+    FOREIGN KEY ("formId") REFERENCES "form"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "automation_run" ADD CONSTRAINT "automation_run_automationId_fkey"
+    FOREIGN KEY ("automationId") REFERENCES "automation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "automation_step_run" ADD CONSTRAINT "automation_step_run_runId_fkey"
+    FOREIGN KEY ("runId") REFERENCES "automation_run"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -172,6 +172,7 @@ model Form {
   aiChatConversations AIChatConversation[]
   pdfTemplates        PdfTemplate[]
   pdfGenerators       PdfGenerator[]
+  automations         Automation[]
 
   @@index([organizationId])
   @@index([organizationId, createdById])
@@ -574,6 +575,75 @@ model PluginBackfillJob {
   @@index([pluginId])
   @@index([formId])
   @@map("plugin_backfill_job")
+}
+
+// Automation System Models
+
+model Automation {
+  id             String   @id @default(cuid())
+  formId         String // Reference to Form
+  organizationId String
+  name           String
+  status         String   @default("DRAFT") // DRAFT | ACTIVE | PAUSED
+  triggerType    String // "form.submitted" | "response.edited" | "schedule"
+  triggerConfig  Json? // e.g. cron expression for schedule trigger
+  graph          Json // { nodes: [...], edges: [...] } - React Flow shape
+  version        Int      @default(1) // bumped on every graph save
+  createdBy      String
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  // Relations
+  form Form              @relation(fields: [formId], references: [id], onDelete: Cascade)
+  runs AutomationRun[]
+
+  @@index([formId])
+  @@index([organizationId])
+  @@index([formId, status])
+  @@map("automation")
+}
+
+model AutomationRun {
+  id                String    @id @default(cuid())
+  automationId      String // Reference to Automation
+  responseId        String? // Reference to Response (nullable for schedule triggers; no FK — response may be deleted while run history remains)
+  automationVersion Int
+  graphSnapshot     Json // graph frozen at trigger time
+  status            String // RUNNING | WAITING | COMPLETED | FAILED | CANCELLED
+  currentNodeId     String?
+  context           Json // trigger payload + accumulated step outputs
+  startedAt         DateTime  @default(now())
+  completedAt       DateTime?
+
+  // Relations
+  automation Automation          @relation(fields: [automationId], references: [id], onDelete: Cascade)
+  stepRuns   AutomationStepRun[]
+
+  @@index([automationId])
+  @@index([responseId])
+  @@index([status])
+  @@index([automationId, startedAt])
+  @@map("automation_run")
+}
+
+model AutomationStepRun {
+  id           String    @id @default(cuid())
+  runId        String // Reference to AutomationRun
+  nodeId       String // node id within graphSnapshot
+  nodeType     String // "trigger" | "delay" | "condition" | "action:<pluginType>" | "end"
+  status       String // SUCCESS | FAILED | SKIPPED
+  output       Json? // handler result / branch taken / delay until
+  errorMessage String?
+  attempt      Int       @default(1)
+  startedAt    DateTime  @default(now())
+  finishedAt   DateTime?
+
+  // Relations
+  run AutomationRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+
+  @@index([runId])
+  @@index([runId, nodeId])
+  @@map("automation_step_run")
 }
 
 // Audit Log Model — records sensitive operations for security/compliance tracing


### PR DESCRIPTION
Closes #202

## Summary
- Adds `Automation`, `AutomationRun`, `AutomationStepRun` models to `apps/backend/prisma/schema.prisma` per the locked data model in `docs/automations-strategy.md` §4 and epic #191.
- Adds the `automations Automation[]` relation on `Form`.
- Follows the naming/`@@map`/index conventions of the existing `FormPlugin`/`PluginDelivery` models.
- Committed migration `apps/backend/prisma/migrations/20260724120000_add_automation_models/` using `CREATE TABLE IF NOT EXISTS` / idempotent `ADD CONSTRAINT` guards, matching the `add_ai_chat` migration template.

Scope: models + migration only — no engine/resolver/seed code (per issue).

## Test plan
- [x] `pnpm db:generate` succeeds
- [x] `pnpm db:push` applied cleanly to the shared dev DB
- [x] `pnpm type-check` passes across all packages
- [x] Migration applies cleanly via `prisma migrate deploy` against a DB where the tables already exist (dev-DB-via-`db push` scenario) — confirmed `IF NOT EXISTS` guards are idempotent
- [x] `prisma migrate status` reports schema up to date after applying

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automation support for forms.
  - Introduced automation workflows with configurable triggers, statuses, versions, and execution graphs.
  - Added execution tracking, including run history, step-level progress, results, errors, retries, and execution context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->