### PR TITLE
Automations: E2E linear happy path

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -13,7 +13,7 @@ creating a form from a template.
 ## Running
 - `pnpm test:e2e`
 - Optional env vars:
-  - `E2E_BASE_URL` (default: http://localhost:5173)
+  - `E2E_FORM_APP_URL` (default: http://localhost:5173)
   - `E2E_EMAIL` and `E2E_PASSWORD` (required)
   - `E2E_HEADLESS=false` to see the browser locally
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -19,3 +19,24 @@ creating a form from a template.
 
 Artifacts from failures (traces/screenshots/videos) are written to
 `test-results/e2e` and are git-ignored.
+
+## Automations (`@automations`)
+
+`pnpm test:e2e --tags "@automations"` runs the linear automation happy path:
+build a webhook action in the builder, confirm Activate is blocked while it's
+unconfigured, activate it, submit the public form, and poll the runs view for
+the run to reach `COMPLETED` with a `SUCCESS` step.
+
+- The backend must be started with `DIRECT_URL` set — that's what enables the
+  pg-boss automation engine (`initializeAutomationEngine()` degrades to
+  disabled without it). CI's `e2e-local` job already sets `DIRECT_URL` for the
+  same Postgres instance as `DATABASE_URL`, so no CI change was needed here.
+- The webhook action's URL field only accepts `https://` (client-side
+  validation in `WebhookConfigForm`), so this scenario points it at Postman's
+  public echo endpoint (`https://postman-echo.com/post`), which always
+  responds `200`, rather than standing up a local capture server — a
+  self-hosted target would need a self-signed cert plus
+  `NODE_TLS_REJECT_UNAUTHORIZED=0` on the backend process, which weakens TLS
+  verification for every outbound call the backend makes for the life of that
+  process. The scenario only asserts run/step status, not delivered payload
+  content.

--- a/test/e2e/features/automations-happy-path.feature
+++ b/test/e2e/features/automations-happy-path.feature
@@ -1,0 +1,30 @@
+@automations
+Feature: Automations linear happy path
+  End-to-end coverage for a single webhook-action automation: build it, activate it,
+  trigger it via a real form submission, and confirm the run completes successfully.
+
+  Scenario: Build, activate, trigger, and observe a webhook automation run
+    Given I sign in with valid credentials
+    And I create a form via GraphQL for the automations happy path
+    When I publish the form
+    Then the form should be published
+    When I open the automations tab
+    And I create an automation named "Welcome flow"
+    Then I should be in the automation builder
+    When I add a webhook action step
+    Then the action node should show the setup required badge
+    When I close the node config panel
+    And I save the automation graph
+    And I try to activate the automation
+    Then the automation should still be in Draft status
+    When I configure the webhook action with a test delivery URL
+    And I save the automation graph
+    And I activate the automation
+    Then the automation status should be Active
+    When I get the form short URL
+    And I navigate to the form viewer with the short URL
+    And I fill and submit the automations happy path form
+    Then the viewer should show the thank you screen
+    When I open the automation runs view
+    Then a run should reach COMPLETED status
+    And the run's webhook action step should show SUCCESS

--- a/test/e2e/steps/automations.steps.ts
+++ b/test/e2e/steps/automations.steps.ts
@@ -1,0 +1,157 @@
+/**
+ * Automations E2E steps (#199): build a webhook-action automation in the builder,
+ * verify Activate is blocked while the action is unconfigured, activate it once
+ * configured, trigger it via a real public-viewer submission, and confirm the run
+ * completes with a SUCCESS step.
+ *
+ * The webhook action's URL field only accepts `https://` (client-side regex in
+ * WebhookConfigForm), so a self-hosted local capture endpoint would need a
+ * self-signed cert plus NODE_TLS_REJECT_UNAUTHORIZED=0 on the backend process —
+ * more risk (weakens TLS verification for every outbound call the backend makes
+ * during the run) than it's worth for this scenario. Instead this points the
+ * webhook at Postman's public echo endpoint, which always returns HTTP 200 over
+ * a validly-signed cert, and only asserts run/step status — not delivered payload
+ * content — matching the issue's own documented fallback.
+ */
+
+import { Given, When, Then } from '@cucumber/cucumber';
+import { expect } from '@playwright/test';
+import { CustomWorld } from '../support/world';
+import { expectPoll } from '../support/expectPoll';
+import { createFormViaGraphQL, createAutomationsHappyPathFormSchema } from './helpers';
+
+const WEBHOOK_TEST_URL = 'https://postman-echo.com/post';
+
+Given('I create a form via GraphQL for the automations happy path', async function (this: CustomWorld) {
+  await createFormViaGraphQL(this, createAutomationsHappyPathFormSchema(), 'E2E Automations Test');
+});
+
+When('I open the automations tab', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  await this.page.getByTestId('quick-action-automations').click();
+  await expect(this.page).toHaveURL(/\/automations$/, { timeout: 15_000 });
+});
+
+When('I create an automation named {string}', async function (this: CustomWorld, name: string) {
+  if (!this.page) throw new Error('Page is not initialized');
+  await this.page.getByTestId('create-automation-empty-button').click();
+  await this.page.locator('#automation-name-input').fill(name);
+  await this.page.getByRole('button', { name: 'Create', exact: true }).click();
+  await expect(this.page).toHaveURL(/\/automations\/[^/]+$/, { timeout: 20_000 });
+});
+
+Then('I should be in the automation builder', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  await expect(this.page.getByTestId('automation-canvas')).toBeVisible({ timeout: 20_000 });
+});
+
+When('I add a webhook action step', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  await this.page.getByRole('button', { name: 'Add a step' }).click();
+  await this.page.getByRole('button', { name: 'Webhook', exact: true }).click();
+  await expect(this.page.getByTestId('automation-node-config-panel')).toBeVisible({ timeout: 10_000 });
+});
+
+Then('the action node should show the setup required badge', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  await expect(
+    this.page.getByTestId('automation-canvas').getByText('Setup required', { exact: true })
+  ).toBeVisible({ timeout: 10_000 });
+});
+
+When('I close the node config panel', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  await this.page.getByRole('button', { name: 'Close panel' }).click();
+  await expect(this.page.getByTestId('automation-node-config-panel')).not.toBeVisible({ timeout: 5_000 });
+});
+
+When('I save the automation graph', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  const saveButton = this.page.getByRole('button', { name: 'Save', exact: true });
+  await saveButton.click();
+  await expect(saveButton).toBeDisabled({ timeout: 10_000 });
+});
+
+When('I try to activate the automation', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  await this.page.getByRole('button', { name: 'Activate', exact: true }).click();
+  // Give the setStatus mutation time to round-trip and reject before asserting on it.
+  await this.page.waitForTimeout(1_500);
+});
+
+Then('the automation should still be in Draft status', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  await expect(this.page.getByText('Draft', { exact: true })).toBeVisible({ timeout: 5_000 });
+  await expect(this.page.getByRole('button', { name: 'Activate', exact: true })).toBeVisible({ timeout: 5_000 });
+});
+
+When('I configure the webhook action with a test delivery URL', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  await this.page.getByTestId('automation-canvas').getByText('Webhook', { exact: true }).click();
+  const panel = this.page.getByTestId('automation-node-config-panel');
+  await expect(panel).toBeVisible({ timeout: 10_000 });
+
+  await panel.locator('#name').fill('Welcome flow webhook');
+  await panel.locator('#url').fill(WEBHOOK_TEST_URL);
+  await panel.getByRole('button', { name: 'Save action', exact: true }).click();
+  await expect(panel).not.toBeVisible({ timeout: 5_000 });
+});
+
+When('I activate the automation', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  await this.page.getByRole('button', { name: 'Activate', exact: true }).click();
+});
+
+Then('the automation status should be Active', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  await expect(this.page.getByText('Active', { exact: true })).toBeVisible({ timeout: 10_000 });
+  await expect(this.page.getByRole('button', { name: 'Pause', exact: true })).toBeVisible({ timeout: 10_000 });
+});
+
+When('I fill and submit the automations happy path form', async function (this: CustomWorld) {
+  if (!this.viewerPage) throw new Error('Viewer page is not initialized');
+  await this.viewerPage.locator('input[name="automation-e2e-name"]').fill('Automation E2E Runner');
+  await this.viewerPage.locator('input[name="automation-e2e-email"]').fill('automation-e2e@example.com');
+
+  const submitButton = this.viewerPage.getByTestId('viewer-submit-button');
+  await expect(submitButton).toBeVisible({ timeout: 10_000 });
+  await submitButton.click();
+});
+
+When('I open the automation runs view', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  await this.page.getByRole('button', { name: 'Runs', exact: true }).click();
+  await expect(this.page).toHaveURL(/\/runs$/, { timeout: 15_000 });
+});
+
+Then('a run should reach COMPLETED status', async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  const page = this.page;
+
+  await expectPoll(
+    async () => {
+      await page.reload({ waitUntil: 'networkidle' });
+      return page
+        .getByText('Completed', { exact: true })
+        .first()
+        .isVisible()
+        .catch(() => false);
+    },
+    {
+      timeout: 90_000,
+      interval: 3_000,
+      message: 'Automation run did not reach COMPLETED status in time',
+    }
+  );
+});
+
+Then("the run's webhook action step should show SUCCESS", async function (this: CustomWorld) {
+  if (!this.page) throw new Error('Page is not initialized');
+  await this.page.getByText('Completed', { exact: true }).first().click();
+
+  const dialog = this.page.getByRole('dialog');
+  await expect(dialog).toBeVisible({ timeout: 15_000 });
+  await expect(dialog.getByText('Webhook', { exact: true })).toBeVisible({ timeout: 10_000 });
+  await expect(dialog.getByText('Success', { exact: true }).first()).toBeVisible({ timeout: 10_000 });
+  await expect(dialog.getByText('Failed', { exact: true })).toHaveCount(0);
+});

