### PR TITLE
Automations: crash-safe successor enqueue

### DIFF
--- a/apps/backend/src/services/automation/__tests__/engine.test.ts
+++ b/apps/backend/src/services/automation/__tests__/engine.test.ts
@@ -97,13 +97,182 @@ describe('automation engine', () => {
     } as any);
   });
 
-  describe('idempotency', () => {
-    it('skips execution entirely when a SUCCESS step run already exists', async () => {
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue({ id: 'x', status: 'SUCCESS' } as any);
+  describe('redelivery reconciliation (existing SUCCESS step found)', () => {
+    it('re-enqueues a delay node successor that a crash left un-enqueued', async () => {
+      const graph: AutomationGraph = {
+        nodes: [
+          { id: 'delay-1', type: 'delay', data: { amount: 1, unit: 'hours' } },
+          { id: 'action-1', type: 'action', data: { actionType: 'webhook', config: {} } },
+        ],
+        edges: [{ id: 'e1', source: 'delay-1', target: 'action-1' }],
+      };
+      const delayUntil = new Date('2026-01-01T02:00:00.000Z');
 
-      await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'node-1' }));
+      vi.mocked(prisma.automationStepRun.findFirst).mockImplementation((({ where }: any) => {
+        if (where.status === 'SUCCESS') {
+          // The step already succeeded and recorded its decision...
+          return { output: { delayUntil: delayUntil.toISOString(), capped: false } } as any;
+        }
+        // ...but the crash happened before the successor was ever enqueued or run.
+        return null;
+      }) as any);
+      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+        makeRun({ status: 'WAITING', graphSnapshot: graph }) as any
+      );
 
-      expect(prisma.automationRun.findUnique).not.toHaveBeenCalled();
+      await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'delay-1' }));
+
+      expect(prisma.automationStepRun.create).not.toHaveBeenCalled();
+      expect(mockBoss.send).toHaveBeenCalledWith(
+        AUTOMATION_QUEUE,
+        { runId: 'run-1', nodeId: 'action-1' },
+        expect.objectContaining({ singletonKey: 'run-1:action-1', startAfter: delayUntil })
+      );
+    });
+
+    it('re-enqueues a condition node successor using the persisted branch decision, without re-evaluating the condition', async () => {
+      const graph: AutomationGraph = {
+        nodes: [
+          { id: 'cond-1', type: 'condition', data: { rules: [], combinator: 'AND' } },
+          { id: 'true-1', type: 'end' },
+          { id: 'false-1', type: 'end' },
+        ],
+        edges: [
+          { id: 'e1', source: 'cond-1', target: 'true-1', sourceHandle: 'true' },
+          { id: 'e2', source: 'cond-1', target: 'false-1', sourceHandle: 'false' },
+        ],
+      };
+
+      vi.mocked(prisma.automationStepRun.findFirst).mockImplementation((({ where }: any) => {
+        if (where.status === 'SUCCESS') {
+          return { output: { result: true, branch: 'true' } } as any;
+        }
+        return null;
+      }) as any);
+      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+        makeRun({ status: 'RUNNING', graphSnapshot: graph }) as any
+      );
+
+      await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'cond-1' }));
+
+      expect(evaluateCondition).not.toHaveBeenCalled();
+      expect(mockBoss.send).toHaveBeenCalledWith(
+        AUTOMATION_QUEUE,
+        { runId: 'run-1', nodeId: 'true-1' },
+        expect.objectContaining({ singletonKey: 'run-1:true-1' })
+      );
+    });
+
+    it('completes the run when the succeeded node had no successor and the run was never marked COMPLETED', async () => {
+      const graph: AutomationGraph = {
+        nodes: [{ id: 'delay-1', type: 'delay', data: { amount: 1, unit: 'minutes' } }],
+        edges: [],
+      };
+
+      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue({
+        output: { delayUntil: new Date().toISOString(), capped: false },
+      } as any);
+      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+        makeRun({ status: 'WAITING', graphSnapshot: graph }) as any
+      );
+
+      await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'delay-1' }));
+
+      expect(prisma.automationRun.update).toHaveBeenCalledWith({
+        where: { id: 'run-1' },
+        data: { status: 'COMPLETED', completedAt: expect.any(Date) },
+      });
+      expect(mockBoss.send).not.toHaveBeenCalled();
+    });
+
+    it('replays the stepOutputs merge for an action node when it was lost before the successor was enqueued', async () => {
+      const graph: AutomationGraph = {
+        nodes: [
+          { id: 'action-1', type: 'action', data: { actionType: 'webhook', config: {} } },
+          { id: 'end-1', type: 'end' },
+        ],
+        edges: [{ id: 'e1', source: 'action-1', target: 'end-1' }],
+      };
+
+      vi.mocked(prisma.automationStepRun.findFirst).mockImplementation((({ where }: any) => {
+        if (where.status === 'SUCCESS') {
+          return { output: { delivered: true } } as any;
+        }
+        return null;
+      }) as any);
+      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+        makeRun({ status: 'RUNNING', graphSnapshot: graph, context: { triggerData: {} } }) as any
+      );
+
+      await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'action-1' }));
+
+      expect(getPluginHandler).not.toHaveBeenCalled();
+      expect(prisma.automationRun.update).toHaveBeenCalledWith({
+        where: { id: 'run-1' },
+        data: { context: { triggerData: {}, stepOutputs: { 'action-1': { delivered: true } } } },
+      });
+      expect(mockBoss.send).toHaveBeenCalledWith(
+        AUTOMATION_QUEUE,
+        { runId: 'run-1', nodeId: 'end-1' },
+        expect.objectContaining({ singletonKey: 'run-1:end-1' })
+      );
+    });
+
+    it('does nothing when the successor already has its own step run (already reconciled or genuinely done)', async () => {
+      const graph: AutomationGraph = {
+        nodes: [
+          { id: 'delay-1', type: 'delay', data: { amount: 1, unit: 'minutes' } },
+          { id: 'action-1', type: 'action', data: { actionType: 'webhook', config: {} } },
+        ],
+        edges: [{ id: 'e1', source: 'delay-1', target: 'action-1' }],
+      };
+
+      vi.mocked(prisma.automationStepRun.findFirst).mockImplementation((({ where }: any) => {
+        if (where.status === 'SUCCESS') {
+          return { output: { delayUntil: new Date().toISOString(), capped: false } } as any;
+        }
+        // The successor already ran (or is itself further along).
+        return { id: 'already-ran' } as any;
+      }) as any);
+      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+        makeRun({ status: 'WAITING', graphSnapshot: graph }) as any
+      );
+
+      await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'delay-1' }));
+
+      expect(mockBoss.send).not.toHaveBeenCalled();
+      expect(prisma.automationRun.update).not.toHaveBeenCalled();
+    });
+
+    it('does not merge stepOutputs again for an action node whose context already recorded the output', async () => {
+      const graph: AutomationGraph = {
+        nodes: [{ id: 'action-1', type: 'action', data: { actionType: 'webhook', config: {} } }],
+        edges: [],
+      };
+
+      vi.mocked(prisma.automationStepRun.findFirst).mockImplementation((({ where }: any) => {
+        if (where.status === 'SUCCESS') {
+          return { output: { delivered: true } } as any;
+        }
+        return null;
+      }) as any);
+      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+        makeRun({
+          status: 'RUNNING',
+          graphSnapshot: graph,
+          context: { triggerData: {}, stepOutputs: { 'action-1': { delivered: true } } },
+        }) as any
+      );
+
+      await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'action-1' }));
+
+      // Only the completion update should fire — no redundant context merge, since stepOutputs
+      // already has this node's output on record.
+      expect(prisma.automationRun.update).toHaveBeenCalledTimes(1);
+      expect(prisma.automationRun.update).toHaveBeenCalledWith({
+        where: { id: 'run-1' },
+        data: { status: 'COMPLETED', completedAt: expect.any(Date) },
+      });
       expect(mockBoss.send).not.toHaveBeenCalled();
     });
   });
