### PR TITLE
Fix automation builder canvas: empty-canvas + validation-error bugs

### DIFF
--- a/apps/form-app/src/pages/AutomationBuilder.tsx
+++ b/apps/form-app/src/pages/AutomationBuilder.tsx
@@ -22,7 +22,6 @@ const AutomationBuilderContent: React.FC<{ form: any; automation: any }> = ({ fo
   const formId = form.id;
 
   const loadGraph = useAutomationBuilderStore((s) => s.loadGraph);
-  const resetBuilder = useAutomationBuilderStore((s) => s.resetBuilder);
   const isDirty = useAutomationBuilderStore((s) => s.isDirty);
   const structuralErrors = useAutomationBuilderStore((s) => s.structuralErrors);
   const setValidationErrors = useAutomationBuilderStore((s) => s.setValidationErrors);
@@ -46,8 +45,6 @@ const AutomationBuilderContent: React.FC<{ form: any; automation: any }> = ({ fo
     });
   }, [automationId, automation.graph, form.title, canEdit, loadGraph]);
 
-  useEffect(() => () => resetBuilder(), [resetBuilder]);
-
   const [isEditingName, setIsEditingName] = useState(false);
   const [nameDraft, setNameDraft] = useState(automation.name);
   useEffect(() => {
@@ -66,7 +63,8 @@ const AutomationBuilderContent: React.FC<{ form: any; automation: any }> = ({ fo
       return;
     }
     try {
-      await renameAutomation({ variables: { id: automationId, name: trimmed } });
+      const result = await renameAutomation({ variables: { id: automationId, name: trimmed } });
+      if (result.error) throw result.error;
       toastSuccess(t('toasts.renamedTitle'), t('toasts.renamedMessage', { values: { name: trimmed } }));
     } catch (error: any) {
       setNameDraft(automation.name);
@@ -77,7 +75,8 @@ const AutomationBuilderContent: React.FC<{ form: any; automation: any }> = ({ fo
   const handleSave = async () => {
     try {
       const graph = getSerializableGraph();
-      await updateAutomation({ variables: { id: automationId, graph } });
+      const result = await updateAutomation({ variables: { id: automationId, graph } });
+      if (result.error) throw result.error;
       markSaved();
       clearValidationErrors();
       toastSuccess(t('builder.header.saveSuccessTitle'), t('builder.header.saveSuccessMessage'));
@@ -89,7 +88,11 @@ const AutomationBuilderContent: React.FC<{ form: any; automation: any }> = ({ fo
   const handleActivateToggle = async () => {
     const nextStatus = automation.status === 'ACTIVE' ? 'PAUSED' : 'ACTIVE';
     try {
-      await setStatus({ variables: { id: automationId, status: nextStatus } });
+      const result = await setStatus({ variables: { id: automationId, status: nextStatus } });
+      // Apollo Client v4's mutate() resolves (doesn't reject) when the response contains
+      // GraphQL-level errors — only network/execution failures throw. AUTOMATION_INVALID_GRAPH
+      // is a GraphQL error, so it must be read off the resolved result, not caught.
+      if (result.error) throw result.error;
       clearValidationErrors();
       toastSuccess(
         nextStatus === 'ACTIVE' ? t('toasts.activatedTitle') : t('toasts.pausedTitle'),

--- a/apps/form-app/src/store/slices/automationBuilderSlice.ts
+++ b/apps/form-app/src/store/slices/automationBuilderSlice.ts
@@ -51,7 +51,6 @@ export interface AutomationBuilderState {
   getSerializableGraph: () => SerializedGraph;
   /** Clears the session draft/selection for the current automation — called when the user explicitly discards unsaved changes. */
   discardDraft: () => void;
-  resetBuilder: () => void;
 }
 
 const EDGE_TYPE = 'addStep';
@@ -273,17 +272,4 @@ export const createAutomationBuilderSlice = (set: Set, get: Get): AutomationBuil
       persistSelectedNodeId(automationId, null);
     }
   },
-
-  resetBuilder: () =>
-    set({
-      automationId: null,
-      formTitle: '',
-      nodes: [],
-      edges: [],
-      selectedNodeId: null,
-      isDirty: false,
-      isReadOnly: false,
-      validationErrorsByNode: {},
-      structuralErrors: [],
-    }),
 });


### PR DESCRIPTION
Follow-up to #213 (merged). Live-testing that PR's actual UI (not just type-check/lint/build) turned up two real bugs that static checks couldn't catch.

## Bug 1: canvas rendered permanently empty in dev
`AutomationBuilder.tsx` had:
```ts
useEffect(() => () => resetBuilder(), [resetBuilder]);
```
React 18 StrictMode double-invokes effects on mount (setup → cleanup → setup again) specifically to catch bugs like this. Since `loadGraph` populates the store *synchronously* in its own effect, the synthetic cleanup fired immediately afterward and wiped it via `resetBuilder()` — which then never ran again (`loadGraph` is guarded to fire once per `automationId`). Net effect: the canvas showed zero nodes/edges every time, in every `pnpm form-app:dev` session.

`CollaborativeFormBuilder.tsx` has the identical pattern and "works" only by accident — its data arrives later over a Y.js WebSocket, so there's nothing to lose at the moment the synthetic cleanup fires.

**Fix**: removed the effect (and the now-unused `resetBuilder` action). `loadGraph` already fully reinitializes all builder state on every mount, so the cleanup wasn't protecting anything a real unmount needed.

## Bug 2: "Activate surfaces server validation errors on the offending nodes" didn't work
Apollo Client v4's `mutate()` **resolves** rather than rejects when the response carries GraphQL-level errors — only network/execution failures throw (confirmed against the Apollo Client docs: "GraphQL errors in response: onError is called but promise still resolves"). The `try/catch` around `setStatus()`/`updateAutomation()`/`renameAutomation()` never ran for `AUTOMATION_INVALID_GRAPH`, so `extractValidationErrors()` was never called and the red node outline/tooltip never appeared — Activate just silently failed with no visible feedback.

**Fix**: check `result.error` on the resolved mutation result and rethrow it into the existing catch block, for all three mutations in this file.

## Verified live (Playwright against a real backend + Postgres)
- Create automation → add delay + email action via `+` → configure → Save → Activate → reload: full round-trip, all data persists correctly, "Wait 1 hour" singular pluralization correct
- `hideEventsSection` confirmed: no "Trigger Events" card shown in the action panel
- Added an intentionally unconfigured webhook action → live "Setup required" badge appears immediately (client-side check)
- Saved + attempted Activate → correctly **blocked**, red outline + warning icon appears on the exact offending node (this was the broken path before this fix)
- Removed that node via the delete affordance → clean re-layout, edges reconnect correctly
- Saved + Activated successfully once valid → status badge updates to Active

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes (0 errors)
- [x] Full pre-push build/test suite passes
- [x] Manual live verification (see above) — this is what caught both bugs; static checks alone had passed on #213 without catching either

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when renaming automations, saving workflow changes, or changing automation status, ensuring errors are surfaced reliably.
  * Updated draft management so discarding a draft clears the saved draft and node selection without unexpectedly resetting the active builder state.
  * Preserved builder state when leaving and returning to the automation builder, providing a more consistent editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->