### PR TITLE
Speed up E2E CI job: parallelize setup, raise test concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -465,104 +465,86 @@ jobs:
           name: backend-dist-${{ github.sha }}
           path: apps/backend/dist
 
-      - name: Run migrations
-        run: pnpm db:migrate:deploy
-
-      - name: Seed templates (no S3 uploads)
-        run: |
-          cd apps/backend
-          DATABASE_URL=${{ env.DATABASE_URL }} \
-          BETTER_AUTH_SECRET=${{ env.BETTER_AUTH_SECRET }} \
-          PUBLIC_S3_ENDPOINT=${{ env.PUBLIC_S3_ENDPOINT }} \
-          PUBLIC_S3_ACCESS_KEY=${{ env.PUBLIC_S3_ACCESS_KEY }} \
-          PUBLIC_S3_SECRET_KEY=${{ env.PUBLIC_S3_SECRET_KEY }} \
-          PUBLIC_S3_BUCKET_NAME=${{ env.PUBLIC_S3_BUCKET_NAME }} \
-          PRIVATE_S3_BUCKET_NAME=${{ env.PRIVATE_S3_BUCKET_NAME }} \
-          PUBLIC_S3_CDN_URL=${{ env.PUBLIC_S3_CDN_URL }} \
-          NODE_ENV=test \
-          npx tsx src/scripts/seed-templates-ci.ts || echo "Template seeding done (errors OK)"
-
-      - name: Create E2E test user
-        run: |
-          cd apps/backend
-          DATABASE_URL=${{ env.DATABASE_URL }} \
-          BETTER_AUTH_SECRET=${{ env.BETTER_AUTH_SECRET }} \
-          BETTER_AUTH_URL=${{ env.BETTER_AUTH_URL }} \
-          PUBLIC_S3_ENDPOINT=${{ env.PUBLIC_S3_ENDPOINT }} \
-          PUBLIC_S3_ACCESS_KEY=${{ env.PUBLIC_S3_ACCESS_KEY }} \
-          PUBLIC_S3_SECRET_KEY=${{ env.PUBLIC_S3_SECRET_KEY }} \
-          PUBLIC_S3_BUCKET_NAME=${{ env.PUBLIC_S3_BUCKET_NAME }} \
-          PRIVATE_S3_BUCKET_NAME=${{ env.PRIVATE_S3_BUCKET_NAME }} \
-          PUBLIC_S3_CDN_URL=${{ env.PUBLIC_S3_CDN_URL }} \
-          NODE_ENV=test \
-          E2E_EMAIL=${{ env.E2E_EMAIL }} \
-          E2E_PASSWORD=${{ env.E2E_PASSWORD }} \
-          npx tsx src/scripts/create-e2e-user.ts
-
-      - name: Start backend
-        run: |
-          node apps/backend/dist/apps/backend/src/index.js &
-          echo "BACKEND_PID=$!" >> $GITHUB_ENV
-        env:
-          PORT: 4000
-
-      - name: Wait for backend
-        run: |
-          for i in {1..30}; do
-            if curl -sf http://localhost:4000/health > /dev/null 2>&1; then
-              echo "✅ Backend ready"
-              exit 0
-            fi
-            echo "Waiting for backend (${i}/30)..."
-            sleep 2
-          done
-          echo "❌ Backend failed to start" && exit 1
-
-      - name: Build form-app & form-viewer (parallel)
-        run: |
-          set -e
-          (
-            VITE_API_URL=http://localhost:4000 \
-            VITE_GRAPHQL_URL=http://localhost:4000/graphql \
-            VITE_FORM_VIEWER_URL=http://localhost:5173 \
-            pnpm --filter form-app build
-          ) &
-          FORM_APP_PID=$!
-
-          (
-            VITE_API_URL=http://localhost:4000 \
-            VITE_GRAPHQL_URL=http://localhost:4000/graphql \
-            pnpm --filter form-viewer build
-          ) &
-          FORM_VIEWER_PID=$!
-
-          wait $FORM_APP_PID
-          wait $FORM_VIEWER_PID
-
-      - name: Serve form-app & form-viewer
-        run: |
-          pnpm --filter form-app preview --port 3000 --host &
-          pnpm --filter form-viewer preview --port 5173 --host &
-
-      - name: Wait for frontends
-        run: |
-          for i in {1..30}; do
-            FA=$(curl -sf http://localhost:3000 > /dev/null 2>&1 && echo ok || echo -)
-            FV=$(curl -sf http://localhost:5173 > /dev/null 2>&1 && echo ok || echo -)
-            [ "$FA" = "ok" ] && [ "$FV" = "ok" ] && echo "✅ Both frontends ready" && exit 0
-            echo "Waiting for frontends form-app=$FA viewer=$FV (${i}/30)..."
-            sleep 3
-          done
-          echo "❌ Frontends failed to start" && exit 1
-
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
 
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install chromium --with-deps
+      # Three independent tracks — backend provisioning, frontend build+serve, and
+      # Playwright browser install — don't depend on each other, only on the E2E run
+      # below. Running them as backgrounded subshells in one step (rather than as
+      # separate sequential steps) overlaps their wall-clock time instead of summing it.
+      - name: Provision backend, build frontends, and install Playwright browsers (parallel)
+        run: |
+          set -e
+
+          (
+            set -e
+            pnpm db:migrate:deploy
+
+            cd apps/backend
+            npx tsx src/scripts/seed-templates-ci.ts || echo "Template seeding done (errors OK)"
+            npx tsx src/scripts/create-e2e-user.ts
+            cd ../..
+
+            PORT=4000 node apps/backend/dist/apps/backend/src/index.js &
+
+            for i in {1..30}; do
+              if curl -sf http://localhost:4000/health > /dev/null 2>&1; then
+                echo "✅ Backend ready"
+                exit 0
+              fi
+              echo "Waiting for backend (${i}/30)..."
+              sleep 2
+            done
+            echo "❌ Backend failed to start" && exit 1
+          ) &
+          BACKEND_TRACK=$!
+
+          (
+            set -e
+            (
+              VITE_API_URL=http://localhost:4000 \
+              VITE_GRAPHQL_URL=http://localhost:4000/graphql \
+              VITE_FORM_VIEWER_URL=http://localhost:5173 \
+              pnpm --filter form-app build
+            ) &
+            FORM_APP_PID=$!
+
+            (
+              VITE_API_URL=http://localhost:4000 \
+              VITE_GRAPHQL_URL=http://localhost:4000/graphql \
+              pnpm --filter form-viewer build
+            ) &
+            FORM_VIEWER_PID=$!
+
+            wait $FORM_APP_PID
+            wait $FORM_VIEWER_PID
+
+            pnpm --filter form-app preview --port 3000 --host &
+            pnpm --filter form-viewer preview --port 5173 --host &
+
+            for i in {1..30}; do
+              FA=$(curl -sf http://localhost:3000 > /dev/null 2>&1 && echo ok || echo -)
+              FV=$(curl -sf http://localhost:5173 > /dev/null 2>&1 && echo ok || echo -)
+              [ "$FA" = "ok" ] && [ "$FV" = "ok" ] && echo "✅ Both frontends ready" && exit 0
+              echo "Waiting for frontends form-app=$FA viewer=$FV (${i}/30)..."
+              sleep 3
+            done
+            echo "❌ Frontends failed to start" && exit 1
+          ) &
+          FRONTEND_TRACK=$!
+
+          (
+            set -e
+            pnpm exec playwright install chromium --with-deps
+          ) &
+          PLAYWRIGHT_TRACK=$!
+
+          wait $BACKEND_TRACK
+          wait $FRONTEND_TRACK
+          wait $PLAYWRIGHT_TRACK
 
       - name: Run E2E tests
         run: pnpm test:e2e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -470,6 +470,8 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       # Three independent tracks — backend provisioning, frontend build+serve, and
       # Playwright browser install — don't depend on each other, only on the E2E run

--- a/test/e2e/cucumber.js
+++ b/test/e2e/cucumber.js
@@ -9,7 +9,7 @@ module.exports = {
     format: ['progress'],
     paths: ['test/e2e/features/**/*.feature'],
     publishQuiet: true,
-    parallel: 4,
+    parallel: 6,
     retry: 3,
   },
 };


### PR DESCRIPTION
## Summary
- The `e2e-local` job ran backend provisioning (migrate/seed/create-user/start/wait), frontend build+serve, and Playwright browser install as separate sequential steps, even though none of them depend on each other — only the final `Run E2E tests` step needs all three done. Merged them into one step with three backgrounded tracks joined by `wait`, overlapping ~130s of previously serial setup into the length of the longest track (~55s, per the last successful run's timings).
- Bumped Cucumber's `parallel` worker count from 4 → 6 in `test/e2e/cucumber.js`. The scenarios are network/render-bound browser automation rather than CPU-bound, so oversubscribing past the runner's 4 vCPUs should still help — this targets the E2E test-run step itself, which was the single largest chunk of the job (~3m39s of the ~7m14s total).
- Dropped the now-unused `BACKEND_PID` env var (written to `$GITHUB_ENV` but never read).

Based on real timing pulled from the last successful `build.yml` run via `gh run view`, expected savings are roughly 1.5–2 minutes off the ~7m14s job, without changing test logic or coverage.

## Test plan
- [x] Ran `pnpm --filter backend test:coverage`, `pnpm --filter form-viewer test:unit`, `pnpm --filter {form-viewer,form-app,admin-app} build` locally (pre-push hook) — all pass.
- [ ] Confirm the `e2e-local` job succeeds on this PR's own CI run and check the new step timings.
- [ ] Watch for flakiness from the `parallel: 6` bump; dial back to 5 if scenarios start failing intermittently under contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased end-to-end test parallelization to improve execution time (higher Cucumber worker count).
* **Chores**
  * Streamlined the local end-to-end test environment setup by running backend, frontend, and browser preparation steps in parallel.
  * Added browser download caching to speed up subsequent test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->