### PR TITLE
Automations: condition evaluator + graph validator

### DIFF
--- a/apps/backend/src/services/automation/__tests__/conditionEvaluator.test.ts
+++ b/apps/backend/src/services/automation/__tests__/conditionEvaluator.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateCondition } from '../conditionEvaluator.js';
+import type { ConditionRule } from '../types.js';
+
+describe('evaluateCondition', () => {
+  describe('empty / combinator basics', () => {
+    it('returns true for an empty rules array regardless of combinator', () => {
+      expect(evaluateCondition([], 'AND', { a: '1' })).toBe(true);
+      expect(evaluateCondition([], 'OR', { a: '1' })).toBe(true);
+    });
+
+    it('AND requires every rule to pass', () => {
+      const rules: ConditionRule[] = [
+        { fieldId: 'age', operator: 'GREATER_THAN', value: '18' },
+        { fieldId: 'name', operator: 'EQUALS', value: 'Jane' },
+      ];
+      expect(evaluateCondition(rules, 'AND', { age: '25', name: 'Jane' })).toBe(true);
+      expect(evaluateCondition(rules, 'AND', { age: '10', name: 'Jane' })).toBe(false);
+    });
+
+    it('OR requires at least one rule to pass', () => {
+      const rules: ConditionRule[] = [
+        { fieldId: 'age', operator: 'GREATER_THAN', value: '18' },
+        { fieldId: 'name', operator: 'EQUALS', value: 'Jane' },
+      ];
+      expect(evaluateCondition(rules, 'OR', { age: '10', name: 'Jane' })).toBe(true);
+      expect(evaluateCondition(rules, 'OR', { age: '10', name: 'John' })).toBe(false);
+    });
+  });
+
+  describe('IS_EMPTY / IS_NOT_EMPTY', () => {
+    it('IS_EMPTY matches null, undefined, empty string, empty array', () => {
+      const rule: ConditionRule = { fieldId: 'f', operator: 'IS_EMPTY' };
+      expect(evaluateCondition([rule], 'AND', { f: null })).toBe(true);
+      expect(evaluateCondition([rule], 'AND', {})).toBe(true);
+      expect(evaluateCondition([rule], 'AND', { f: '' })).toBe(true);
+      expect(evaluateCondition([rule], 'AND', { f: [] })).toBe(true);
+      expect(evaluateCondition([rule], 'AND', { f: 'x' })).toBe(false);
+    });
+
+    it('IS_NOT_EMPTY is the inverse', () => {
+      const rule: ConditionRule = { fieldId: 'f', operator: 'IS_NOT_EMPTY' };
+      expect(evaluateCondition([rule], 'AND', { f: 'x' })).toBe(true);
+      expect(evaluateCondition([rule], 'AND', { f: null })).toBe(false);
+    });
+  });
+
+  describe('EQUALS / NOT_EQUALS', () => {
+    it('EQUALS is case-insensitive string equality', () => {
+      const rule: ConditionRule = { fieldId: 'f', operator: 'EQUALS', value: 'Hello' };
+      expect(evaluateCondition([rule], 'AND', { f: 'hello' })).toBe(true);
+      expect(evaluateCondition([rule], 'AND', { f: 'world' })).toBe(false);
+    });
+
+    it('EQUALS with array field + values does an order-independent exact match', () => {
+      const rule: ConditionRule = { fieldId: 'f', operator: 'EQUALS', values: ['b', 'a'] };
+      expect(evaluateCondition([rule], 'AND', { f: ['a', 'b'] })).toBe(true);
+      expect(evaluateCondition([rule], 'AND', { f: ['a', 'b', 'c'] })).toBe(false);
+    });
+
+    it('EQUALS returns false when no value/values provided', () => {
+      const rule: ConditionRule = { fieldId: 'f', operator: 'EQUALS' };
+      expect(evaluateCondition([rule], 'AND', { f: 'anything' })).toBe(false);
+    });
+
+    it('NOT_EQUALS treats missing/empty field values as "not equal" (true)', () => {
+      const rule: ConditionRule = { fieldId: 'f', operator: 'NOT_EQUALS', value: 'x' };
+      expect(evaluateCondition([rule], 'AND', {})).toBe(true);
+      expect(evaluateCondition([rule], 'AND', { f: 'x' })).toBe(false);
+      expect(evaluateCondition([rule], 'AND', { f: 'y' })).toBe(true);
+    });
+  });
+
+  describe('CONTAINS / NOT_CONTAINS', () => {
+    it('CONTAINS matches substrings case-insensitively', () => {
+      const rule: ConditionRule = { fieldId: 'f', operator: 'CONTAINS', value: 'lo w' };
+      expect(evaluateCondition([rule], 'AND', { f: 'Hello World' })).toBe(true);
+      expect(evaluateCondition([rule], 'AND', { f: 'nope' })).toBe(false);
+    });
+
+    it('CONTAINS on array fields requires an exact element match', () => {
+      const rule: ConditionRule = { fieldId: 'f', operator: 'CONTAINS', value: 'js' };
+      expect(evaluateCondition([rule], 'AND', { f: ['js', 'ts'] })).toBe(true);
+      expect(evaluateCondition([rule], 'AND', { f: ['java'] })).toBe(false);
+    });
+
+    it('CONTAINS with empty search value never matches', () => {
+      const rule: ConditionRule = { fieldId: 'f', operator: 'CONTAINS', value: '' };
+      expect(evaluateCondition([rule], 'AND', { f: 'anything' })).toBe(false);
+    });
+
+    it('NOT_CONTAINS is the inverse, and empty search value always passes', () => {
+      const rule: ConditionRule = { fieldId: 'f', operator: 'NOT_CONTAINS', value: 'x' };
+      expect(evaluateCondition([rule], 'AND', { f: 'yz' })).toBe(true);
+      expect(evaluateCondition([rule], 'AND', { f: 'ax' })).toBe(false);
+      expect(evaluateCondition([{ fieldId: 'f', operator: 'NOT_CONTAINS', value: '' }], 'AND', { f: 'anything' })).toBe(true);
+    });
+  });
+
+  describe('STARTS_WITH / ENDS_WITH', () => {
+    it('STARTS_WITH / ENDS_WITH are case-insensitive', () => {
+      expect(
+        evaluateCondition([{ fieldId: 'f', operator: 'STARTS_WITH', value: 'HEL' }], 'AND', { f: 'hello' })
+      ).toBe(true);
+      expect(
+        evaluateCondition([{ fieldId: 'f', operator: 'ENDS_WITH', value: 'LO' }], 'AND', { f: 'hello' })
+      ).toBe(true);
+      expect(
+        evaluateCondition([{ fieldId: 'f', operator: 'STARTS_WITH', value: 'x' }], 'AND', { f: 'hello' })
+      ).toBe(false);
+    });
+
+    it('STARTS_WITH / ENDS_WITH are false when the field value is empty', () => {
+      expect(
+        evaluateCondition([{ fieldId: 'f', operator: 'STARTS_WITH', value: '' }], 'AND', {})
+      ).toBe(false);
+    });
+  });
+
+  describe('numeric comparisons', () => {
+    const rules = (operator: string, value: string): ConditionRule[] => [
+      { fieldId: 'age', operator, value },
+    ];
+
+    it('GREATER_THAN / GREATER_THAN_OR_EQUAL', () => {
+      expect(evaluateCondition(rules('GREATER_THAN', '18'), 'AND', { age: '19' })).toBe(true);
+      expect(evaluateCondition(rules('GREATER_THAN', '18'), 'AND', { age: '18' })).toBe(false);
+      expect(evaluateCondition(rules('GREATER_THAN_OR_EQUAL', '18'), 'AND', { age: '18' })).toBe(true);
+    });
+
+    it('LESS_THAN / LESS_THAN_OR_EQUAL', () => {
+      expect(evaluateCondition(rules('LESS_THAN', '18'), 'AND', { age: '10' })).toBe(true);
+      expect(evaluateCondition(rules('LESS_THAN', '18'), 'AND', { age: '18' })).toBe(false);
+      expect(evaluateCondition(rules('LESS_THAN_OR_EQUAL', '18'), 'AND', { age: '18' })).toBe(true);
+    });
+
+    it('numeric operators return false for non-numeric field values', () => {
+      expect(evaluateCondition(rules('GREATER_THAN', '18'), 'AND', { age: 'not-a-number' })).toBe(false);
+    });
+
+    it('BETWEEN uses numberRange with optional min/max', () => {
+      const rule: ConditionRule = { fieldId: 'age', operator: 'BETWEEN', numberRange: { min: 18, max: 30 } };
+      expect(evaluateCondition([rule], 'AND', { age: 25 })).toBe(true);
+      expect(evaluateCondition([rule], 'AND', { age: 35 })).toBe(false);
+      expect(evaluateCondition([{ fieldId: 'age', operator: 'BETWEEN' }], 'AND', { age: 25 })).toBe(false);
+    });
+  });
+
+  describe('IN / NOT_IN / CONTAINS_ALL', () => {
+    it('IN matches select/radio string fields', () => {
+      const rule: ConditionRule = { fieldId: 'f', operator: 'IN', values: ['a', 'b'] };
+      expect(evaluateCondition([rule], 'AND', { f: 'b' })).toBe(true);
+      expect(evaluateCondition([rule], 'AND', { f: 'c' })).toBe(false);
+    });
+
+    it('IN matches checkbox array fields (any overlap)', () => {
+      const rule: ConditionRule = { fieldId: 'f', operator: 'IN', values: ['a', 'b'] };
+      expect(evaluateCondition([rule], 'AND', { f: ['x', 'b'] })).toBe(true);
+    });
+
+    it('NOT_IN is the inverse', () => {
+      const rule: ConditionRule = { fieldId: 'f', operator: 'NOT_IN', values: ['a', 'b'] };
+      expect(evaluateCondition([rule], 'AND', { f: 'c' })).toBe(true);
+      expect(evaluateCondition([rule], 'AND', { f: 'a' })).toBe(false);
+    });
+
+    it('CONTAINS_ALL requires every value present in an array field', () => {
+      const rule: ConditionRule = { fieldId: 'f', operator: 'CONTAINS_ALL', values: ['js', 'ts'] };
+      expect(evaluateCondition([rule], 'AND', { f: ['js', 'ts', 'react'] })).toBe(true);
+      expect(evaluateCondition([rule], 'AND', { f: ['js'] })).toBe(false);
+      expect(evaluateCondition([rule], 'AND', { f: 'js' })).toBe(false);
+    });
+  });
+
+  describe('date operators', () => {
+    it('DATE_EQUALS / DATE_BEFORE / DATE_AFTER', () => {
+      const iso = new Date('2024-06-01T00:00:00Z').toISOString();
+      expect(
+        evaluateCondition([{ fieldId: 'd', operator: 'DATE_EQUALS', value: iso }], 'AND', { d: iso })
+      ).toBe(true);
+      expect(
+        evaluateCondition(
+          [{ fieldId: 'd', operator: 'DATE_BEFORE', value: new Date('2024-06-02').toISOString() }],
+          'AND',
+          { d: iso }
+        )
+      ).toBe(true);
+      expect(
+        evaluateCondition(
+          [{ fieldId: 'd', operator: 'DATE_AFTER', value: new Date('2024-05-01').toISOString() }],
+          'AND',
+          { d: iso }
+        )
+      ).toBe(true);
+    });
+
+    it('DATE_EQUALS returns false for an unparseable field value', () => {
+      const rule: ConditionRule = { fieldId: 'd', operator: 'DATE_EQUALS', value: new Date().toISOString() };
+      expect(evaluateCondition([rule], 'AND', { d: 'not-a-date' })).toBe(false);
+    });
+
+    it('DATE_BETWEEN uses dateRange with optional from/to', () => {
+      const rule: ConditionRule = {
+        fieldId: 'd',
+        operator: 'DATE_BETWEEN',
+        dateRange: { from: '2024-01-01', to: '2024-12-31' },
+      };
+      expect(evaluateCondition([rule], 'AND', { d: '2024-06-01' })).toBe(true);
+      expect(evaluateCondition([rule], 'AND', { d: '2025-01-01' })).toBe(false);
+      expect(evaluateCondition([{ fieldId: 'd', operator: 'DATE_BETWEEN' }], 'AND', { d: '2024-06-01' })).toBe(false);
+    });
+
+    it('DATE_TODAY matches only the current day', () => {
+      const rule: ConditionRule = { fieldId: 'd', operator: 'DATE_TODAY' };
+      expect(evaluateCondition([rule], 'AND', { d: new Date().toISOString() })).toBe(true);
+      expect(evaluateCondition([rule], 'AND', { d: '2020-01-01' })).toBe(false);
+    });
+
+    it('DATE_LAST_N_DAYS matches recent dates and rejects negative N', () => {
+      const recent = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+      expect(
+        evaluateCondition([{ fieldId: 'd', operator: 'DATE_LAST_N_DAYS', value: '7' }], 'AND', { d: recent })
+      ).toBe(true);
+      expect(
+        evaluateCondition([{ fieldId: 'd', operator: 'DATE_LAST_N_DAYS', value: '-5' }], 'AND', { d: recent })
+      ).toBe(false);
+    });
+  });
+
+  describe('null / undefined field access', () => {
+    it('handles a rule whose fieldId is absent from responseData', () => {
+      const rule: ConditionRule = { fieldId: 'missing', operator: 'EQUALS', value: 'x' };
+      expect(evaluateCondition([rule], 'AND', { other: 'y' })).toBe(false);
+    });
+
+    it('unknown operator names fail closed (false)', () => {
+      const rule = { fieldId: 'f', operator: 'NOT_A_REAL_OPERATOR' } as unknown as ConditionRule;
+      expect(evaluateCondition([rule], 'AND', { f: 'x' })).toBe(false);
+    });
+  });
+});