@@ -129,6 +298,63 @@ describe('automation engine', () => {
 
       expect(prisma.automationRun.update).not.toHaveBeenCalled();
       expect(mockBoss.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unhandleable node failures', () => {
+    it('records a FAILED step run and reports to Sentry when the node is missing from the graph snapshot', async () => {
+      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
+      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+        makeRun({ graphSnapshot: { nodes: [], edges: [] } }) as any
+      );
+
+      await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'missing-node' }));
+
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('missing-node') })
+      );
+      expect(prisma.automationStepRun.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          runId: 'run-1',
+          nodeId: 'missing-node',
+          nodeType: 'unknown',
+          status: 'FAILED',
+        }),
+      });
+      expect(prisma.automationRun.update).toHaveBeenCalledWith({
+        where: { id: 'run-1' },
+        data: { status: 'FAILED', completedAt: expect.any(Date) },
+      });
+    });
+
+    it('records a FAILED step run and reports to Sentry for a node type the engine does not handle', async () => {
+      const graph: AutomationGraph = {
+        nodes: [{ id: 'trigger-1', type: 'trigger', data: { triggerType: 'form.submitted' } }],
+        edges: [],
+      };
+
+      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
+      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+        makeRun({ graphSnapshot: graph }) as any
+      );
+
+      await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'trigger-1' }));
+
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('trigger-1') })
+      );
+      expect(prisma.automationStepRun.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          runId: 'run-1',
+          nodeId: 'trigger-1',
+          nodeType: 'trigger',
+          status: 'FAILED',
+        }),
+      });
+      expect(prisma.automationRun.update).toHaveBeenCalledWith({
+        where: { id: 'run-1' },
+        data: { status: 'FAILED', completedAt: expect.any(Date) },
+      });
     });
   });
 