--- a/test/e2e/steps/automations.steps.ts
+++ b/test/e2e/steps/automations.steps.ts
@@ -69,14 +69,20 @@ When('I save the automation graph', async function (this: CustomWorld) {
   if (!this.page) throw new Error('Page is not initialized');
   const saveButton = this.page.getByRole('button', { name: 'Save', exact: true });
   await saveButton.click();
+  // toBeDisabled() alone can't distinguish "already clean" from "save in flight" —
+  // the success toast is the actual signal that updateAutomation resolved.
+  await expect(this.page.getByText('Automation saved', { exact: true })).toBeVisible({ timeout: 10_000 });
   await expect(saveButton).toBeDisabled({ timeout: 10_000 });
 });
 
 When('I try to activate the automation', async function (this: CustomWorld) {
   if (!this.page) throw new Error('Page is not initialized');
   await this.page.getByRole('button', { name: 'Activate', exact: true }).click();
-  // Give the setStatus mutation time to round-trip and reject before asserting on it.
-  await this.page.waitForTimeout(1_500);
+  // Wait for the setStatus mutation's rejection toast rather than a fixed sleep —
+  // this is the actual signal that the AUTOMATION_INVALID_GRAPH rejection landed.
+  await expect(
+    this.page.getByText("Automation isn't ready to activate", { exact: true })
+  ).toBeVisible({ timeout: 10_000 });
 });
 
 Then('the automation should still be in Draft status', async function (this: CustomWorld) {
@@ -151,7 +157,14 @@ Then("the run's webhook action step should show SUCCESS", async function (this: 
 
   const dialog = this.page.getByRole('dialog');
   await expect(dialog).toBeVisible({ timeout: 15_000 });
-  await expect(dialog.getByText('Webhook', { exact: true })).toBeVisible({ timeout: 10_000 });
-  await expect(dialog.getByText('Success', { exact: true }).first()).toBeVisible({ timeout: 10_000 });
-  await expect(dialog.getByText('Failed', { exact: true })).toHaveCount(0);
+
+  // Scope the status assertion to the webhook step's own row — the run also has an
+  // "end" step, so an unscoped `dialog.getByText('Success')` could pass on that step
+  // instead of the webhook one. The step label (h4) and its status badge (span) are
+  // rendered as siblings under the same immediate wrapper div in AutomationRunDetail.
+  const webhookHeading = dialog.getByRole('heading', { level: 4, name: 'Webhook', exact: true });
+  await expect(webhookHeading).toBeVisible({ timeout: 10_000 });
+  const webhookRow = webhookHeading.locator('xpath=..');
+  await expect(webhookRow.getByText('Success', { exact: true })).toBeVisible({ timeout: 10_000 });
+  await expect(webhookRow.getByText('Failed', { exact: true })).toHaveCount(0);
 });

--- a/test/e2e/steps/helpers/form-schemas.ts
+++ b/test/e2e/steps/helpers/form-schemas.ts
@@ -285,6 +285,61 @@ export function createFilterTestFormSchema() {
 }
 
 /**
+ * Minimal single-page form used by the automations E2E happy path (#199):
+ * one text field and one email field, just enough for a webhook action's
+ * event payload to have something to substitute.
+ */
+export function createAutomationsHappyPathFormSchema() {
+  return {
+    layout: {
+      theme: "light",
+      textColor: "#000000",
+      spacing: "normal",
+      code: "L9",
+      content: "<h1>Automations E2E Test</h1>",
+      customBackGroundColor: "#ffffff",
+      backgroundImageKey: "",
+      pageMode: "single",
+      isCustomBackgroundColorEnabled: false
+    },
+    pages: [
+      {
+        id: "page-1",
+        title: "Contact Details",
+        fields: [
+          {
+            id: "automation-e2e-name",
+            type: "text_input_field",
+            label: "Name",
+            defaultValue: "",
+            prefix: "",
+            hint: "",
+            placeholder: "Enter your name",
+            validation: {
+              required: false,
+              type: "text_field_validation"
+            }
+          },
+          {
+            id: "automation-e2e-email",
+            type: "email_field",
+            label: "Email",
+            defaultValue: "",
+            prefix: "",
+            hint: "",
+            placeholder: "Enter your email",
+            validation: {
+              required: false,
+              type: "fillable_form_field"
+            }
+          }
+        ]
+      }
+    ]
+  };
+}
+
+/**
  * Create comprehensive form schema for mass response testing
  * Contains 9 fields across 3 pages with variety for data generation
  */


### PR DESCRIPTION
Closes #199

## Summary
- Adds an `@automations`-tagged Cucumber scenario covering the linear automation happy path per #199: sign in, create a form, build a webhook action in the builder, confirm Activate is blocked while the action is unconfigured (and the node shows the "Setup required" badge), configure and activate it, submit the public form, and poll the runs view until the run reaches `COMPLETED` with a `SUCCESS` step.
- Adds a minimal single-page form schema helper (`createAutomationsHappyPathFormSchema`) for the scenario.
- Documents the scenario in `test/e2e/README.md`.

## Notes on scope decisions
- **No CI wiring change needed.** The default `pnpm test:e2e` tag filter (`not @mass-responses and not @persistence and not @skip-ci`) already includes `@automations`, and the `e2e-local` CI job already sets `DIRECT_URL` (required for the pg-boss automation engine to enable — see `initializeAutomationEngine()` in `apps/backend/src/index.ts`). Verified both directly rather than assuming.
- **Webhook target is a public echo endpoint, not a local capture server.** `WebhookConfigForm`'s URL field only accepts `https://` (client-side regex), so a self-hosted local capture server would need a self-signed cert plus `NODE_TLS_REJECT_UNAUTHORIZED=0` on the backend process — weakening TLS verification for every outbound call the backend makes for the life of that process. Instead the scenario points the webhook at `https://postman-echo.com/post` (always returns 200) and only asserts run/step status, not delivered payload content — matching the fallback the issue itself calls out.
- This depends on #197 (builder canvas) and #194 (trigger service), both merged, plus #218 (run history + test mode UI), which merged during this work and is required for the runs-view assertions the scenario needs.

## Test plan
- [x] `pnpm test:e2e --tags "@automations"` passes locally (fresh local Postgres, backend + built form-app/form-viewer served like CI's `e2e-local` job)
- [x] Full existing suite passes: `pnpm test:e2e` → 89 scenarios / 1260 steps, all passed
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean (0 errors; pre-existing warnings only)
- [x] Pre-push hook (backend unit tests + coverage thresholds, form-viewer unit tests, form-app/form-viewer/admin-app builds) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for the automation webhook “happy path.”
  * Validates form creation and publication, automation draft activation behavior, webhook configuration, activation, and viewer thank-you submission.
  * Verifies an automation run completes and the webhook step reports success with no failures.

* **Documentation**
  * Updated E2E README with an `@automations` scenario and prerequisites (backend startup settings and HTTPS-only webhook URLs).
  * Renamed the optional base URL variable from `E2E_BASE_URL` to `E2E_FORM_APP_URL` while keeping login credentials requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->