--- a/apps/backend/src/services/automation/__tests__/graphValidator.test.ts
+++ b/apps/backend/src/services/automation/__tests__/graphValidator.test.ts
@@ -1,0 +1,430 @@
+import { describe, it, expect } from 'vitest';
+import { validateAutomationGraph, GRAPH_ERROR_CODES } from '../graphValidator.js';
+import type { AutomationGraph } from '../types.js';
+
+const PLUGIN_TYPES = ['email', 'webhook', 'slack', 'quiz-grading'];
+
+function validate(graph: unknown, pluginTypes: string[] = PLUGIN_TYPES) {
+  return validateAutomationGraph(graph, { pluginTypes });
+}
+
+function codesOf(result: ReturnType<typeof validate>): string[] {
+  return result.errors.map((e) => e.code);
+}
+
+const validGraph: AutomationGraph = {
+  nodes: [
+    { id: 'trigger-1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+    { id: 'delay-1', type: 'delay', data: { amount: 1, unit: 'hours' } },
+    {
+      id: 'condition-1',
+      type: 'condition',
+      data: {
+        rules: [{ fieldId: 'age', operator: 'GREATER_THAN', value: '18' }],
+        combinator: 'AND',
+      },
+    },
+    {
+      id: 'action-email',
+      type: 'action',
+      data: {
+        actionType: 'email',
+        config: { recipientEmail: 'a@b.com', subject: 'Hi', message: 'Hello' },
+      },
+    },
+    { id: 'end-1', type: 'end' },
+  ],
+  edges: [
+    { id: 'e1', source: 'trigger-1', target: 'delay-1' },
+    { id: 'e2', source: 'delay-1', target: 'condition-1' },
+    { id: 'e3', source: 'condition-1', target: 'action-email', sourceHandle: 'true' },
+    { id: 'e4', source: 'condition-1', target: 'end-1', sourceHandle: 'false' },
+    { id: 'e5', source: 'action-email', target: 'end-1' },
+  ],
+};
+
+describe('validateAutomationGraph', () => {
+  it('accepts a well-formed graph with no errors', () => {
+    const result = validate(validGraph);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('INVALID_GRAPH_SHAPE: rejects malformed graph structure', () => {
+    const result = validate({ nodes: 'not-an-array', edges: [] });
+    expect(result.valid).toBe(false);
+    expect(codesOf(result)).toEqual([GRAPH_ERROR_CODES.INVALID_GRAPH_SHAPE]);
+  });
+
+  it('INVALID_GRAPH_SHAPE: rejects an unknown node type', () => {
+    const result = validate({
+      nodes: [{ id: 'n1', type: 'not-a-real-type', data: {} }],
+      edges: [],
+    });
+    expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.INVALID_GRAPH_SHAPE);
+  });
+
+  it('MISSING_TRIGGER: rejects a graph with zero trigger nodes', () => {
+    const graph: AutomationGraph = { nodes: [{ id: 'end-1', type: 'end' }], edges: [] };
+    const result = validate(graph);
+    expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.MISSING_TRIGGER);
+  });
+
+  it('MULTIPLE_TRIGGERS: rejects a graph with more than one trigger node', () => {
+    const graph: AutomationGraph = {
+      nodes: [
+        { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+        { id: 't2', type: 'trigger', data: { triggerType: 'form.submitted' } },
+        { id: 'end-1', type: 'end' },
+      ],
+      edges: [
+        { id: 'e1', source: 't1', target: 'end-1' },
+        { id: 'e2', source: 't2', target: 'end-1' },
+      ],
+    };
+    const result = validate(graph);
+    expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.MULTIPLE_TRIGGERS);
+  });
+
+  it('INVALID_TRIGGER_CONFIG: rejects a trigger node missing triggerType', () => {
+    const graph: AutomationGraph = {
+      nodes: [
+        { id: 't1', type: 'trigger', data: {} as any },
+        { id: 'end-1', type: 'end' },
+      ],
+      edges: [{ id: 'e1', source: 't1', target: 'end-1' }],
+    };
+    const result = validate(graph);
+    expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.INVALID_TRIGGER_CONFIG);
+  });
+
+  it('INVALID_EDGE: rejects an edge referencing a non-existent node', () => {
+    const graph: AutomationGraph = {
+      nodes: [
+        { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+        { id: 'end-1', type: 'end' },
+      ],
+      edges: [{ id: 'e1', source: 't1', target: 'does-not-exist' }],
+    };
+    const result = validate(graph);
+    expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.INVALID_EDGE);
+  });
+
+  it('GRAPH_CYCLE: rejects a graph containing a cycle', () => {
+    const graph: AutomationGraph = {
+      nodes: [
+        { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+        { id: 'd1', type: 'delay', data: { amount: 1, unit: 'minutes' } },
+        { id: 'd2', type: 'delay', data: { amount: 1, unit: 'minutes' } },
+      ],
+      edges: [
+        { id: 'e1', source: 't1', target: 'd1' },
+        { id: 'e2', source: 'd1', target: 'd2' },
+        { id: 'e3', source: 'd2', target: 'd1' },
+      ],
+    };
+    const result = validate(graph);
+    expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.GRAPH_CYCLE);
+  });
+
+  it('ORPHAN_NODE: rejects a node unreachable from the trigger', () => {
+    const graph: AutomationGraph = {
+      nodes: [
+        { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+        { id: 'end-1', type: 'end' },
+        { id: 'orphan', type: 'end' },
+      ],
+      edges: [{ id: 'e1', source: 't1', target: 'end-1' }],
+    };
+    const result = validate(graph);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ nodeId: 'orphan', code: GRAPH_ERROR_CODES.ORPHAN_NODE })
+    );
+  });
+
+  it('NO_REACHABLE_END: rejects a graph where every reachable node has a successor (pure cycle)', () => {
+    // With a valid (acyclic) reachable subgraph a sink always exists by pigeonhole, so the
+    // only way to have zero reachable nodes with no successor is a cycle in the reachable
+    // set itself — this co-occurs with GRAPH_CYCLE rather than being mutually exclusive.
+    const graph: AutomationGraph = {
+      nodes: [
+        { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+        { id: 'd1', type: 'delay', data: { amount: 1, unit: 'minutes' } },
+        { id: 'd2', type: 'delay', data: { amount: 1, unit: 'minutes' } },
+      ],
+      edges: [
+        { id: 'e1', source: 't1', target: 'd1' },
+        { id: 'e2', source: 'd1', target: 'd2' },
+        { id: 'e3', source: 'd2', target: 'd1' },
+      ],
+    };
+    const result = validate(graph);
+    expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.GRAPH_CYCLE);
+    expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.NO_REACHABLE_END);
+  });
+
+  it('INVALID_CONDITION_BRANCH: rejects a condition node with two true edges', () => {
+    const graph: AutomationGraph = {
+      nodes: [
+        { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+        {
+          id: 'c1',
+          type: 'condition',
+          data: { rules: [{ fieldId: 'f', operator: 'IS_EMPTY' }], combinator: 'AND' },
+        },
+        { id: 'end-1', type: 'end' },
+        { id: 'end-2', type: 'end' },
+      ],
+      edges: [
+        { id: 'e1', source: 't1', target: 'c1' },
+        { id: 'e2', source: 'c1', target: 'end-1', sourceHandle: 'true' },
+        { id: 'e3', source: 'c1', target: 'end-2', sourceHandle: 'true' },
+      ],
+    };
+    const result = validate(graph);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ nodeId: 'c1', code: GRAPH_ERROR_CODES.INVALID_CONDITION_BRANCH })
+    );
+  });
+
+  it('INVALID_CONDITION_BRANCH: rejects a condition node with an untagged outgoing edge', () => {
+    const graph: AutomationGraph = {
+      nodes: [
+        { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+        {
+          id: 'c1',
+          type: 'condition',
+          data: { rules: [{ fieldId: 'f', operator: 'IS_EMPTY' }], combinator: 'AND' },
+        },
+        { id: 'end-1', type: 'end' },
+      ],
+      edges: [
+        { id: 'e1', source: 't1', target: 'c1' },
+        { id: 'e2', source: 'c1', target: 'end-1' },
+      ],
+    };
+    const result = validate(graph);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ nodeId: 'c1', code: GRAPH_ERROR_CODES.INVALID_CONDITION_BRANCH })
+    );
+  });
+
+  it('INVALID_CONDITION_CONFIG: rejects a condition node with empty rules', () => {
+    const graph: AutomationGraph = {
+      nodes: [
+        { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+        { id: 'c1', type: 'condition', data: { rules: [], combinator: 'AND' } },
+        { id: 'end-1', type: 'end' },
+      ],
+      edges: [
+        { id: 'e1', source: 't1', target: 'c1' },
+        { id: 'e2', source: 'c1', target: 'end-1', sourceHandle: 'true' },
+      ],
+    };
+    const result = validate(graph);
+    expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.INVALID_CONDITION_CONFIG);
+  });
+
+  it('INVALID_CONDITION_CONFIG: rejects a condition node with an unknown operator', () => {
+    const graph: AutomationGraph = {
+      nodes: [
+        { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+        {
+          id: 'c1',
+          type: 'condition',
+          data: { rules: [{ fieldId: 'f', operator: 'NOT_A_REAL_OP' }], combinator: 'AND' },
+        },
+        { id: 'end-1', type: 'end' },
+      ],
+      edges: [
+        { id: 'e1', source: 't1', target: 'c1' },
+        { id: 'e2', source: 'c1', target: 'end-1', sourceHandle: 'true' },
+      ],
+    };
+    const result = validate(graph);
+    expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.INVALID_CONDITION_CONFIG);
+  });
+
+  it('INVALID_DELAY: rejects a delay node with a non-positive amount', () => {
+    const graph: AutomationGraph = {
+      nodes: [
+        { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+        { id: 'd1', type: 'delay', data: { amount: 0, unit: 'minutes' } },
+        { id: 'end-1', type: 'end' },
+      ],
+      edges: [
+        { id: 'e1', source: 't1', target: 'd1' },
+        { id: 'e2', source: 'd1', target: 'end-1' },
+      ],
+    };
+    const result = validate(graph);
+    expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.INVALID_DELAY);
+  });
+
+  it('INVALID_DELAY: rejects a delay node with an unsupported unit', () => {
+    const graph: AutomationGraph = {
+      nodes: [
+        { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+        { id: 'd1', type: 'delay', data: { amount: 5, unit: 'weeks' } as any },
+        { id: 'end-1', type: 'end' },
+      ],
+      edges: [
+        { id: 'e1', source: 't1', target: 'd1' },
+        { id: 'e2', source: 'd1', target: 'end-1' },
+      ],
+    };
+    const result = validate(graph);
+    expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.INVALID_DELAY);
+  });
+
+  it('DELAY_LIMIT_EXCEEDED: rejects a path whose cumulative delay exceeds 30 days', () => {
+    const graph: AutomationGraph = {
+      nodes: [
+        { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+        { id: 'd1', type: 'delay', data: { amount: 20, unit: 'days' } },
+        { id: 'd2', type: 'delay', data: { amount: 15, unit: 'days' } },
+        { id: 'end-1', type: 'end' },
+      ],
+      edges: [
+        { id: 'e1', source: 't1', target: 'd1' },
+        { id: 'e2', source: 'd1', target: 'd2' },
+        { id: 'e3', source: 'd2', target: 'end-1' },
+      ],
+    };
+    const result = validate(graph);
+    expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.DELAY_LIMIT_EXCEEDED);
+  });
+
+  it('allows a single delay node at exactly the 30-day cap', () => {
+    const graph: AutomationGraph = {
+      nodes: [
+        { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+        { id: 'd1', type: 'delay', data: { amount: 30, unit: 'days' } },
+        { id: 'end-1', type: 'end' },
+      ],
+      edges: [
+        { id: 'e1', source: 't1', target: 'd1' },
+        { id: 'e2', source: 'd1', target: 'end-1' },
+      ],
+    };
+    const result = validate(graph);
+    expect(codesOf(result)).not.toContain(GRAPH_ERROR_CODES.DELAY_LIMIT_EXCEEDED);
+  });
+
+  it('UNKNOWN_ACTION_TYPE: rejects an actionType not in the registered plugin types', () => {
+    const graph: AutomationGraph = {
+      nodes: [
+        { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+        { id: 'a1', type: 'action', data: { actionType: 'carrier-pigeon', config: {} } },
+        { id: 'end-1', type: 'end' },
+      ],
+      edges: [
+        { id: 'e1', source: 't1', target: 'a1' },
+        { id: 'e2', source: 'a1', target: 'end-1' },
+      ],
+    };
+    const result = validate(graph);
+    expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.UNKNOWN_ACTION_TYPE);
+  });
+
+  describe('INVALID_ACTION_CONFIG', () => {
+    it('rejects an email action missing both recipientEmail and recipientFieldId', () => {
+      const graph: AutomationGraph = {
+        nodes: [
+          { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+          {
+            id: 'a1',
+            type: 'action',
+            data: { actionType: 'email', config: { subject: 'Hi', message: 'Hello' } },
+          },
+          { id: 'end-1', type: 'end' },
+        ],
+        edges: [
+          { id: 'e1', source: 't1', target: 'a1' },
+          { id: 'e2', source: 'a1', target: 'end-1' },
+        ],
+      };
+      const result = validate(graph);
+      expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.INVALID_ACTION_CONFIG);
+    });
+
+    it('rejects a webhook action with a non-URL url', () => {
+      const graph: AutomationGraph = {
+        nodes: [
+          { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+          { id: 'a1', type: 'action', data: { actionType: 'webhook', config: { url: 'not-a-url' } } },
+          { id: 'end-1', type: 'end' },
+        ],
+        edges: [
+          { id: 'e1', source: 't1', target: 'a1' },
+          { id: 'e2', source: 'a1', target: 'end-1' },
+        ],
+      };
+      const result = validate(graph);
+      expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.INVALID_ACTION_CONFIG);
+    });
+
+    it('rejects a slack action missing a message', () => {
+      const graph: AutomationGraph = {
+        nodes: [
+          { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+          {
+            id: 'a1',
+            type: 'action',
+            data: { actionType: 'slack', config: { webhookUrl: 'https://hooks.slack.com/x' } },
+          },
+          { id: 'end-1', type: 'end' },
+        ],
+        edges: [
+          { id: 'e1', source: 't1', target: 'a1' },
+          { id: 'e2', source: 'a1', target: 'end-1' },
+        ],
+      };
+      const result = validate(graph);
+      expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.INVALID_ACTION_CONFIG);
+    });
+
+    it('accepts a valid webhook action config', () => {
+      const graph: AutomationGraph = {
+        nodes: [
+          { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+          {
+            id: 'a1',
+            type: 'action',
+            data: { actionType: 'webhook', config: { url: 'https://example.com/hook' } },
+          },
+          { id: 'end-1', type: 'end' },
+        ],
+        edges: [
+          { id: 'e1', source: 't1', target: 'a1' },
+          { id: 'e2', source: 'a1', target: 'end-1' },
+        ],
+      };
+      const result = validate(graph);
+      expect(result.valid).toBe(true);
+    });
+
+    it('does not apply per-type config validation to action types without a dedicated schema', () => {
+      const graph: AutomationGraph = {
+        nodes: [
+          { id: 't1', type: 'trigger', data: { triggerType: 'form.submitted' } },
+          { id: 'a1', type: 'action', data: { actionType: 'quiz-grading', config: {} } },
+          { id: 'end-1', type: 'end' },
+        ],
+        edges: [
+          { id: 'e1', source: 't1', target: 'a1' },
+          { id: 'e2', source: 'a1', target: 'end-1' },
+        ],
+      };
+      const result = validate(graph);
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  it('collects multiple independent errors in a single pass', () => {
+    const graph: AutomationGraph = { nodes: [], edges: [] };
+    const result = validate(graph);
+    expect(result.valid).toBe(false);
+    expect(codesOf(result)).toContain(GRAPH_ERROR_CODES.MISSING_TRIGGER);
+  });
+});

--- a/apps/backend/src/services/automation/conditionEvaluator.ts
+++ b/apps/backend/src/services/automation/conditionEvaluator.ts
@@ -1,15 +1,24 @@
 import type { ConditionCombinator, ConditionRule } from './types.js';
+import { evaluateFilterOperator } from '../responseFilterService.js';
 
 /**
- * Placeholder pending #193 (condition evaluator + graph validator), which reuses the
- * 22 filter operators from responseFilterService.ts against this same rule shape. Kept
- * as a standalone module so engine.ts's condition-node branching can be wired and tested
- * now (via mocking this function) without depending on #193 landing first.
+ * Evaluates a condition node's rules against a flat responseData map, reusing the exact
+ * same 22-operator semantics as the Responses filter (services/responseFilterService.ts)
+ * via the shared evaluateFilterOperator function — so the two can never drift apart.
+ *
+ * An empty rules array evaluates to true regardless of combinator, mirroring
+ * applyResponseFilters' "no filters means nothing to exclude" behavior. graphValidator
+ * rejects empty rules on save/activate, so this is a defensive default, not a relied-upon path.
  */
 export function evaluateCondition(
-  _rules: ConditionRule[],
-  _combinator: ConditionCombinator,
-  _responseData: Record<string, any>
+  rules: ConditionRule[],
+  combinator: ConditionCombinator,
+  responseData: Record<string, any>
 ): boolean {
-  return false;
+  if (!rules || rules.length === 0) return true;
+
+  const evaluateRule = (rule: ConditionRule): boolean =>
+    evaluateFilterOperator(rule.operator, responseData?.[rule.fieldId], rule);
+
+  return combinator === 'OR' ? rules.some(evaluateRule) : rules.every(evaluateRule);
 }

--- a/apps/backend/src/services/automation/graphValidator.ts
+++ b/apps/backend/src/services/automation/graphValidator.ts
@@ -104,7 +104,7 @@ const ActionDataSchema = z.object({
 // stricter per-type validation.
 const EmailActionConfigSchema = z
   .object({
-    recipientEmail: z.string().email().optional(),
+    recipientEmail: z.email().optional(),
     recipientFieldId: z.string().optional(),
     recipientFieldLabel: z.string().optional(),
     subject: z.string().min(1),
@@ -118,7 +118,7 @@ const EmailActionConfigSchema = z
   });
 
 const WebhookActionConfigSchema = z.object({
-  url: z.string().url(),
+  url: z.url(),
   secret: z.string().optional(),
   headers: z.record(z.string(), z.string()).optional(),
 });
@@ -126,7 +126,7 @@ const WebhookActionConfigSchema = z.object({
 // Slack has no backend plugin handler yet (packages/plugins/src/manifests/slack.ts marks it
 // comingSoon); this schema documents the intended config shape ahead of that handler landing.
 const SlackActionConfigSchema = z.object({
-  webhookUrl: z.string().url(),
+  webhookUrl: z.url(),
   channel: z.string().optional(),
   message: z.string().min(1),
 });

--- a/apps/backend/src/services/automation/graphValidator.ts
+++ b/apps/backend/src/services/automation/graphValidator.ts
@@ -1,0 +1,435 @@
+import { z } from 'zod';
+import type { DelayUnit } from './types.js';
+
+export interface GraphValidationError {
+  nodeId?: string;
+  code: string;
+  message: string;
+}
+
+export interface GraphValidationResult {
+  valid: boolean;
+  errors: GraphValidationError[];
+}
+
+export interface ValidateAutomationGraphOptions {
+  /** Registered plugin/action types, e.g. getAvailablePluginTypes() from plugins/core/registry.ts. */
+  pluginTypes: string[];
+}
+
+/** Stable error codes surfaced to the builder UI (#197) for node-level badges. */
+export const GRAPH_ERROR_CODES = {
+  INVALID_GRAPH_SHAPE: 'INVALID_GRAPH_SHAPE',
+  MISSING_TRIGGER: 'MISSING_TRIGGER',
+  MULTIPLE_TRIGGERS: 'MULTIPLE_TRIGGERS',
+  INVALID_TRIGGER_CONFIG: 'INVALID_TRIGGER_CONFIG',
+  INVALID_EDGE: 'INVALID_EDGE',
+  GRAPH_CYCLE: 'GRAPH_CYCLE',
+  ORPHAN_NODE: 'ORPHAN_NODE',
+  NO_REACHABLE_END: 'NO_REACHABLE_END',
+  INVALID_CONDITION_BRANCH: 'INVALID_CONDITION_BRANCH',
+  INVALID_CONDITION_CONFIG: 'INVALID_CONDITION_CONFIG',
+  INVALID_DELAY: 'INVALID_DELAY',
+  DELAY_LIMIT_EXCEEDED: 'DELAY_LIMIT_EXCEEDED',
+  UNKNOWN_ACTION_TYPE: 'UNKNOWN_ACTION_TYPE',
+  INVALID_ACTION_CONFIG: 'INVALID_ACTION_CONFIG',
+} as const;
+
+// Mirrors the 22-operator FilterOperator enum in graphql/schema.ts / responseFilterService.ts.
+const FILTER_OPERATORS = [
+  'EQUALS', 'NOT_EQUALS', 'CONTAINS', 'NOT_CONTAINS', 'STARTS_WITH', 'ENDS_WITH',
+  'IN', 'NOT_IN', 'CONTAINS_ALL',
+  'GREATER_THAN', 'GREATER_THAN_OR_EQUAL', 'LESS_THAN', 'LESS_THAN_OR_EQUAL', 'BETWEEN',
+  'IS_EMPTY', 'IS_NOT_EMPTY',
+  'DATE_EQUALS', 'DATE_BEFORE', 'DATE_AFTER', 'DATE_BETWEEN', 'DATE_TODAY', 'DATE_LAST_N_DAYS',
+] as const;
+
+const MAX_DELAY_DAYS = 30;
+const DELAY_UNIT_TO_MINUTES: Record<DelayUnit, number> = {
+  minutes: 1,
+  hours: 60,
+  days: 24 * 60,
+};
+
+const RawNodeSchema = z.object({
+  id: z.string().min(1),
+  type: z.enum(['trigger', 'delay', 'condition', 'action', 'end']),
+  data: z.record(z.string(), z.any()).default({}),
+});
+
+const RawEdgeSchema = z.object({
+  id: z.string().min(1),
+  source: z.string().min(1),
+  target: z.string().min(1),
+  sourceHandle: z.enum(['true', 'false']).optional(),
+});
+
+const RawGraphSchema = z.object({
+  nodes: z.array(RawNodeSchema),
+  edges: z.array(RawEdgeSchema),
+});
+
+type RawNode = z.infer<typeof RawNodeSchema>;
+type RawEdge = z.infer<typeof RawEdgeSchema>;
+
+const ConditionRuleSchema = z.object({
+  fieldId: z.string().min(1),
+  operator: z.enum(FILTER_OPERATORS),
+  value: z.any().optional(),
+  values: z.array(z.any()).optional(),
+  dateRange: z.object({ from: z.string().optional(), to: z.string().optional() }).optional(),
+  numberRange: z.object({ min: z.number().optional(), max: z.number().optional() }).optional(),
+});
+
+const TriggerDataSchema = z.object({ triggerType: z.string().min(1) });
+
+const DelayDataSchema = z.object({
+  amount: z.number().positive(),
+  unit: z.enum(['minutes', 'hours', 'days']),
+});
+
+const ConditionDataSchema = z.object({
+  rules: z.array(ConditionRuleSchema).min(1),
+  combinator: z.enum(['AND', 'OR']),
+});
+
+const ActionDataSchema = z.object({
+  actionType: z.string().min(1),
+  config: z.record(z.string(), z.any()),
+});
+
+// Per-type action config schemas — mirror what plugins/*/handler.ts reads from plugin.config.
+// Types without a dedicated schema here (quiz-grading, google-sheets, ai-tagger, …) still get
+// the generic ActionDataSchema.config check above; only well-known automation actions get
+// stricter per-type validation.
+const EmailActionConfigSchema = z
+  .object({
+    recipientEmail: z.string().email().optional(),
+    recipientFieldId: z.string().optional(),
+    recipientFieldLabel: z.string().optional(),
+    subject: z.string().min(1),
+    message: z.string().min(1),
+    sendToSubmitter: z.boolean().optional(),
+    attachPdfTemplateId: z.string().optional(),
+    attachPdfTemplateName: z.string().optional(),
+  })
+  .refine((cfg) => Boolean(cfg.recipientEmail?.trim() || cfg.recipientFieldId), {
+    message: 'Email action requires recipientEmail or recipientFieldId',
+  });
+
+const WebhookActionConfigSchema = z.object({
+  url: z.string().url(),
+  secret: z.string().optional(),
+  headers: z.record(z.string(), z.string()).optional(),
+});
+
+// Slack has no backend plugin handler yet (packages/plugins/src/manifests/slack.ts marks it
+// comingSoon); this schema documents the intended config shape ahead of that handler landing.
+const SlackActionConfigSchema = z.object({
+  webhookUrl: z.string().url(),
+  channel: z.string().optional(),
+  message: z.string().min(1),
+});
+
+const ACTION_CONFIG_SCHEMAS: Record<string, z.ZodTypeAny> = {
+  email: EmailActionConfigSchema,
+  webhook: WebhookActionConfigSchema,
+  slack: SlackActionConfigSchema,
+};
+
+function detectCycle(nodeIds: string[], adjacency: Map<string, string[]>): string[] {
+  const UNVISITED = 0;
+  const IN_PROGRESS = 1;
+  const DONE = 2;
+  const state = new Map<string, number>(nodeIds.map((id) => [id, UNVISITED]));
+  const stack: string[] = [];
+
+  function visit(nodeId: string): string[] | null {
+    state.set(nodeId, IN_PROGRESS);
+    stack.push(nodeId);
+    for (const next of adjacency.get(nodeId) ?? []) {
+      const nextState = state.get(next);
+      if (nextState === IN_PROGRESS) {
+        const cycleStart = stack.indexOf(next);
+        return [...stack.slice(cycleStart), next];
+      }
+      if (nextState === UNVISITED) {
+        const found = visit(next);
+        if (found) return found;
+      }
+    }
+    stack.pop();
+    state.set(nodeId, DONE);
+    return null;
+  }
+
+  for (const id of nodeIds) {
+    if (state.get(id) === UNVISITED) {
+      const found = visit(id);
+      if (found) return found;
+    }
+  }
+  return [];
+}
+
+function bfsReachable(startId: string, adjacency: Map<string, string[]>): Set<string> {
+  const visited = new Set<string>([startId]);
+  const queue = [startId];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    for (const next of adjacency.get(current) ?? []) {
+      if (!visited.has(next)) {
+        visited.add(next);
+        queue.push(next);
+      }
+    }
+  }
+  return visited;
+}
+
+/**
+ * Longest (worst-case) cumulative delay in minutes across any path from the trigger,
+ * assuming the reachable subgraph is acyclic (callers must skip this when a cycle exists).
+ */
+function computeMaxPathDelayMinutes(
+  reachableIds: Set<string>,
+  nodesById: Map<string, RawNode>,
+  edges: RawEdge[]
+): number {
+  const predecessors = new Map<string, string[]>();
+  const inDegree = new Map<string, number>();
+  const adjacency = new Map<string, string[]>();
+  for (const id of reachableIds) {
+    predecessors.set(id, []);
+    inDegree.set(id, 0);
+    adjacency.set(id, []);
+  }
+  for (const edge of edges) {
+    if (!reachableIds.has(edge.source) || !reachableIds.has(edge.target)) continue;
+    predecessors.get(edge.target)!.push(edge.source);
+    adjacency.get(edge.source)!.push(edge.target);
+    inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
+  }
+
+  const queue: string[] = [];
+  for (const id of reachableIds) if ((inDegree.get(id) ?? 0) === 0) queue.push(id);
+
+  const order: string[] = [];
+  while (queue.length > 0) {
+    const nodeId = queue.shift()!;
+    order.push(nodeId);
+    for (const next of adjacency.get(nodeId) ?? []) {
+      inDegree.set(next, (inDegree.get(next) ?? 0) - 1);
+      if (inDegree.get(next) === 0) queue.push(next);
+    }
+  }
+
+  const dp = new Map<string, number>();
+  for (const nodeId of order) {
+    const preds = predecessors.get(nodeId) ?? [];
+    const maxIncoming = preds.length === 0 ? 0 : Math.max(...preds.map((p) => dp.get(p) ?? 0));
+    const node = nodesById.get(nodeId);
+    const delayMinutes =
+      node?.type === 'delay' &&
+      typeof node.data?.amount === 'number' &&
+      typeof node.data?.unit === 'string'
+        ? node.data.amount * (DELAY_UNIT_TO_MINUTES[node.data.unit as DelayUnit] ?? 0)
+        : 0;
+    dp.set(nodeId, maxIncoming + delayMinutes);
+  }
+
+  return Math.max(0, ...Array.from(dp.values()));
+}
+
+/**
+ * Validates an automation graph (JSON shape stored on Automation.graph / AutomationRun.graphSnapshot)
+ * against every structural and per-node-type rule from issue #193. Pure and injectable: pluginTypes
+ * is passed in (e.g. getAvailablePluginTypes()) rather than imported, so this stays unit-testable
+ * without the plugin registry's runtime registration state.
+ */
+export function validateAutomationGraph(
+  graph: unknown,
+  options: ValidateAutomationGraphOptions
+): GraphValidationResult {
+  const parsed = RawGraphSchema.safeParse(graph);
+  if (!parsed.success) {
+    return {
+      valid: false,
+      errors: [
+        {
+          code: GRAPH_ERROR_CODES.INVALID_GRAPH_SHAPE,
+          message: `Automation graph does not match the expected shape: ${parsed.error.message}`,
+        },
+      ],
+    };
+  }
+
+  const { nodes, edges } = parsed.data;
+  const errors: GraphValidationError[] = [];
+  const nodeIds = new Set(nodes.map((n) => n.id));
+  const nodesById = new Map(nodes.map((n) => [n.id, n]));
+
+  const triggerNodes = nodes.filter((n) => n.type === 'trigger');
+  const delayNodes = nodes.filter((n) => n.type === 'delay');
+  const conditionNodes = nodes.filter((n) => n.type === 'condition');
+  const actionNodes = nodes.filter((n) => n.type === 'action');
+
+  if (triggerNodes.length === 0) {
+    errors.push({
+      code: GRAPH_ERROR_CODES.MISSING_TRIGGER,
+      message: 'Automation graph must have exactly one trigger node',
+    });
+  } else if (triggerNodes.length > 1) {
+    errors.push({
+      code: GRAPH_ERROR_CODES.MULTIPLE_TRIGGERS,
+      message: 'Automation graph must have exactly one trigger node',
+    });
+  }
+
+  for (const node of triggerNodes) {
+    const result = TriggerDataSchema.safeParse(node.data);
+    if (!result.success) {
+      errors.push({
+        nodeId: node.id,
+        code: GRAPH_ERROR_CODES.INVALID_TRIGGER_CONFIG,
+        message: `Trigger node ${node.id} has invalid data: ${result.error.message}`,
+      });
+    }
+  }
+
+  for (const node of delayNodes) {
+    const result = DelayDataSchema.safeParse(node.data);
+    if (!result.success) {
+      errors.push({
+        nodeId: node.id,
+        code: GRAPH_ERROR_CODES.INVALID_DELAY,
+        message: `Delay node ${node.id} must have a positive amount and unit in minutes|hours|days: ${result.error.message}`,
+      });
+    }
+  }
+
+  for (const node of conditionNodes) {
+    const result = ConditionDataSchema.safeParse(node.data);
+    if (!result.success) {
+      errors.push({
+        nodeId: node.id,
+        code: GRAPH_ERROR_CODES.INVALID_CONDITION_CONFIG,
+        message: `Condition node ${node.id} must have non-empty rules with valid operators and an AND|OR combinator: ${result.error.message}`,
+      });
+    }
+  }
+
+  for (const node of actionNodes) {
+    const result = ActionDataSchema.safeParse(node.data);
+    if (!result.success) {
+      errors.push({
+        nodeId: node.id,
+        code: GRAPH_ERROR_CODES.INVALID_ACTION_CONFIG,
+        message: `Action node ${node.id} has invalid data: ${result.error.message}`,
+      });
+      continue;
+    }
+
+    const { actionType, config } = result.data;
+    if (!options.pluginTypes.includes(actionType)) {
+      errors.push({
+        nodeId: node.id,
+        code: GRAPH_ERROR_CODES.UNKNOWN_ACTION_TYPE,
+        message: `Action node ${node.id} references unregistered action type: ${actionType}`,
+      });
+      continue;
+    }
+
+    const configSchema = ACTION_CONFIG_SCHEMAS[actionType];
+    if (configSchema) {
+      const configResult = configSchema.safeParse(config);
+      if (!configResult.success) {
+        errors.push({
+          nodeId: node.id,
+          code: GRAPH_ERROR_CODES.INVALID_ACTION_CONFIG,
+          message: `Action node ${node.id} (${actionType}) has an invalid config: ${configResult.error.message}`,
+        });
+      }
+    }
+  }
+
+  const validEdges: RawEdge[] = [];
+  for (const edge of edges) {
+    if (!nodeIds.has(edge.source) || !nodeIds.has(edge.target)) {
+      errors.push({
+        code: GRAPH_ERROR_CODES.INVALID_EDGE,
+        message: `Edge ${edge.id} references a non-existent node (source: ${edge.source}, target: ${edge.target})`,
+      });
+      continue;
+    }
+    validEdges.push(edge);
+  }
+
+  for (const node of conditionNodes) {
+    const outgoing = validEdges.filter((e) => e.source === node.id);
+    const trueEdges = outgoing.filter((e) => e.sourceHandle === 'true');
+    const falseEdges = outgoing.filter((e) => e.sourceHandle === 'false');
+    const untaggedEdges = outgoing.filter((e) => e.sourceHandle === undefined);
+    if (trueEdges.length > 1 || falseEdges.length > 1 || untaggedEdges.length > 0) {
+      errors.push({
+        nodeId: node.id,
+        code: GRAPH_ERROR_CODES.INVALID_CONDITION_BRANCH,
+        message: `Condition node ${node.id} must have at most one 'true' and one 'false' outgoing edge, and no untagged edges`,
+      });
+    }
+  }
+
+  const adjacency = new Map<string, string[]>();
+  for (const node of nodes) adjacency.set(node.id, []);
+  for (const edge of validEdges) adjacency.get(edge.source)?.push(edge.target);
+
+  const cycleNodeIds = detectCycle(
+    nodes.map((n) => n.id),
+    adjacency
+  );
+  if (cycleNodeIds.length > 0) {
+    errors.push({
+      code: GRAPH_ERROR_CODES.GRAPH_CYCLE,
+      message: `Automation graph contains a cycle: ${cycleNodeIds.join(' -> ')}`,
+    });
+  }
+
+  if (triggerNodes.length === 1) {
+    const triggerId = triggerNodes[0].id;
+    const reachable = bfsReachable(triggerId, adjacency);
+
+    const orphanNodes = nodes.filter((n) => !reachable.has(n.id));
+    for (const orphan of orphanNodes) {
+      errors.push({
+        nodeId: orphan.id,
+        code: GRAPH_ERROR_CODES.ORPHAN_NODE,
+        message: `Node ${orphan.id} is unreachable from the trigger`,
+      });
+    }
+
+    // A node with no successor is an implicit end (the chosen convention — see #193).
+    // On a purely cyclic reachable subgraph every node has >=1 outgoing edge, so this
+    // is the only way "no sink exists" can happen; it's reported alongside GRAPH_CYCLE
+    // rather than gated behind it, since both BFS and the Kahn's-algorithm delay walk
+    // below terminate safely regardless of cycles (cyclic nodes just never get visited).
+    const hasReachableEnd = Array.from(reachable).some(
+      (id) => (adjacency.get(id)?.length ?? 0) === 0
+    );
+    if (!hasReachableEnd) {
+      errors.push({
+        code: GRAPH_ERROR_CODES.NO_REACHABLE_END,
+        message: 'Automation graph has no reachable end (a node with no outgoing edges)',
+      });
+    }
+
+    const maxDelayMinutes = computeMaxPathDelayMinutes(reachable, nodesById, validEdges);
+    if (maxDelayMinutes > MAX_DELAY_DAYS * 24 * 60) {
+      errors.push({
+        code: GRAPH_ERROR_CODES.DELAY_LIMIT_EXCEEDED,
+        message: `Total delay along at least one path exceeds ${MAX_DELAY_DAYS} days`,
+      });
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/apps/backend/src/services/automation/types.ts
+++ b/apps/backend/src/services/automation/types.ts
@@ -8,6 +8,8 @@ export interface ConditionRule {
   operator: string;
   value?: string;
   values?: string[];
+  dateRange?: { from?: string; to?: string };
+  numberRange?: { min?: number; max?: number };
 }
 
 export type ConditionCombinator = 'AND' | 'OR';

--- a/apps/backend/src/services/responseFilterService.ts
+++ b/apps/backend/src/services/responseFilterService.ts
@@ -7,6 +7,16 @@ export interface ResponseFilter {
   numberRange?: { min?: number; max?: number };
 }
 
+/** Per-value comparison inputs for a single operator evaluation — the subset of
+ *  ResponseFilter that evaluateFilterOperator needs, independent of where fieldId
+ *  resolution comes from (DB response object vs. a flat automation responseData map). */
+export interface FilterOperatorInput {
+  value?: string;
+  values?: string[];
+  dateRange?: { from?: string; to?: string };
+  numberRange?: { min?: number; max?: number };
+}
+
 /**
  * Applies filters to response data based on various operators
  * @param responses - Array of response objects
@@ -133,7 +143,21 @@ function applyFilterToResponse(filter: ResponseFilter, response: any): boolean {
         response.responseData?.[filter.fieldId] ??
         response.data?.[filter.fieldId];
 
-      switch (filter.operator) {
+      return evaluateFilterOperator(filter.operator, fieldValue, filter);
+}
+
+/**
+ * Pure per-value comparison for a single filter operator against a single field value.
+ * Shared by the Responses filter (applyFilterToResponse, above) and the automation
+ * condition evaluator (services/automation/conditionEvaluator.ts) so the 22 operators'
+ * semantics can never drift between the two callers.
+ */
+export function evaluateFilterOperator(
+  operator: string,
+  fieldValue: unknown,
+  input: FilterOperatorInput
+): boolean {
+      switch (operator) {
         case 'IS_EMPTY':
           return isValueEmpty(fieldValue);
 
@@ -142,79 +166,79 @@ function applyFilterToResponse(filter: ResponseFilter, response: any): boolean {
 
         case 'EQUALS':
           // Handle both string equality and array exact match
-          if (Array.isArray(fieldValue) && filter.values && filter.values.length > 0) {
+          if (Array.isArray(fieldValue) && input.values && input.values.length > 0) {
             // Array exact match: same length and same values (order-independent)
-            if (fieldValue.length !== filter.values.length) return false;
+            if (fieldValue.length !== input.values.length) return false;
             const fieldValuesLower = fieldValue.map(v => String(v).toLowerCase()).sort();
-            const filterValuesLower = filter.values.map(v => String(v).toLowerCase()).sort();
+            const filterValuesLower = input.values.map(v => String(v).toLowerCase()).sort();
             return fieldValuesLower.every((val, idx) => val === filterValuesLower[idx]);
           }
           // No value to compare against — skip (matches DB path behaviour)
-          if (filter.value === undefined && (!filter.values || filter.values.length === 0)) return false;
+          if (input.value === undefined && (!input.values || input.values.length === 0)) return false;
           // String equality
-          return String(fieldValue).toLowerCase() === String(filter.value || '').toLowerCase();
+          return String(fieldValue).toLowerCase() === String(input.value || '').toLowerCase();
 
         case 'NOT_EQUALS':
           // Absent field values do not equal anything — treat as "not equal"
           if (isValueEmpty(fieldValue)) return true;
-          return String(fieldValue).toLowerCase() !== String(filter.value || '').toLowerCase();
+          return String(fieldValue).toLowerCase() !== String(input.value || '').toLowerCase();
 
         case 'CONTAINS':
           // Empty search value never matches (mirrors DB path which skips the filter)
-          if (!filter.value) return false;
+          if (!input.value) return false;
           // Array fields: exact element match (mirrors DB path LOWER(elem) = $n)
           if (Array.isArray(fieldValue)) {
-            return fieldValue.some(v => String(v).toLowerCase() === filter.value!.toLowerCase());
+            return fieldValue.some(v => String(v).toLowerCase() === input.value!.toLowerCase());
           }
-          return !!fieldValue && String(fieldValue).toLowerCase().includes(filter.value.toLowerCase());
+          return !!fieldValue && String(fieldValue).toLowerCase().includes(input.value.toLowerCase());
 
         case 'NOT_CONTAINS':
           // Empty search value — nothing is "contained", so everything passes
-          if (!filter.value) return true;
+          if (!input.value) return true;
           // Array fields: exact element match (mirrors DB path)
           if (Array.isArray(fieldValue)) {
-            return !fieldValue.some(v => String(v).toLowerCase() === filter.value!.toLowerCase());
+            return !fieldValue.some(v => String(v).toLowerCase() === input.value!.toLowerCase());
           }
-          return !fieldValue || !String(fieldValue).toLowerCase().includes(filter.value.toLowerCase());
+          return !fieldValue || !String(fieldValue).toLowerCase().includes(input.value.toLowerCase());
 
         case 'STARTS_WITH':
-          return fieldValue && String(fieldValue).toLowerCase().startsWith(String(filter.value || '').toLowerCase());
+          return !!fieldValue && String(fieldValue).toLowerCase().startsWith(String(input.value || '').toLowerCase());
 
         case 'ENDS_WITH':
-          return fieldValue && String(fieldValue).toLowerCase().endsWith(String(filter.value || '').toLowerCase());
+          return !!fieldValue && String(fieldValue).toLowerCase().endsWith(String(input.value || '').toLowerCase());
 
         case 'GREATER_THAN': {
-          const filterNum = parseFilterNumber(filter.value);
+          const filterNum = parseFilterNumber(input.value);
           if (filterNum === null) return false;
           const numValue = toNumber(fieldValue);
           return numValue !== null && numValue > filterNum;
         }
 
         case 'GREATER_THAN_OR_EQUAL': {
-          const filterNum = parseFilterNumber(filter.value);
+          const filterNum = parseFilterNumber(input.value);
           if (filterNum === null) return false;
           const numValue = toNumber(fieldValue);
           return numValue !== null && numValue >= filterNum;
         }
 
         case 'LESS_THAN': {
-          const filterNum = parseFilterNumber(filter.value);
+          const filterNum = parseFilterNumber(input.value);
           if (filterNum === null) return false;
           const numValue = toNumber(fieldValue);
           return numValue !== null && numValue < filterNum;
         }
 
         case 'LESS_THAN_OR_EQUAL': {
-          const filterNum = parseFilterNumber(filter.value);
+          const filterNum = parseFilterNumber(input.value);
           if (filterNum === null) return false;
           const numValue = toNumber(fieldValue);
           return numValue !== null && numValue <= filterNum;
         }
 
         case 'BETWEEN': {
-          if (!filter.numberRange) return false;
-          const min = filter.numberRange.min;
-          const max = filter.numberRange.max;
+          if (!input.numberRange) return false;
+          const min = input.numberRange.min;
+          const max = input.numberRange.max;
           // No bounds provided — nothing to filter (mirrors DB path which skips empty conditions)
           if (min === undefined && max === undefined) return false;
           const numValue3 = toNumber(fieldValue);
@@ -228,7 +252,7 @@ function applyFilterToResponse(filter: ResponseFilter, response: any): boolean {
         case 'DATE_EQUALS': {
           try {
             const fieldDate = parseDate(fieldValue);
-            const compareDate = parseDate(filter.value || '');
+            const compareDate = parseDate(input.value || '');
             if (isNaN(fieldDate.getTime()) || isNaN(compareDate.getTime())) return false;
             return fieldDate.toDateString() === compareDate.toDateString();
           } catch {
@@ -239,7 +263,7 @@ function applyFilterToResponse(filter: ResponseFilter, response: any): boolean {
         case 'DATE_BEFORE': {
           try {
             const fieldDate = parseDate(fieldValue);
-            const compareDate = parseDate(filter.value || '');
+            const compareDate = parseDate(input.value || '');
             if (isNaN(fieldDate.getTime()) || isNaN(compareDate.getTime())) return false;
             return fieldDate < compareDate;
           } catch {
@@ -250,7 +274,7 @@ function applyFilterToResponse(filter: ResponseFilter, response: any): boolean {
         case 'DATE_AFTER': {
           try {
             const fieldDate = parseDate(fieldValue);
-            const compareDate = parseDate(filter.value || '');
+            const compareDate = parseDate(input.value || '');
             if (isNaN(fieldDate.getTime()) || isNaN(compareDate.getTime())) return false;
             return fieldDate > compareDate;
           } catch {
@@ -259,13 +283,13 @@ function applyFilterToResponse(filter: ResponseFilter, response: any): boolean {
         }
 
         case 'DATE_BETWEEN': {
-          if (!filter.dateRange) return false;
+          if (!input.dateRange) return false;
           try {
             const fieldDate = parseDate(fieldValue);
             if (isNaN(fieldDate.getTime())) return false;
 
-            const fromDate = filter.dateRange.from ? parseDate(filter.dateRange.from) : null;
-            const toDate = filter.dateRange.to ? parseDate(filter.dateRange.to) : null;
+            const fromDate = input.dateRange.from ? parseDate(input.dateRange.from) : null;
+            const toDate = input.dateRange.to ? parseDate(input.dateRange.to) : null;
 
             if ((fromDate && isNaN(fromDate.getTime())) || (toDate && isNaN(toDate.getTime()))) {
               return false;
@@ -292,7 +316,7 @@ function applyFilterToResponse(filter: ResponseFilter, response: any): boolean {
           try {
             const fieldDate = parseDate(fieldValue);
             if (isNaN(fieldDate.getTime())) return false;
-            const days = parseInt(filter.value || '7', 10);
+            const days = parseInt(input.value || '7', 10);
             if (isNaN(days) || days < 0) return false;
             const now = new Date();
             const startDate = new Date(now);
@@ -307,12 +331,12 @@ function applyFilterToResponse(filter: ResponseFilter, response: any): boolean {
         case 'IN': {
           // For arrays (checkbox fields), check if any selected value matches
           if (Array.isArray(fieldValue)) {
-            return filter.values?.some(value =>
+            return input.values?.some(value =>
               fieldValue.some(v => String(v).toLowerCase() === String(value).toLowerCase())
             ) ?? false;
           }
           // For strings (select/radio fields)
-          return filter.values?.some(value =>
+          return input.values?.some(value =>
             String(fieldValue).toLowerCase() === String(value).toLowerCase()
           ) ?? false;
         }
@@ -320,23 +344,23 @@ function applyFilterToResponse(filter: ResponseFilter, response: any): boolean {
         case 'NOT_IN': {
           // For arrays (checkbox fields)
           if (Array.isArray(fieldValue)) {
-            return !(filter.values?.some(value =>
+            return !(input.values?.some(value =>
               fieldValue.some(v => String(v).toLowerCase() === String(value).toLowerCase())
             ) ?? false);
           }
           // For strings (select/radio fields)
-          return !(filter.values?.some(value =>
+          return !(input.values?.some(value =>
             String(fieldValue).toLowerCase() === String(value).toLowerCase()
           ) ?? false);
         }
 
         case 'CONTAINS_ALL': {
           // Check if array contains ALL of the specified values
-          if (!filter.values || filter.values.length === 0) return false;
+          if (!input.values || input.values.length === 0) return false;
           if (!Array.isArray(fieldValue)) return false;
 
           const fieldValuesLower = fieldValue.map(v => String(v).toLowerCase());
-          return filter.values.every(value =>
+          return input.values.every(value =>
             fieldValuesLower.includes(String(value).toLowerCase())
           );
         }


### PR DESCRIPTION
Closes #193

## Summary
- `conditionEvaluator.ts`: `evaluateCondition(rules, combinator, responseData)` reuses the exact 22-operator semantics from `responseFilterService.ts`. The per-value comparison switch was extracted into a shared, exported `evaluateFilterOperator(operator, fieldValue, input)` function used by both `applyFilterToResponse` and the new evaluator, so the two can never drift apart. `ConditionRule` (in `services/automation/types.ts`) gained optional `dateRange`/`numberRange` fields to match `ResponseFilter`'s shape for `BETWEEN`/`DATE_BETWEEN`.
- `graphValidator.ts`: `validateAutomationGraph(graph, { pluginTypes })` uses zod to enforce every rule from the issue — single trigger, DAG (no cycles), no orphan/unreachable nodes, condition `true`/`false` handles (at most one edge each), delay node caps (positive amount, `minutes|hours|days` unit, ≤30-day total path delay), registered `actionType` + per-type config schemas for `email`/`webhook`/`slack`, and an implicit-end convention (a reachable node with no outgoing edges). Stable error codes (`GRAPH_CYCLE`, `MISSING_TRIGGER`, `INVALID_ACTION_CONFIG`, etc.) are exported via `GRAPH_ERROR_CODES` for the builder UI (#197) to map to node-level badges.

## Test plan
- [x] `conditionEvaluator.test.ts` — every operator (incl. null/undefined/array/date edge cases), both AND/OR combinators, empty-rules default
- [x] `graphValidator.test.ts` — valid-graph baseline + one fixture per error code (`INVALID_GRAPH_SHAPE`, `MISSING_TRIGGER`, `MULTIPLE_TRIGGERS`, `INVALID_TRIGGER_CONFIG`, `INVALID_EDGE`, `GRAPH_CYCLE`, `ORPHAN_NODE`, `NO_REACHABLE_END`, `INVALID_CONDITION_BRANCH`, `INVALID_CONDITION_CONFIG`, `INVALID_DELAY`, `DELAY_LIMIT_EXCEEDED`, `UNKNOWN_ACTION_TYPE`, `INVALID_ACTION_CONFIG`)
- [x] Existing `responseFilterService.test.ts` suite passes unchanged (no behavior change)
- [x] `pnpm type-check`, `pnpm lint`, `pnpm test:unit` all pass (2715/2715 tests, full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automation condition rules now evaluate with AND/OR logic and support operators for case-insensitive text matching, array comparisons, numeric thresholds, and date ranges.
  * Automation graph validation now detects invalid graph structure, trigger/node/edge issues, cycles and reachability problems, unsupported/invalid action configurations, and maximum delay limits with clear error codes.
  * Response filtering now uses consistent operator behavior across text, arrays, numeric, membership, and date comparisons.
* **Bug Fixes**
  * Automation condition evaluation no longer defaults to a fixed result and now reflects the configured rules.
* **Tests**
  * Added unit test coverage for condition evaluation and automation graph validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->