--- a/apps/backend/src/services/automation/__tests__/engine.test.ts
+++ b/apps/backend/src/services/automation/__tests__/engine.test.ts
@@ -24,6 +24,9 @@ vi.mock('../../../lib/prisma.js', () => ({
       findUnique: vi.fn(),
       update: vi.fn(),
     },
+    // Array-form $transaction: operations are already-invoked PrismaPromises by the time
+    // $transaction receives them, so resolving them as-is mirrors the real API.
+    $transaction: vi.fn((ops: unknown[]) => Promise.all(ops)),
   },
 }));
 

--- a/apps/backend/src/services/automation/engine.ts
+++ b/apps/backend/src/services/automation/engine.ts
@@ -319,16 +319,119 @@ async function handleActionNode(
   }
 }
 
+/**
+ * Advances past a node whose SUCCESS AutomationStepRun is already on record, verifying (rather
+ * than assuming) that the successor was actually enqueued before redelivery is allowed to be a
+ * no-op. Reconstructs the successor decision from the persisted step output — never re-derives
+ * it (e.g. re-evaluating a condition or re-running a handler), since the recorded outcome is the
+ * one that already happened.
+ */
+async function reconcileSuccessor(
+  run: { id: string; status: string },
+  nextNodeId: string | null,
+  graph: AutomationGraph,
+  startAfter?: Date
+): Promise<void> {
+  if (!nextNodeId) {
+    if (run.status !== 'COMPLETED') {
+      await completeRun(run.id);
+    }
+    return;
+  }
+
+  // If the successor already has its own step run, it has executed (or progressed further) —
+  // the crash window has already closed safely and re-enqueuing now would risk a duplicate
+  // execution once pg-boss's singletonKey slot has freed up behind a completed job.
+  const successorStarted = await prisma.automationStepRun.findFirst({
+    where: { runId: run.id, nodeId: nextNodeId },
+  });
+  if (successorStarted) {
+    return;
+  }
+
+  logger.warn(
+    `[Automation Engine] Run ${run.id}: successor ${nextNodeId} was never recorded after its predecessor succeeded — re-enqueuing (singletonKey makes this a no-op if it is already pending)`
+  );
+  await enqueueStep(run.id, nextNodeId, graph, startAfter);
+}
+
+async function reconcileSuccessStep(
+  run: { id: string; status: string; context: unknown },
+  node: AutomationNode,
+  graph: AutomationGraph,
+  existingSuccess: { output: unknown }
+): Promise<void> {
+  switch (node.type) {
+    case 'delay': {
+      const output = (existingSuccess.output as { delayUntil?: string } | null) ?? {};
+      const startAfter = output.delayUntil ? new Date(output.delayUntil) : undefined;
+      await reconcileSuccessor(run, findNextNodeId(graph, node.id), graph, startAfter);
+      return;
+    }
+    case 'condition': {
+      const output = (existingSuccess.output as { result?: boolean } | null) ?? {};
+      const branch: 'true' | 'false' = output.result ? 'true' : 'false';
+      await reconcileSuccessor(run, findNextNodeId(graph, node.id, branch), graph);
+      return;
+    }
+    case 'action': {
+      // Close the equivalent gap between the SUCCESS step write and the stepOutputs merge: if
+      // the context update was lost to the same crash window, replay it from the persisted
+      // step output rather than the (unavailable) live handler result.
+      const context = (run.context as AutomationRunContext) ?? {};
+      if (!(node.id in (context.stepOutputs ?? {}))) {
+        await prisma.automationRun.update({
+          where: { id: run.id },
+          data: { context: mergeStepOutput(run.context, node.id, existingSuccess.output) },
+        });
+      }
+      await reconcileSuccessor(run, findNextNodeId(graph, node.id), graph);
+      return;
+    }
+    case 'end':
+      if (run.status !== 'COMPLETED') {
+        await completeRun(run.id);
+      }
+      return;
+    default:
+      // Trigger nodes never record a SUCCESS step run, so this is unreachable in practice.
+      return;
+  }
+}
+
+async function recordUnhandleableStepFailure(
+  runId: string,
+  nodeId: string,
+  nodeType: string,
+  message: string,
+  attempt: number
+): Promise<void> {
+  logger.error(`[Automation Engine] ${message}`);
+  Sentry.captureException(new Error(message));
+  await prisma.automationStepRun.create({
+    data: {
+      id: generateId(),
+      runId,
+      nodeId,
+      nodeType,
+      status: 'FAILED',
+      errorMessage: message,
+      attempt,
+      finishedAt: new Date(),
+    },
+  });
+  await prisma.automationRun.update({
+    where: { id: runId },
+    data: { status: 'FAILED', completedAt: new Date() },
+  });
+}
+
 export async function executeAutomationStep(job: JobWithMetadata<AutomationStepJobData>): Promise<void> {
   const { runId, nodeId } = job.data;
 
   const existingSuccess = await prisma.automationStepRun.findFirst({
     where: { runId, nodeId, status: 'SUCCESS' },
   });
-  if (existingSuccess) {
-    logger.info(`[Automation Engine] Step ${nodeId} for run ${runId} already succeeded — skipping redelivery`);
-    return;
-  }
 
   const run = await prisma.automationRun.findUnique({
     where: { id: runId },
@@ -347,12 +450,21 @@ export async function executeAutomationStep(job: JobWithMetadata<AutomationStepJ
   const graph = run.graphSnapshot as unknown as AutomationGraph;
   const node = findNode(graph, nodeId);
   if (!node) {
-    logger.error(`[Automation Engine] Node ${nodeId} not found in run ${runId} graph snapshot`);
-    await prisma.automationRun.update({
-      where: { id: runId },
-      data: { status: 'FAILED', completedAt: new Date() },
-    });
+    await recordUnhandleableStepFailure(
+      runId,
+      nodeId,
+      'unknown',
+      `Node ${nodeId} not found in run ${runId} graph snapshot`,
+      job.retryCount + 1
+    );
     return;
+  }
+
+  if (existingSuccess) {
+    logger.info(
+      `[Automation Engine] Step ${nodeId} for run ${runId} already succeeded — verifying the successor was enqueued before skipping redelivery`
+    );
+    return reconcileSuccessStep(run, node, graph, existingSuccess);
   }
 
   switch (node.type) {
@@ -365,11 +477,13 @@ export async function executeAutomationStep(job: JobWithMetadata<AutomationStepJ
     case 'end':
       return handleEndNode(run, node);
     default:
-      logger.error(`[Automation Engine] Unexpected node type for node ${nodeId} in run ${runId}`);
-      await prisma.automationRun.update({
-        where: { id: runId },
-        data: { status: 'FAILED', completedAt: new Date() },
-      });
+      return recordUnhandleableStepFailure(
+        runId,
+        nodeId,
+        node.type,
+        `Unexpected node type for node ${nodeId} in run ${runId}`,
+        job.retryCount + 1
+      );
   }
 }
 

--- a/apps/backend/src/services/automation/engine.ts
+++ b/apps/backend/src/services/automation/engine.ts
@@ -408,22 +408,27 @@ async function recordUnhandleableStepFailure(
 ): Promise<void> {
   logger.error(`[Automation Engine] ${message}`);
   Sentry.captureException(new Error(message));
-  await prisma.automationStepRun.create({
-    data: {
-      id: generateId(),
-      runId,
-      nodeId,
-      nodeType,
-      status: 'FAILED',
-      errorMessage: message,
-      attempt,
-      finishedAt: new Date(),
-    },
-  });
-  await prisma.automationRun.update({
-    where: { id: runId },
-    data: { status: 'FAILED', completedAt: new Date() },
-  });
+  // Single transaction: a crash between these two writes would otherwise leave the run
+  // non-terminal, causing redelivery to hit this same branch again and insert a duplicate
+  // FAILED step run for the same node.
+  await prisma.$transaction([
+    prisma.automationStepRun.create({
+      data: {
+        id: generateId(),
+        runId,
+        nodeId,
+        nodeType,
+        status: 'FAILED',
+        errorMessage: message,
+        attempt,
+        finishedAt: new Date(),
+      },
+    }),
+    prisma.automationRun.update({
+      where: { id: runId },
+      data: { status: 'FAILED', completedAt: new Date() },
+    }),
+  ]);
 }
 
 export async function executeAutomationStep(job: JobWithMetadata<AutomationStepJobData>): Promise<void> {


### PR DESCRIPTION
Closes #206

## Problem

`executeAutomationStep` recorded an `AutomationStepRun` with `status: 'SUCCESS'` and then, as a separate step, enqueued the successor job. A crash between those two writes left the SUCCESS row committed but no successor enqueued. On pg-boss redelivery, the idempotency guard found the existing SUCCESS row and returned unconditionally — so the redelivered job was acked as a successful no-op and the run was silently stuck forever.

## Approach chosen: reconciliation on redelivery (not transactional enqueue)

The issue offered two options. I evaluated transactional enqueue first: pg-boss 12.26.2 does ship a `fromPrisma(tx)` adapter, and it works mechanically in this repo (Prisma's `PrismaPg` driver adapter exposes `$queryRawUnsafe`, which is all `fromPrisma` needs). But pg-boss's worker deliberately connects via `DIRECT_URL` instead of the pooled `DATABASE_URL` specifically to stay off PgBouncer (see `boss.ts`). Routing the job insert through Prisma's pooled connection via `fromPrisma` reintroduces exactly the coupling that split was meant to avoid, for a hardening ticket where correctness needs to be easy to verify.

Reconciliation is simpler and self-contained:
- The idempotency guard no longer returns unconditionally on an existing SUCCESS row. It now rebuilds the successor decision **from the already-persisted step output** (delay's `delayUntil`, condition's `result`) — it never re-evaluates the condition or re-invokes a handler, since that outcome already happened and is on record.
- Before re-enqueuing, it checks whether the successor already has its own `AutomationStepRun`. If so, the successor already ran (or is further along) and nothing is done — this avoids ever re-sending into a slot pg-boss's `singletonKey` has since freed behind a *completed* job, which is the one scenario where a blind resend could cause a duplicate execution.
- If the successor was never recorded, it re-enqueues via the existing `enqueueStep`, which already uses `singletonKey: {runId}:{nodeId}` — so if the successor is merely pending (not yet run), the resend is a safe, pg-boss-native no-op.
- The same mechanism closes the equivalent gap in `handleActionNode`: if the `context.stepOutputs` merge was lost to the same crash window, it's replayed from the persisted step output rather than a live handler result.

## Also fixed

`executeAutomationStep`'s node-not-found and unknown-node-type branches now write a `FAILED` `AutomationStepRun` and call `Sentry.captureException`, matching every other failure path in the file (previously they only logged and marked the run `FAILED`).

## Testing

- Added `services/automation/__tests__/engine.test.ts` coverage for the crash-then-redeliver scenario: existing SUCCESS step + successor never enqueued → successor gets enqueued on redelivery (delay, condition, and action nodes), the run completes when the succeeded node had no successor, the stepOutputs replay for action nodes, and the safe no-op case where the successor already progressed.
- Added coverage for the two new failure branches (StepRun write + Sentry).
- `pnpm type-check`, `pnpm lint`, `pnpm test:unit` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash-safe recovery for redelivered automation steps, reconciling successor progression instead of stopping early.
  * Correctly restores delayed and conditional successors using persisted scheduling/branch decisions.
  * Repairs missing action step outputs and merges persisted results back into the run context during recovery.
  * Ensures automation runs are marked **FAILED** with accurate failure recording when a step is missing from the stored graph or has an unsupported node type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->