### PR TITLE
Automations: fix canvas layout collisions, add horizontal Typeform-style redesign

### DIFF
--- a/apps/form-app/src/components/automations/builder/AutomationCanvas.tsx
+++ b/apps/form-app/src/components/automations/builder/AutomationCanvas.tsx
@@ -1,5 +1,14 @@
-import React, { useCallback } from 'react';
-import { ReactFlow, ReactFlowProvider, Background, BackgroundVariant, Controls, type NodeMouseHandler } from '@xyflow/react';
+import React, { useCallback, useMemo } from 'react';
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  BackgroundVariant,
+  Controls,
+  MarkerType,
+  type NodeChange,
+  type NodeMouseHandler,
+} from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import { useAutomationBuilderStore } from '../../../store/useAutomationBuilderStore';
 import { TriggerNode } from './nodes/TriggerNode';
@@ -31,6 +40,29 @@ const AutomationCanvasInner: React.FC<AutomationCanvasProps> = ({ form }) => {
   const nodes = useAutomationBuilderStore((s) => s.nodes);
   const edges = useAutomationBuilderStore((s) => s.edges);
   const setSelectedNodeId = useAutomationBuilderStore((s) => s.setSelectedNodeId);
+  const applyMeasuredLayout = useAutomationBuilderStore((s) => s.applyMeasuredLayout);
+
+  // dagre lays nodes out using DEFAULT_DIMENSIONS (layout.ts) before React Flow has ever
+  // rendered them, since real widths depend on label text (condition summaries, i18n) and
+  // differ from the fallback per node type. React Flow reports each node's real rendered
+  // size as a 'dimensions' NodeChange once its ResizeObserver fires (on mount, and again on
+  // any insert/remove); `useNodesInitialized()` cannot substitute for this — it's derived
+  // from whatever `.measured` is already sitting on the *external* nodes prop we hand back
+  // in, which never happens in a purely store-controlled canvas like this one, so it would
+  // never flip true. Feeding real sizes back through here keeps edges landing exactly on
+  // each node's rendered handle instead of the dagre-assumed center.
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => {
+      const dimensionChanges = changes
+        .filter((change) => change.type === 'dimensions' && change.dimensions)
+        .map((change) => {
+          const c = change as Extract<NodeChange, { type: 'dimensions' }>;
+          return { id: c.id, width: c.dimensions!.width, height: c.dimensions!.height };
+        });
+      if (dimensionChanges.length > 0) applyMeasuredLayout(dimensionChanges);
+    },
+    [applyMeasuredLayout]
+  );
 
   const onNodeClick = useCallback<NodeMouseHandler>(
     (_event, node) => {
@@ -41,16 +73,29 @@ const AutomationCanvasInner: React.FC<AutomationCanvasProps> = ({ form }) => {
 
   const onPaneClick = useCallback(() => setSelectedNodeId(null), [setSelectedNodeId]);
 
+  // A small closed arrowhead just before each node, matching the reference workflow
+  // builder's line language — applied here at render time rather than baked into every
+  // edge-creation call site in automationBuilderSlice.ts, since it's pure presentation.
+  const edgesWithMarkers = useMemo(
+    () =>
+      edges.map((edge) => ({
+        ...edge,
+        markerEnd: { type: MarkerType.ArrowClosed, color: 'var(--tf-light-muted)', width: 16, height: 16 },
+      })),
+    [edges]
+  );
+
   return (
     <div className="flex h-full w-full overflow-hidden">
       <div className="flex-1 min-w-0" data-testid="automation-canvas">
         <ReactFlow
           nodes={nodes}
-          edges={edges}
+          edges={edgesWithMarkers}
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
           onNodeClick={onNodeClick}
           onPaneClick={onPaneClick}
+          onNodesChange={onNodesChange}
           nodesDraggable={false}
           nodesConnectable={false}
           edgesFocusable={false}

--- a/apps/form-app/src/components/automations/builder/AutomationCanvas.tsx
+++ b/apps/form-app/src/components/automations/builder/AutomationCanvas.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   ReactFlow,
   ReactFlowProvider,
@@ -6,6 +6,8 @@ import {
   BackgroundVariant,
   Controls,
   MarkerType,
+  MiniMap,
+  useReactFlow,
   type NodeChange,
   type NodeMouseHandler,
 } from '@xyflow/react';
@@ -39,8 +41,10 @@ interface AutomationCanvasProps {
 const AutomationCanvasInner: React.FC<AutomationCanvasProps> = ({ form }) => {
   const nodes = useAutomationBuilderStore((s) => s.nodes);
   const edges = useAutomationBuilderStore((s) => s.edges);
+  const selectedNodeId = useAutomationBuilderStore((s) => s.selectedNodeId);
   const setSelectedNodeId = useAutomationBuilderStore((s) => s.setSelectedNodeId);
   const applyMeasuredLayout = useAutomationBuilderStore((s) => s.applyMeasuredLayout);
+  const { fitView } = useReactFlow();
 
   // dagre lays nodes out using DEFAULT_DIMENSIONS (layout.ts) before React Flow has ever
   // rendered them, since real widths depend on label text (condition summaries, i18n) and
@@ -63,6 +67,27 @@ const AutomationCanvasInner: React.FC<AutomationCanvasProps> = ({ form }) => {
     },
     [applyMeasuredLayout]
   );
+
+  // Automations can grow wide once a few branches/steps are added, easily pushing a
+  // freshly-inserted step outside the current viewport with no indication anything
+  // changed. insertStepOnEdge always selects the node it just created, so a node id that
+  // (a) wasn't present last render and (b) is the current selection can only mean "the
+  // user just added a step" — not an existing-node click (no new id) or a fresh
+  // automation load (multiple/all ids appear new at once, never exactly one on a graph
+  // that always has at least a trigger + End node). Panning only in that specific case
+  // avoids fighting the user's manual pan/zoom the rest of the time.
+  const previousNodeIdsRef = useRef<Set<string> | null>(null);
+  useEffect(() => {
+    const currentIds = new Set(nodes.map((n) => n.id));
+    const previousIds = previousNodeIdsRef.current;
+    previousNodeIdsRef.current = currentIds;
+    if (!previousIds) return; // first render — the `fitView` prop already handles this
+
+    const newlyAdded = [...currentIds].filter((id) => !previousIds.has(id));
+    if (newlyAdded.length === 1 && newlyAdded[0] === selectedNodeId) {
+      fitView({ nodes: [{ id: newlyAdded[0] }], duration: 400, padding: 0.5, maxZoom: 1 });
+    }
+  }, [nodes, selectedNodeId, fitView]);
 
   const onNodeClick = useCallback<NodeMouseHandler>(
     (_event, node) => {
@@ -108,6 +133,15 @@ const AutomationCanvasInner: React.FC<AutomationCanvasProps> = ({ form }) => {
         >
           <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="var(--tf-border-strong)" />
           <Controls showInteractive={false} position="bottom-left" />
+          <MiniMap
+            position="bottom-right"
+            pannable
+            zoomable
+            nodeColor="var(--tf-light-muted)"
+            nodeStrokeWidth={0}
+            maskColor="var(--tf-overlay)"
+            style={{ border: '1px solid var(--tf-border-medium)', borderRadius: 8 }}
+          />
         </ReactFlow>
       </div>
       <NodeConfigPanel form={form} />

--- a/apps/form-app/src/components/automations/builder/__tests__/layout.test.ts
+++ b/apps/form-app/src/components/automations/builder/__tests__/layout.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for layoutAutomationGraph (LR dagre layout + spacer-node routing for
+ * rank-skipping branches + true/false branch-order mirroring). Each of these tests locks
+ * in a bug that was previously only caught by manually reproducing a specific click
+ * sequence in a browser:
+ *
+ *  - "Yes"/"No" branches rendering in the wrong vertical order relative to their fixed
+ *    handle positions, crossing directly under the condition card (#see layout.ts
+ *    conditionsByRank mirror pass).
+ *  - A rank-skipping branch's edge routed straight through — and rendered invisible
+ *    behind — a sibling branch's node (#see the spacer-node rewrite).
+ *  - A branch that no longer skips any rank still rendering via a stale bend route
+ *    computed for an earlier, longer graph shape (#see withoutStaleBend).
+ *  - The exact same graph topology laying out differently depending only on which
+ *    branch's step was added first (edge array order) — layoutAutomationGraph must be
+ *    order-independent.
+ *
+ * jest-environment-jsdom doesn't expose Node's built-in structuredClone, which
+ * @dagrejs/dagre relies on internally — see the same polyfill in
+ * automationBuilderSlice.test.ts.
+ */
+if (typeof (global as any).structuredClone !== 'function') {
+  (global as any).structuredClone = (value: unknown) => JSON.parse(JSON.stringify(value));
+}
+
+import { layoutAutomationGraph, type AutomationNode, type AutomationEdge } from '../layout';
+
+const node = (id: string, type: AutomationNode['type'], width = 280, height = 90): AutomationNode => ({
+  id,
+  type,
+  data: {} as any,
+  position: { x: 0, y: 0 },
+  measured: { width, height },
+});
+
+const edge = (id: string, source: string, target: string, sourceHandle?: 'true' | 'false'): AutomationEdge => ({
+  id,
+  source,
+  target,
+  ...(sourceHandle ? { sourceHandle } : {}),
+});
+
+const findNode = (nodes: AutomationNode[], id: string) => nodes.find((n) => n.id === id)!;
+const findEdge = (edges: AutomationEdge[], id: string) => edges.find((e) => e.id === id)!;
+const centerY = (n: AutomationNode) => n.position.y + (n.measured!.height as number) / 2;
+const centerX = (n: AutomationNode) => n.position.x + (n.measured!.width as number) / 2;
+
+describe('layoutAutomationGraph — basic LR layout', () => {
+  test('lays out a straight chain left-to-right with strictly increasing x and no bend points', () => {
+    const nodes = [node('trigger', 'trigger'), node('action', 'action'), node('end', 'end')];
+    const edges = [edge('e1', 'trigger', 'action'), edge('e2', 'action', 'end')];
+
+    const { nodes: laidOut, edges: laidOutEdges } = layoutAutomationGraph(nodes, edges);
+
+    const xs = ['trigger', 'action', 'end'].map((id) => centerX(findNode(laidOut, id)));
+    expect(xs[0]).toBeLessThan(xs[1]);
+    expect(xs[1]).toBeLessThan(xs[2]);
+    for (const e of laidOutEdges) expect(e.data?.bendPoints).toBeUndefined();
+  });
+});
+
+describe('layoutAutomationGraph — true/false branch order', () => {
+  test('the "true" branch always renders at or above the "false" branch, regardless of what dagre would naturally pick', () => {
+    // A deliberately asymmetric shape: the false branch merges immediately, while the true
+    // branch runs through two more steps first — the exact kind of imbalance that, in the
+    // real automation this was found on, made dagre's crossing-minimization pass put the
+    // false branch's subtree above the true branch's.
+    const nodes = [
+      node('trigger', 'trigger'),
+      node('c1', 'condition'),
+      node('t1', 'action'),
+      node('t2', 'action'),
+      node('f1', 'action'),
+      node('end', 'end'),
+    ];
+    const edges = [
+      edge('e1', 'trigger', 'c1'),
+      edge('e2', 'c1', 't1', 'true'),
+      edge('e3', 't1', 't2'),
+      edge('e4', 't2', 'end'),
+      edge('e5', 'c1', 'f1', 'false'),
+      edge('e6', 'f1', 'end'),
+    ];
+
+    const { nodes: laidOut } = layoutAutomationGraph(nodes, edges);
+    expect(centerY(findNode(laidOut, 't1'))).toBeLessThanOrEqual(centerY(findNode(laidOut, 'f1')));
+  });
+
+  test('holds for nested conditions too', () => {
+    // trigger -> c1 -[true]-> c2 -[true]-> t1 -> end
+    //                  |          -[false]-> f1 -> end
+    //                  -[false]-> b1 -> end
+    const nodes = [
+      node('trigger', 'trigger'),
+      node('c1', 'condition'),
+      node('c2', 'condition'),
+      node('t1', 'action'),
+      node('f1', 'action'),
+      node('b1', 'action'),
+      node('end', 'end'),
+    ];
+    const edges = [
+      edge('e1', 'trigger', 'c1'),
+      edge('e2', 'c1', 'c2', 'true'),
+      edge('e3', 'c1', 'b1', 'false'),
+      edge('e4', 'b1', 'end'),
+      edge('e5', 'c2', 't1', 'true'),
+      edge('e6', 'c2', 'f1', 'false'),
+      edge('e7', 't1', 'end'),
+      edge('e8', 'f1', 'end'),
+    ];
+
+    const { nodes: laidOut } = layoutAutomationGraph(nodes, edges);
+    expect(centerY(findNode(laidOut, 't1'))).toBeLessThanOrEqual(centerY(findNode(laidOut, 'f1')));
+  });
+});
+
+describe('layoutAutomationGraph — order independence', () => {
+  test('produces the same layout whether the "false" branch or the "true" branch was populated first', () => {
+    // Same final topology as the nested-condition case above, but with the false-branch
+    // edges listed before the true-branch edges — reproducing "add a step to No, then
+    // add a step to Yes" versus "Yes then No". A pure function of graph shape must not
+    // care about this.
+    const nodes = [
+      node('trigger', 'trigger'),
+      node('c1', 'condition'),
+      node('t1', 'action'),
+      node('f1', 'action'),
+      node('end', 'end'),
+    ];
+    const edgesYesFirst = [
+      edge('e1', 'trigger', 'c1'),
+      edge('e2', 'c1', 't1', 'true'),
+      edge('e3', 'c1', 'f1', 'false'),
+      edge('e4', 't1', 'end'),
+      edge('e5', 'f1', 'end'),
+    ];
+    const edgesNoFirst = [
+      edge('e1', 'trigger', 'c1'),
+      edge('e3', 'c1', 'f1', 'false'),
+      edge('e2', 'c1', 't1', 'true'),
+      edge('e5', 'f1', 'end'),
+      edge('e4', 't1', 'end'),
+    ];
+
+    const a = layoutAutomationGraph(nodes, edgesYesFirst);
+    const b = layoutAutomationGraph(nodes, edgesNoFirst);
+
+    for (const id of ['trigger', 'c1', 't1', 'f1', 'end']) {
+      expect(findNode(a.nodes, id).position).toEqual(findNode(b.nodes, id).position);
+    }
+  });
+});
+
+describe('layoutAutomationGraph — rank-skipping branches route through spacer nodes', () => {
+  test('a branch skipping past its sibling\'s multi-step chain gets bend points that clear every node in the skipped ranks', () => {
+    // c1 -[true]-> t1 -> t2 -> end   (2-step branch)
+    // c1 -[false]-> end              (skips t1's and t2's ranks entirely)
+    const nodes = [
+      node('trigger', 'trigger'),
+      node('c1', 'condition'),
+      node('t1', 'action'),
+      node('t2', 'action'),
+      node('end', 'end'),
+    ];
+    const edges = [
+      edge('e1', 'trigger', 'c1'),
+      edge('e2', 'c1', 't1', 'true'),
+      edge('e3', 't1', 't2'),
+      edge('e4', 't2', 'end'),
+      edge('e5', 'c1', 'end', 'false'),
+    ];
+
+    const { nodes: laidOut, edges: laidOutEdges } = layoutAutomationGraph(nodes, edges);
+    const falseEdge = findEdge(laidOutEdges, 'e5');
+    const bendPoints = falseEdge.data?.bendPoints as { x: number; y: number }[] | undefined;
+
+    // Skips exactly two ranks (t1's and t2's), so needs exactly two bend points.
+    expect(bendPoints).toHaveLength(2);
+
+    const t1 = findNode(laidOut, 't1');
+    const t2 = findNode(laidOut, 't2');
+    const within = (y: number, n: AutomationNode) => {
+      const top = n.position.y;
+      const bottom = n.position.y + (n.measured!.height as number);
+      return y >= top && y <= bottom;
+    };
+    for (const point of bendPoints!) {
+      expect(within(point.y, t1)).toBe(false);
+      expect(within(point.y, t2)).toBe(false);
+    }
+  });
+
+  test('clears bend points once the graph no longer needs them (sibling branch deleted)', () => {
+    const withSibling = [
+      node('trigger', 'trigger'),
+      node('c1', 'condition'),
+      node('t1', 'action'),
+      node('end', 'end'),
+    ];
+    const edgesWithSibling = [
+      edge('e1', 'trigger', 'c1'),
+      edge('e2', 'c1', 't1', 'true'),
+      edge('e3', 't1', 'end'),
+      edge('e4', 'c1', 'end', 'false'),
+    ];
+    const { edges: firstPass } = layoutAutomationGraph(withSibling, edgesWithSibling);
+    expect(findEdge(firstPass, 'e4').data?.bendPoints).toHaveLength(1);
+
+    // t1 deleted and its neighbors reconnected — exactly what removeNode does — leaving a
+    // trivial trigger -> c1 -> end / end graph where "false" is adjacent-rank again. The
+    // edge object being re-fed in still carries last pass's bendPoints in its `data`.
+    const withoutSibling = [node('trigger', 'trigger'), node('c1', 'condition'), node('end', 'end')];
+    const edgesWithoutSibling = [
+      edge('e1', 'trigger', 'c1'),
+      edge('e6', 'c1', 'end', 'true'),
+      findEdge(firstPass, 'e4'), // still has stale data.bendPoints from the first pass
+    ];
+
+    const { edges: secondPass } = layoutAutomationGraph(withoutSibling, edgesWithoutSibling);
+    expect(findEdge(secondPass, 'e4').data?.bendPoints).toBeUndefined();
+  });
+});

--- a/apps/form-app/src/components/automations/builder/edges/AddStepEdge.tsx
+++ b/apps/form-app/src/components/automations/builder/edges/AddStepEdge.tsx
@@ -165,10 +165,8 @@ export const AddStepEdge: React.FC<EdgeProps> = ({
                 <button
                   type="button"
                   aria-label={t('builder.addStep.buttonLabel')}
-                  className="h-6 w-6 rounded-full flex items-center justify-center transition-colors"
-                  style={{ backgroundColor: 'var(--tf-dark)', boxShadow: 'var(--shadow-sm)' }}
-                  onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--tf-darkest)')}
-                  onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'var(--tf-dark)')}
+                  className="h-6 w-6 rounded-full flex items-center justify-center transition-colors bg-[var(--tf-dark)] hover:bg-[var(--tf-darkest)]"
+                  style={{ boxShadow: 'var(--shadow-sm)' }}
                 >
                   <Plus className="h-3.5 w-3.5" style={{ color: 'white' }} />
                 </button>

--- a/apps/form-app/src/components/automations/builder/edges/AddStepEdge.tsx
+++ b/apps/form-app/src/components/automations/builder/edges/AddStepEdge.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import {
   BaseEdge,
   EdgeLabelRenderer,
-  getSmoothStepPath,
+  getBezierPath,
   Position,
   type EdgeProps,
 } from '@xyflow/react';
@@ -44,47 +44,34 @@ const CatalogItem: React.FC<CatalogItemProps> = ({ icon, iconBg, label, disabled
   </button>
 );
 
-const BORDER_RADIUS = 8;
-
 /**
- * Draws a path through `points` (source, any dagre-computed bend points, target) by
- * chaining getSmoothStepPath calls segment-by-segment — the same function and radius
- * every other (adjacent-rank, no-bend) edge uses, so a branch edge that skips a rank
- * (e.g. an empty condition branch wired straight past its sibling's node) still reads
- * as visually consistent with the rest of the graph instead of cutting a single
- * straight diagonal across the skipped rank. Interior points are treated as pass-through
- * stops (exiting "Bottom", entering "Top"), mirroring the dummy chain node dagre itself
- * inserts there.
+ * Draws a smooth curve through `points` (source, any dagre-computed bend points, target)
+ * by chaining getBezierPath calls segment-by-segment — matching the reference workflow
+ * builder's curved connector language — so a branch edge that skips a rank (e.g. an empty
+ * condition branch wired straight past its sibling's node) still reads as visually
+ * consistent with the rest of the graph instead of cutting a single straight diagonal
+ * across the skipped rank. Interior points are treated as pass-through stops (exiting
+ * "Right", entering "Left"), mirroring the dummy chain node dagre itself inserts there.
  */
-function buildSteppedPath(
+function buildCurvedPath(
   points: { x: number; y: number }[],
   sourcePosition: Position,
-  targetPosition: Position,
-  // Overrides the Y at which the *final* segment bends toward the target. Sibling edges
-  // that reconverge on the same node otherwise all compute the same default (source/
-  // target midpoint) bend Y whenever they also share a source Y (e.g. two branches'
-  // action nodes landing on the same rank before both feeding the shared End node),
-  // making their paths pixel-identical for the whole final approach — see mergeCenterY
-  // in AddStepEdge.
-  finalCenterY?: number
+  targetPosition: Position
 ): { path: string; labelX: number; labelY: number } {
   const segments: string[] = [];
   let labelX = points[0].x;
   let labelY = points[0].y;
   const midSegmentIndex = Math.floor((points.length - 2) / 2);
-  const lastSegmentIndex = points.length - 2;
 
   for (let i = 0; i < points.length - 1; i++) {
-    const isLast = i === lastSegmentIndex;
-    const [segPath, segLabelX, segLabelY] = getSmoothStepPath({
+    const isLast = i === points.length - 2;
+    const [segPath, segLabelX, segLabelY] = getBezierPath({
       sourceX: points[i].x,
       sourceY: points[i].y,
-      sourcePosition: i === 0 ? sourcePosition : Position.Bottom,
+      sourcePosition: i === 0 ? sourcePosition : Position.Right,
       targetX: points[i + 1].x,
       targetY: points[i + 1].y,
-      targetPosition: isLast ? targetPosition : Position.Top,
-      borderRadius: BORDER_RADIUS,
-      ...(isLast && finalCenterY !== undefined ? { centerY: finalCenterY } : {}),
+      targetPosition: isLast ? targetPosition : Position.Left,
     });
     segments.push(segPath);
     if (i === midSegmentIndex) {
@@ -115,16 +102,7 @@ export const AddStepEdge: React.FC<EdgeProps> = ({
 
   const bendPoints = (data?.bendPoints as { x: number; y: number }[] | undefined) ?? [];
   const pathPoints = [{ x: sourceX, y: sourceY }, ...bendPoints, { x: targetX, y: targetY }];
-
-  const mergeIndex = data?.mergeIndex as number | undefined;
-  const mergeCount = data?.mergeCount as number | undefined;
-  const lastPoint = pathPoints[pathPoints.length - 2];
-  const mergeCenterY =
-    mergeIndex !== undefined && mergeCount !== undefined && mergeCount > 1
-      ? lastPoint.y + (targetY - lastPoint.y) * (0.5 + (mergeIndex - (mergeCount - 1) / 2) * 0.14)
-      : undefined;
-
-  const { path: edgePath, labelX, labelY } = buildSteppedPath(pathPoints, sourcePosition, targetPosition, mergeCenterY);
+  const { path: edgePath, labelX, labelY } = buildCurvedPath(pathPoints, sourcePosition, targetPosition);
 
   const branchLabel =
     sourceHandleId === 'true'
@@ -157,7 +135,7 @@ export const AddStepEdge: React.FC<EdgeProps> = ({
           <div
             style={{
               position: 'absolute',
-              transform: `translate(-50%, 0) translate(${sourceX}px, ${sourceY + 10}px)`,
+              transform: `translate(0, -50%) translate(${sourceX + 10}px, ${sourceY}px)`,
               pointerEvents: 'none',
             }}
             className="nodrag nopan"

--- a/apps/form-app/src/components/automations/builder/edges/AddStepEdge.tsx
+++ b/apps/form-app/src/components/automations/builder/edges/AddStepEdge.tsx
@@ -3,6 +3,7 @@ import {
   BaseEdge,
   EdgeLabelRenderer,
   getSmoothStepPath,
+  Position,
   type EdgeProps,
 } from '@xyflow/react';
 import { Popover, PopoverContent, PopoverTrigger, Badge } from '@dculus/ui';
@@ -43,6 +44,58 @@ const CatalogItem: React.FC<CatalogItemProps> = ({ icon, iconBg, label, disabled
   </button>
 );
 
+const BORDER_RADIUS = 8;
+
+/**
+ * Draws a path through `points` (source, any dagre-computed bend points, target) by
+ * chaining getSmoothStepPath calls segment-by-segment — the same function and radius
+ * every other (adjacent-rank, no-bend) edge uses, so a branch edge that skips a rank
+ * (e.g. an empty condition branch wired straight past its sibling's node) still reads
+ * as visually consistent with the rest of the graph instead of cutting a single
+ * straight diagonal across the skipped rank. Interior points are treated as pass-through
+ * stops (exiting "Bottom", entering "Top"), mirroring the dummy chain node dagre itself
+ * inserts there.
+ */
+function buildSteppedPath(
+  points: { x: number; y: number }[],
+  sourcePosition: Position,
+  targetPosition: Position,
+  // Overrides the Y at which the *final* segment bends toward the target. Sibling edges
+  // that reconverge on the same node otherwise all compute the same default (source/
+  // target midpoint) bend Y whenever they also share a source Y (e.g. two branches'
+  // action nodes landing on the same rank before both feeding the shared End node),
+  // making their paths pixel-identical for the whole final approach — see mergeCenterY
+  // in AddStepEdge.
+  finalCenterY?: number
+): { path: string; labelX: number; labelY: number } {
+  const segments: string[] = [];
+  let labelX = points[0].x;
+  let labelY = points[0].y;
+  const midSegmentIndex = Math.floor((points.length - 2) / 2);
+  const lastSegmentIndex = points.length - 2;
+
+  for (let i = 0; i < points.length - 1; i++) {
+    const isLast = i === lastSegmentIndex;
+    const [segPath, segLabelX, segLabelY] = getSmoothStepPath({
+      sourceX: points[i].x,
+      sourceY: points[i].y,
+      sourcePosition: i === 0 ? sourcePosition : Position.Bottom,
+      targetX: points[i + 1].x,
+      targetY: points[i + 1].y,
+      targetPosition: isLast ? targetPosition : Position.Top,
+      borderRadius: BORDER_RADIUS,
+      ...(isLast && finalCenterY !== undefined ? { centerY: finalCenterY } : {}),
+    });
+    segments.push(segPath);
+    if (i === midSegmentIndex) {
+      labelX = segLabelX;
+      labelY = segLabelY;
+    }
+  }
+
+  return { path: segments.join(' '), labelX, labelY };
+}
+
 export const AddStepEdge: React.FC<EdgeProps> = ({
   id,
   sourceX,
@@ -53,21 +106,25 @@ export const AddStepEdge: React.FC<EdgeProps> = ({
   targetPosition,
   sourceHandleId,
   markerEnd,
+  data,
 }) => {
   const { t } = useTranslation('automations');
   const [open, setOpen] = useState(false);
   const isReadOnly = useAutomationBuilderStore((s) => s.isReadOnly);
   const insertStepOnEdge = useAutomationBuilderStore((s) => s.insertStepOnEdge);
 
-  const [edgePath, labelX, labelY] = getSmoothStepPath({
-    sourceX,
-    sourceY,
-    sourcePosition,
-    targetX,
-    targetY,
-    targetPosition,
-    borderRadius: 8,
-  });
+  const bendPoints = (data?.bendPoints as { x: number; y: number }[] | undefined) ?? [];
+  const pathPoints = [{ x: sourceX, y: sourceY }, ...bendPoints, { x: targetX, y: targetY }];
+
+  const mergeIndex = data?.mergeIndex as number | undefined;
+  const mergeCount = data?.mergeCount as number | undefined;
+  const lastPoint = pathPoints[pathPoints.length - 2];
+  const mergeCenterY =
+    mergeIndex !== undefined && mergeCount !== undefined && mergeCount > 1
+      ? lastPoint.y + (targetY - lastPoint.y) * (0.5 + (mergeIndex - (mergeCount - 1) / 2) * 0.14)
+      : undefined;
+
+  const { path: edgePath, labelX, labelY } = buildSteppedPath(pathPoints, sourcePosition, targetPosition, mergeCenterY);
 
   const branchLabel =
     sourceHandleId === 'true'
@@ -94,7 +151,7 @@ export const AddStepEdge: React.FC<EdgeProps> = ({
 
   return (
     <>
-      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={{ stroke: 'var(--tf-border-strong)', strokeWidth: 1.5 }} />
+      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={{ stroke: 'var(--tf-light-muted)', strokeWidth: 1.5 }} />
       {branchLabel && (
         <EdgeLabelRenderer>
           <div
@@ -130,10 +187,12 @@ export const AddStepEdge: React.FC<EdgeProps> = ({
                 <button
                   type="button"
                   aria-label={t('builder.addStep.buttonLabel')}
-                  className="h-6 w-6 rounded-full flex items-center justify-center bg-white hover:bg-[rgba(87,84,91,0.06)] transition-colors"
-                  style={{ border: '1.5px solid var(--tf-border-strong)' }}
+                  className="h-6 w-6 rounded-full flex items-center justify-center transition-colors"
+                  style={{ backgroundColor: 'var(--tf-dark)', boxShadow: 'var(--shadow-sm)' }}
+                  onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--tf-darkest)')}
+                  onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'var(--tf-dark)')}
                 >
-                  <Plus className="h-3.5 w-3.5" style={{ color: 'var(--tf-muted)' }} />
+                  <Plus className="h-3.5 w-3.5" style={{ color: 'white' }} />
                 </button>
               </PopoverTrigger>
               <PopoverContent align="center" className="w-64 p-2">

--- a/apps/form-app/src/components/automations/builder/layout.ts
+++ b/apps/form-app/src/components/automations/builder/layout.ts
@@ -48,6 +48,53 @@ export function layoutAutomationGraph(
 
   dagre.layout(g);
 
+  // ConditionNode fixes "Yes" at the card's left handle (30%) and "No" at the right handle
+  // (70%) — see ConditionNode.tsx — but dagre's crossing-minimization ordering pass has no
+  // notion of that convention; it's free to place the "false" branch's subtree to the left
+  // of the "true" branch's, purely to minimize crossings elsewhere in the graph. When it
+  // does, the Yes edge (leaving from the left handle) has to swing right past the No edge
+  // (leaving from the right handle) swinging left, crossing directly under the card. Detect
+  // that per condition node and mirror each branch's *exclusive* subtree (nodes reachable
+  // only from that branch, not also from the other one, e.g. shared merge points like a
+  // downstream End node are left untouched) around the condition's own x, swapping which
+  // side they render on to match the fixed handle positions.
+  const reachableFrom = (startId: string, excludeId: string): Set<string> => {
+    const visited = new Set<string>();
+    const stack = [startId];
+    while (stack.length > 0) {
+      const id = stack.pop()!;
+      if (id === excludeId || visited.has(id)) continue;
+      visited.add(id);
+      for (const edge of edges) {
+        if (edge.source === id) stack.push(edge.target);
+      }
+    }
+    return visited;
+  };
+
+  const conditionsByRank = nodes
+    .filter((n) => n.type === 'condition')
+    .sort((a, b) => (g.node(a.id)?.y ?? 0) - (g.node(b.id)?.y ?? 0));
+  for (const condition of conditionsByRank) {
+    const trueEdge = edges.find((e) => e.source === condition.id && e.sourceHandle === 'true');
+    const falseEdge = edges.find((e) => e.source === condition.id && e.sourceHandle === 'false');
+    if (!trueEdge || !falseEdge || !g.hasNode(trueEdge.target) || !g.hasNode(falseEdge.target)) continue;
+
+    const centerX = g.node(condition.id)?.x;
+    const trueX = g.node(trueEdge.target)?.x;
+    const falseX = g.node(falseEdge.target)?.x;
+    if (centerX === undefined || trueX === undefined || falseX === undefined || trueX <= falseX) continue;
+
+    const reachTrue = reachableFrom(trueEdge.target, condition.id);
+    const reachFalse = reachableFrom(falseEdge.target, condition.id);
+    const onlyTrue = [...reachTrue].filter((id) => !reachFalse.has(id));
+    const onlyFalse = [...reachFalse].filter((id) => !reachTrue.has(id));
+    for (const id of [...onlyTrue, ...onlyFalse]) {
+      const pos = g.node(id);
+      if (pos) pos.x = 2 * centerX - pos.x;
+    }
+  }
+
   // dagre's within-rank X-coordinate heuristic (Brandes-Köpf) doesn't always perfectly
   // center a node under its single parent when that parent's *other* descendants pull the
   // alignment pass toward a different median — even though aligning them costs nothing,

--- a/apps/form-app/src/components/automations/builder/layout.ts
+++ b/apps/form-app/src/components/automations/builder/layout.ts
@@ -17,38 +17,89 @@ const DEFAULT_DIMENSIONS: Record<AutomationNodeType, { width: number; height: nu
 
 const RANK_SEP = 96;
 const NODE_SEP = 56;
+const SPACER_SIZE = 1;
+const SPACER_PREFIX = '__spacer_';
 
 /**
  * Runs dagre's LR (left-to-right) auto-layout over the given nodes/edges and returns new
  * node objects with recomputed `position`, plus the edges enriched with any bend points
- * dagre computed for them. Nodes are never user-draggable in this builder, so this is the
- * single source of truth for node position after every graph mutation (insert/remove/load).
+ * needed to route a rank-skipping edge (e.g. an empty condition branch, wired straight to
+ * a node several ranks down past its sibling branch's own steps) around whatever it would
+ * otherwise cut straight through. Nodes are never user-draggable in this builder, so this
+ * is the single source of truth for node position after every graph mutation
+ * (insert/remove/load).
  *
- * Rank progresses left-to-right (dagre's `rankdir: 'LR'`), matching the reference workflow
- * builder's horizontal layout — same-rank nodes share an x, and vary in y. dagre's returned
- * node.x/node.y always mean standard screen-space horizontal/vertical regardless of
- * rankdir; only which axis represents "rank" changes. Every post-processing pass below is
- * the horizontal-layout mirror of what a TB layout would need along the other axis.
+ * A rank-skipping edge is never routed by computing a "safe" detour after the fact —
+ * hand-rolled clearance math only knows how to dodge *node boxes*, not the curves of
+ * *other edges* passing through the same rank, and a bezier's control-point bulge can
+ * still sweep back through a rank it was meant to clear. Instead, every edge that would
+ * skip a rank gets small invisible "spacer" nodes inserted into the graph at each skipped
+ * rank *before* dagre lays anything out, splitting it into a chain of plain, adjacent-rank
+ * hops — exactly what a strict tree would look like. dagre's own crossing-minimization and
+ * node separation then keeps every spacer clear of whatever else shares its rank, the same
+ * way it already keeps real nodes apart, so there is no bespoke routing logic left that can
+ * disagree with what actually got drawn.
+ *
+ * Rank progresses left-to-right (dagre's `rankdir: 'LR'`) — same-rank nodes share an x, and
+ * vary in y. dagre's returned node.x/node.y always mean standard screen-space
+ * horizontal/vertical regardless of rankdir; only which axis represents "rank" changes.
  */
 export function layoutAutomationGraph(
   nodes: AutomationNode[],
   edges: AutomationEdge[]
 ): { nodes: AutomationNode[]; edges: AutomationEdge[] } {
+  const validEdges = edges.filter((e) => nodes.some((n) => n.id === e.source) && nodes.some((n) => n.id === e.target));
+
+  // Preliminary layout, purely to learn each node's rank — how many spacer hops a given
+  // edge needs — before building the real, spacer-expanded graph dagre actually lays out.
+  const prelim = new dagre.graphlib.Graph();
+  prelim.setGraph({ rankdir: 'LR', nodesep: NODE_SEP, ranksep: RANK_SEP });
+  prelim.setDefaultEdgeLabel(() => ({}));
+  for (const node of nodes) {
+    const fallback = DEFAULT_DIMENSIONS[node.type as AutomationNodeType] ?? DEFAULT_DIMENSIONS.action;
+    prelim.setNode(node.id, { width: node.measured?.width ?? fallback.width, height: node.measured?.height ?? fallback.height });
+  }
+  for (const edge of validEdges) prelim.setEdge(edge.source, edge.target);
+  dagre.layout(prelim);
+
+  const prelimRankIndexByX = new Map<number, number>(
+    [...new Set(nodes.map((n) => prelim.node(n.id)?.x).filter((x): x is number => x !== undefined))]
+      .sort((a, b) => a - b)
+      .map((x, i) => [x, i])
+  );
+  const prelimRankOf = (nodeId: string): number => prelimRankIndexByX.get(prelim.node(nodeId)?.x ?? 0) ?? 0;
+
+  // Build the real graph, splitting any edge that spans more than one rank into a chain of
+  // single-rank hops through spacer nodes. `routeNodeIds` records the full node-id path
+  // (source, ...spacers, target) per original edge so the final positions can be read back
+  // into bend points afterward.
   const g = new dagre.graphlib.Graph();
   g.setGraph({ rankdir: 'LR', nodesep: NODE_SEP, ranksep: RANK_SEP });
   g.setDefaultEdgeLabel(() => ({}));
-
   for (const node of nodes) {
     const fallback = DEFAULT_DIMENSIONS[node.type as AutomationNodeType] ?? DEFAULT_DIMENSIONS.action;
-    const width = node.measured?.width ?? fallback.width;
-    const height = node.measured?.height ?? fallback.height;
-    g.setNode(node.id, { width, height });
+    g.setNode(node.id, { width: node.measured?.width ?? fallback.width, height: node.measured?.height ?? fallback.height });
   }
 
-  for (const edge of edges) {
-    if (g.hasNode(edge.source) && g.hasNode(edge.target)) {
-      g.setEdge(edge.source, edge.target);
+  const routeNodeIds = new Map<string, string[]>();
+  const expandedHops: { source: string; target: string }[] = [];
+  let spacerCount = 0;
+  for (const edge of validEdges) {
+    const gap = prelimRankOf(edge.target) - prelimRankOf(edge.source);
+    const route = [edge.source];
+    let prev = edge.source;
+    for (let i = 1; i < gap; i++) {
+      const spacerId = `${SPACER_PREFIX}${spacerCount++}`;
+      g.setNode(spacerId, { width: SPACER_SIZE, height: SPACER_SIZE });
+      g.setEdge(prev, spacerId);
+      expandedHops.push({ source: prev, target: spacerId });
+      route.push(spacerId);
+      prev = spacerId;
     }
+    g.setEdge(prev, edge.target);
+    expandedHops.push({ source: prev, target: edge.target });
+    route.push(edge.target);
+    routeNodeIds.set(edge.id, route);
   }
 
   dagre.layout(g);
@@ -59,10 +110,11 @@ export function layoutAutomationGraph(
   // "true" branch's, purely to minimize crossings elsewhere in the graph. When it does, the
   // Yes edge (leaving from the top handle) has to swing down past the No edge (leaving from
   // the bottom handle) swinging up, crossing directly beside the card. Detect that per
-  // condition node and mirror each branch's *exclusive* subtree (nodes reachable only from
-  // that branch, not also from the other one — shared merge points like a downstream End
-  // node are left untouched) around the condition's own y, swapping which side they render
-  // on to match the fixed handle positions.
+  // condition node and mirror each branch's *exclusive* subtree — including any spacer
+  // nodes now standing in for its rank-skipping hops, so they stay consistent with whatever
+  // real node they lead to — around the condition's own y, swapping which side they render
+  // on to match the fixed handle positions. Shared merge points (and the spacers leading to
+  // them) reachable from *both* branches are left untouched.
   const reachableFrom = (startId: string, excludeId: string): Set<string> => {
     const visited = new Set<string>();
     const stack = [startId];
@@ -70,8 +122,8 @@ export function layoutAutomationGraph(
       const id = stack.pop()!;
       if (id === excludeId || visited.has(id)) continue;
       visited.add(id);
-      for (const edge of edges) {
-        if (edge.source === id) stack.push(edge.target);
+      for (const hop of expandedHops) {
+        if (hop.source === id) stack.push(hop.target);
       }
     }
     return visited;
@@ -81,17 +133,24 @@ export function layoutAutomationGraph(
     .filter((n) => n.type === 'condition')
     .sort((a, b) => (g.node(a.id)?.x ?? 0) - (g.node(b.id)?.x ?? 0));
   for (const condition of conditionsByRank) {
-    const trueEdge = edges.find((e) => e.source === condition.id && e.sourceHandle === 'true');
-    const falseEdge = edges.find((e) => e.source === condition.id && e.sourceHandle === 'false');
-    if (!trueEdge || !falseEdge || !g.hasNode(trueEdge.target) || !g.hasNode(falseEdge.target)) continue;
+    const trueEdge = validEdges.find((e) => e.source === condition.id && e.sourceHandle === 'true');
+    const falseEdge = validEdges.find((e) => e.source === condition.id && e.sourceHandle === 'false');
+    if (!trueEdge || !falseEdge) continue;
 
+    const trueNextId = routeNodeIds.get(trueEdge.id)?.[1];
+    const falseNextId = routeNodeIds.get(falseEdge.id)?.[1];
     const centerY = g.node(condition.id)?.y;
-    const trueY = g.node(trueEdge.target)?.y;
-    const falseY = g.node(falseEdge.target)?.y;
+    const trueY = trueNextId ? g.node(trueNextId)?.y : undefined;
+    const falseY = falseNextId ? g.node(falseNextId)?.y : undefined;
     if (centerY === undefined || trueY === undefined || falseY === undefined || trueY <= falseY) continue;
 
-    const reachTrue = reachableFrom(trueEdge.target, condition.id);
-    const reachFalse = reachableFrom(falseEdge.target, condition.id);
+    // Start each side's reachability walk at its *first hop* (a spacer, if the edge skips
+    // any ranks, otherwise the real target directly) rather than at trueEdge/falseEdge's
+    // real target — starting at the target would skip every spacer standing in for that
+    // same edge's own rank-skipping hops, since they sit *before* the target in the route,
+    // not reachable by walking forward from it.
+    const reachTrue = reachableFrom(trueNextId!, condition.id);
+    const reachFalse = reachableFrom(falseNextId!, condition.id);
     const onlyTrue = [...reachTrue].filter((id) => !reachFalse.has(id));
     const onlyFalse = [...reachFalse].filter((id) => !reachTrue.has(id));
     for (const id of [...onlyTrue, ...onlyFalse]) {
@@ -105,31 +164,32 @@ export function layoutAutomationGraph(
   // alignment pass toward a different median — even though aligning them costs nothing,
   // since neither end has any other position constraint. The resulting few-pixel offset is
   // too small for the edge curve to resolve cleanly, so it draws as a barely-visible wiggle
-  // instead of a straight line. Force an exact y match for every hop that is unambiguously
-  // a straight pass-through — the source's only outgoing edge and the target's only
-  // incoming edge — leaving every real branch or merge point (anything with siblings)
-  // exactly as dagre positioned it. Processed in rank (x) order so a parent snapped from
-  // *its* own parent is already resolved before its children are considered.
+  // instead of a straight line. Force an exact y match for every hop — real or spacer —
+  // that is unambiguously a straight pass-through (its only predecessor's only successor),
+  // leaving every real branch or merge point (anything with siblings) exactly as dagre
+  // positioned it. Processed in rank (x) order so a parent snapped from *its* own parent is
+  // already resolved before its children are considered.
   const outDegree = new Map<string, number>();
   const inDegree = new Map<string, number>();
-  for (const edge of edges) {
-    if (!g.hasNode(edge.source) || !g.hasNode(edge.target)) continue;
-    outDegree.set(edge.source, (outDegree.get(edge.source) ?? 0) + 1);
-    inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
+  const allExpandedIds = new Set<string>();
+  for (const hop of expandedHops) {
+    outDegree.set(hop.source, (outDegree.get(hop.source) ?? 0) + 1);
+    inDegree.set(hop.target, (inDegree.get(hop.target) ?? 0) + 1);
+    allExpandedIds.add(hop.source);
+    allExpandedIds.add(hop.target);
   }
   const soleParentOf = new Map<string, string>();
-  for (const edge of edges) {
-    if (!g.hasNode(edge.source) || !g.hasNode(edge.target)) continue;
-    if (outDegree.get(edge.source) === 1 && inDegree.get(edge.target) === 1) {
-      soleParentOf.set(edge.target, edge.source);
+  for (const hop of expandedHops) {
+    if (outDegree.get(hop.source) === 1 && inDegree.get(hop.target) === 1) {
+      soleParentOf.set(hop.target, hop.source);
     }
   }
-  const byRank = [...nodes].sort((a, b) => (g.node(a.id)?.x ?? 0) - (g.node(b.id)?.x ?? 0));
-  for (const node of byRank) {
-    const parentId = soleParentOf.get(node.id);
+  const byRank = [...allExpandedIds].sort((a, b) => (g.node(a)?.x ?? 0) - (g.node(b)?.x ?? 0));
+  for (const id of byRank) {
+    const parentId = soleParentOf.get(id);
     if (!parentId) continue;
     const parentPos = g.node(parentId);
-    const childPos = g.node(node.id);
+    const childPos = g.node(id);
     if (parentPos && childPos) childPos.y = parentPos.y;
   }
 
@@ -145,93 +205,16 @@ export function layoutAutomationGraph(
     };
   });
 
-  // Rank is derived from dagre's own computed x (nodes in the same rank always land on
-  // an identical x in LR layout) rather than reimplemented as a longest-path-from-root
-  // calculation: dagre's network-simplex ranker can push a node meaningfully further
-  // along than its shortest/longest incoming path alone would suggest, to minimize total
-  // edge length across the *whole* graph (e.g. a branch with one action, feeding into an
-  // End node that other, longer branches also feed into, gets pulled forward to align
-  // with those siblings). A naive recomputation disagreed with dagre's real placement in
-  // exactly that case, so a genuinely multi-rank edge was misclassified as adjacent and
-  // drawn as one straight segment cutting across the intervening nodes.
-  const rankIndexByX = new Map<number, number>(
-    [...new Set(nodes.map((n) => g.node(n.id)?.x).filter((x): x is number => x !== undefined))]
-      .sort((a, b) => a - b)
-      .map((x, i) => [x, i])
-  );
-  const rankOf = (nodeId: string): number | undefined => {
-    const x = g.node(nodeId)?.x;
-    return x === undefined ? undefined : rankIndexByX.get(x);
-  };
-  const rankXs = [...rankIndexByX.entries()].sort((a, b) => a[1] - b[1]).map(([x]) => x);
-  const nodesByRank = new Map<number, AutomationNode[]>();
-  for (const node of nodes) {
-    const rank = rankOf(node.id);
-    if (rank === undefined) continue;
-    const list = nodesByRank.get(rank) ?? [];
-    list.push(node);
-    nodesByRank.set(rank, list);
-  }
-
-  // An edge that skips a rank — e.g. a condition branch with a single action, wired
-  // straight to a node that also has other, longer incoming paths — needs bend points so
-  // it routes around whatever occupies the skipped rank(s) instead of cutting a straight
-  // line across it. These are computed here, from nodes' *final* positions (after the
-  // true/false mirror and sole-parent snap above), rather than read from dagre's own
-  // `edge.points` — dagre computes those once during `dagre.layout()`, before either of
-  // those two passes runs, so they'd still reference whatever position a node had *before*
-  // it was mirrored/snapped. E.g. if a condition's true branch went straight to a shared
-  // End node while its false branch had its own action, the action node could get mirrored
-  // to the opposite side of the condition, but the true edge's stale bend point wouldn't
-  // move with it — leaving the true edge routed straight through the action node's new
-  // position, rendered invisible behind its (opaque) card.
-  //
-  // Route above everything in a skipped rank for a "true"/Yes edge (top handle) and below
-  // for "false"/No (bottom handle), matching ConditionNode's fixed handle sides; a plain
-  // (non-condition) edge picks whichever side the source already leans toward.
-  const CLEARANCE = 24;
   const layoutedEdges = edges.map((edge) => {
-    // An edge that needed bend points in an earlier layout pass (e.g. the sibling branch
-    // it was routing around has since been deleted) but doesn't anymore must have that
-    // stale `data.bendPoints` cleared here — every early return below hands back
-    // `withoutStaleBend`, not the raw `edge`, so a rank change that makes bending
-    // unnecessary actually removes the old bend route instead of leaving edges rendered
-    // via a route computed for a graph shape that no longer exists.
-    const withoutStaleBend: AutomationEdge =
-      edge.data?.bendPoints !== undefined ? { ...edge, data: { ...edge.data, bendPoints: undefined } } : edge;
-
-    if (!g.hasNode(edge.source) || !g.hasNode(edge.target)) return withoutStaleBend;
-    const sourceRank = rankOf(edge.source);
-    const targetRank = rankOf(edge.target);
-    if (sourceRank === undefined || targetRank === undefined || targetRank - sourceRank <= 1) return withoutStaleBend;
-
-    const sourcePos = g.node(edge.source);
-    const targetPos = g.node(edge.target);
-    if (!sourcePos || !targetPos) return withoutStaleBend;
-
-    const routeAbove =
-      edge.sourceHandle === 'true' ? true : edge.sourceHandle === 'false' ? false : sourcePos.y <= targetPos.y;
-
-    const bendPoints: { x: number; y: number }[] = [];
-    for (let rank = sourceRank + 1; rank < targetRank; rank++) {
-      const x = rankXs[rank];
-      if (x === undefined) continue;
-      const occupants = (nodesByRank.get(rank) ?? []).filter((n) => n.id !== edge.source && n.id !== edge.target);
-      if (occupants.length === 0) {
-        const t = (rank - sourceRank) / (targetRank - sourceRank);
-        bendPoints.push({ x, y: sourcePos.y + (targetPos.y - sourcePos.y) * t });
-        continue;
-      }
-      const occupantBounds = occupants.map((n) => {
-        const pos = g.node(n.id);
-        return pos ? { top: pos.y - pos.height / 2, bottom: pos.y + pos.height / 2 } : { top: 0, bottom: 0 };
-      });
-      const y = routeAbove
-        ? Math.min(...occupantBounds.map((b) => b.top)) - CLEARANCE
-        : Math.max(...occupantBounds.map((b) => b.bottom)) + CLEARANCE;
-      bendPoints.push({ x, y });
+    const route = routeNodeIds.get(edge.id);
+    const hasStaleBend = edge.data?.bendPoints !== undefined;
+    if (!route || route.length <= 2) {
+      return hasStaleBend ? { ...edge, data: { ...edge.data, bendPoints: undefined } } : edge;
     }
-    if (bendPoints.length === 0) return withoutStaleBend;
+    const bendPoints = route.slice(1, -1).map((id) => {
+      const pos = g.node(id);
+      return { x: pos?.x ?? 0, y: pos?.y ?? 0 };
+    });
     return { ...edge, data: { ...edge.data, bendPoints } };
   });
 

--- a/apps/form-app/src/components/automations/builder/layout.ts
+++ b/apps/form-app/src/components/automations/builder/layout.ts
@@ -145,13 +145,6 @@ export function layoutAutomationGraph(
     };
   });
 
-  // An edge that skips a rank — e.g. a condition branch with a single action, wired
-  // straight to a node that also has other, longer incoming paths — gets dummy chain
-  // nodes from dagre, exposed as extra interior points on the edge label. Only treat an
-  // edge as needing those bend points when it genuinely spans more than one rank: dagre
-  // attaches an interior "edge label" point to every edge it lays out (even a plain
-  // adjacent-rank one), so `points.length` alone isn't a reliable signal.
-  //
   // Rank is derived from dagre's own computed x (nodes in the same rank always land on
   // an identical x in LR layout) rather than reimplemented as a longest-path-from-root
   // calculation: dagre's network-simplex ranker can push a node meaningfully further
@@ -170,17 +163,75 @@ export function layoutAutomationGraph(
     const x = g.node(nodeId)?.x;
     return x === undefined ? undefined : rankIndexByX.get(x);
   };
+  const rankXs = [...rankIndexByX.entries()].sort((a, b) => a[1] - b[1]).map(([x]) => x);
+  const nodesByRank = new Map<number, AutomationNode[]>();
+  for (const node of nodes) {
+    const rank = rankOf(node.id);
+    if (rank === undefined) continue;
+    const list = nodesByRank.get(rank) ?? [];
+    list.push(node);
+    nodesByRank.set(rank, list);
+  }
 
+  // An edge that skips a rank — e.g. a condition branch with a single action, wired
+  // straight to a node that also has other, longer incoming paths — needs bend points so
+  // it routes around whatever occupies the skipped rank(s) instead of cutting a straight
+  // line across it. These are computed here, from nodes' *final* positions (after the
+  // true/false mirror and sole-parent snap above), rather than read from dagre's own
+  // `edge.points` — dagre computes those once during `dagre.layout()`, before either of
+  // those two passes runs, so they'd still reference whatever position a node had *before*
+  // it was mirrored/snapped. E.g. if a condition's true branch went straight to a shared
+  // End node while its false branch had its own action, the action node could get mirrored
+  // to the opposite side of the condition, but the true edge's stale bend point wouldn't
+  // move with it — leaving the true edge routed straight through the action node's new
+  // position, rendered invisible behind its (opaque) card.
+  //
+  // Route above everything in a skipped rank for a "true"/Yes edge (top handle) and below
+  // for "false"/No (bottom handle), matching ConditionNode's fixed handle sides; a plain
+  // (non-condition) edge picks whichever side the source already leans toward.
+  const CLEARANCE = 24;
   const layoutedEdges = edges.map((edge) => {
-    if (!g.hasNode(edge.source) || !g.hasNode(edge.target)) return edge;
+    // An edge that needed bend points in an earlier layout pass (e.g. the sibling branch
+    // it was routing around has since been deleted) but doesn't anymore must have that
+    // stale `data.bendPoints` cleared here — every early return below hands back
+    // `withoutStaleBend`, not the raw `edge`, so a rank change that makes bending
+    // unnecessary actually removes the old bend route instead of leaving edges rendered
+    // via a route computed for a graph shape that no longer exists.
+    const withoutStaleBend: AutomationEdge =
+      edge.data?.bendPoints !== undefined ? { ...edge, data: { ...edge.data, bendPoints: undefined } } : edge;
+
+    if (!g.hasNode(edge.source) || !g.hasNode(edge.target)) return withoutStaleBend;
     const sourceRank = rankOf(edge.source);
     const targetRank = rankOf(edge.target);
-    const rankGap = sourceRank !== undefined && targetRank !== undefined ? targetRank - sourceRank : 1;
-    if (rankGap <= 1) return edge;
+    if (sourceRank === undefined || targetRank === undefined || targetRank - sourceRank <= 1) return withoutStaleBend;
 
-    const dagreEdge = g.edge(edge.source, edge.target);
-    const bendPoints = dagreEdge?.points?.slice(1, -1);
-    if (!bendPoints || bendPoints.length === 0) return edge;
+    const sourcePos = g.node(edge.source);
+    const targetPos = g.node(edge.target);
+    if (!sourcePos || !targetPos) return withoutStaleBend;
+
+    const routeAbove =
+      edge.sourceHandle === 'true' ? true : edge.sourceHandle === 'false' ? false : sourcePos.y <= targetPos.y;
+
+    const bendPoints: { x: number; y: number }[] = [];
+    for (let rank = sourceRank + 1; rank < targetRank; rank++) {
+      const x = rankXs[rank];
+      if (x === undefined) continue;
+      const occupants = (nodesByRank.get(rank) ?? []).filter((n) => n.id !== edge.source && n.id !== edge.target);
+      if (occupants.length === 0) {
+        const t = (rank - sourceRank) / (targetRank - sourceRank);
+        bendPoints.push({ x, y: sourcePos.y + (targetPos.y - sourcePos.y) * t });
+        continue;
+      }
+      const occupantBounds = occupants.map((n) => {
+        const pos = g.node(n.id);
+        return pos ? { top: pos.y - pos.height / 2, bottom: pos.y + pos.height / 2 } : { top: 0, bottom: 0 };
+      });
+      const y = routeAbove
+        ? Math.min(...occupantBounds.map((b) => b.top)) - CLEARANCE
+        : Math.max(...occupantBounds.map((b) => b.bottom)) + CLEARANCE;
+      bendPoints.push({ x, y });
+    }
+    if (bendPoints.length === 0) return withoutStaleBend;
     return { ...edge, data: { ...edge.data, bendPoints } };
   });
 

--- a/apps/form-app/src/components/automations/builder/layout.ts
+++ b/apps/form-app/src/components/automations/builder/layout.ts
@@ -15,22 +15,27 @@ const DEFAULT_DIMENSIONS: Record<AutomationNodeType, { width: number; height: nu
   end: { width: 180, height: 56 },
 };
 
-const RANK_SEP = 72;
-const NODE_SEP = 48;
+const RANK_SEP = 96;
+const NODE_SEP = 56;
 
 /**
- * Runs dagre's TB (top-to-bottom) auto-layout over the given nodes/edges and returns
- * new node objects with recomputed `position`, plus the edges enriched with any bend
- * points dagre computed for them. Nodes are never user-draggable in this builder, so
- * this is the single source of truth for node position after every graph mutation
- * (insert/remove/load).
+ * Runs dagre's LR (left-to-right) auto-layout over the given nodes/edges and returns new
+ * node objects with recomputed `position`, plus the edges enriched with any bend points
+ * dagre computed for them. Nodes are never user-draggable in this builder, so this is the
+ * single source of truth for node position after every graph mutation (insert/remove/load).
+ *
+ * Rank progresses left-to-right (dagre's `rankdir: 'LR'`), matching the reference workflow
+ * builder's horizontal layout — same-rank nodes share an x, and vary in y. dagre's returned
+ * node.x/node.y always mean standard screen-space horizontal/vertical regardless of
+ * rankdir; only which axis represents "rank" changes. Every post-processing pass below is
+ * the horizontal-layout mirror of what a TB layout would need along the other axis.
  */
 export function layoutAutomationGraph(
   nodes: AutomationNode[],
   edges: AutomationEdge[]
 ): { nodes: AutomationNode[]; edges: AutomationEdge[] } {
   const g = new dagre.graphlib.Graph();
-  g.setGraph({ rankdir: 'TB', nodesep: NODE_SEP, ranksep: RANK_SEP });
+  g.setGraph({ rankdir: 'LR', nodesep: NODE_SEP, ranksep: RANK_SEP });
   g.setDefaultEdgeLabel(() => ({}));
 
   for (const node of nodes) {
@@ -48,16 +53,16 @@ export function layoutAutomationGraph(
 
   dagre.layout(g);
 
-  // ConditionNode fixes "Yes" at the card's left handle (30%) and "No" at the right handle
+  // ConditionNode fixes "Yes" at the card's top handle (30%) and "No" at the bottom handle
   // (70%) — see ConditionNode.tsx — but dagre's crossing-minimization ordering pass has no
-  // notion of that convention; it's free to place the "false" branch's subtree to the left
-  // of the "true" branch's, purely to minimize crossings elsewhere in the graph. When it
-  // does, the Yes edge (leaving from the left handle) has to swing right past the No edge
-  // (leaving from the right handle) swinging left, crossing directly under the card. Detect
-  // that per condition node and mirror each branch's *exclusive* subtree (nodes reachable
-  // only from that branch, not also from the other one, e.g. shared merge points like a
-  // downstream End node are left untouched) around the condition's own x, swapping which
-  // side they render on to match the fixed handle positions.
+  // notion of that convention; it's free to place the "false" branch's subtree above the
+  // "true" branch's, purely to minimize crossings elsewhere in the graph. When it does, the
+  // Yes edge (leaving from the top handle) has to swing down past the No edge (leaving from
+  // the bottom handle) swinging up, crossing directly beside the card. Detect that per
+  // condition node and mirror each branch's *exclusive* subtree (nodes reachable only from
+  // that branch, not also from the other one — shared merge points like a downstream End
+  // node are left untouched) around the condition's own y, swapping which side they render
+  // on to match the fixed handle positions.
   const reachableFrom = (startId: string, excludeId: string): Set<string> => {
     const visited = new Set<string>();
     const stack = [startId];
@@ -74,16 +79,16 @@ export function layoutAutomationGraph(
 
   const conditionsByRank = nodes
     .filter((n) => n.type === 'condition')
-    .sort((a, b) => (g.node(a.id)?.y ?? 0) - (g.node(b.id)?.y ?? 0));
+    .sort((a, b) => (g.node(a.id)?.x ?? 0) - (g.node(b.id)?.x ?? 0));
   for (const condition of conditionsByRank) {
     const trueEdge = edges.find((e) => e.source === condition.id && e.sourceHandle === 'true');
     const falseEdge = edges.find((e) => e.source === condition.id && e.sourceHandle === 'false');
     if (!trueEdge || !falseEdge || !g.hasNode(trueEdge.target) || !g.hasNode(falseEdge.target)) continue;
 
-    const centerX = g.node(condition.id)?.x;
-    const trueX = g.node(trueEdge.target)?.x;
-    const falseX = g.node(falseEdge.target)?.x;
-    if (centerX === undefined || trueX === undefined || falseX === undefined || trueX <= falseX) continue;
+    const centerY = g.node(condition.id)?.y;
+    const trueY = g.node(trueEdge.target)?.y;
+    const falseY = g.node(falseEdge.target)?.y;
+    if (centerY === undefined || trueY === undefined || falseY === undefined || trueY <= falseY) continue;
 
     const reachTrue = reachableFrom(trueEdge.target, condition.id);
     const reachFalse = reachableFrom(falseEdge.target, condition.id);
@@ -91,21 +96,20 @@ export function layoutAutomationGraph(
     const onlyFalse = [...reachFalse].filter((id) => !reachTrue.has(id));
     for (const id of [...onlyTrue, ...onlyFalse]) {
       const pos = g.node(id);
-      if (pos) pos.x = 2 * centerX - pos.x;
+      if (pos) pos.y = 2 * centerY - pos.y;
     }
   }
 
-  // dagre's within-rank X-coordinate heuristic (Brandes-Köpf) doesn't always perfectly
-  // center a node under its single parent when that parent's *other* descendants pull the
+  // dagre's within-rank Y-coordinate heuristic (Brandes-Köpf) doesn't always perfectly
+  // center a node beside its single parent when that parent's *other* descendants pull the
   // alignment pass toward a different median — even though aligning them costs nothing,
   // since neither end has any other position constraint. The resulting few-pixel offset is
-  // too small for getSmoothStepPath's corner rounding to resolve into a clean diagonal, so
-  // it draws as a barely-visible S-shaped wiggle instead of a straight line. Force an exact
-  // x match for every hop that is unambiguously a straight pass-through — the source's only
-  // outgoing edge and the target's only incoming edge — leaving every real branch or merge
-  // point (anything with siblings) exactly as dagre positioned it. Processed in rank (y)
-  // order so a parent snapped from *its* own parent is already resolved before its children
-  // are considered.
+  // too small for the edge curve to resolve cleanly, so it draws as a barely-visible wiggle
+  // instead of a straight line. Force an exact y match for every hop that is unambiguously
+  // a straight pass-through — the source's only outgoing edge and the target's only
+  // incoming edge — leaving every real branch or merge point (anything with siblings)
+  // exactly as dagre positioned it. Processed in rank (x) order so a parent snapped from
+  // *its* own parent is already resolved before its children are considered.
   const outDegree = new Map<string, number>();
   const inDegree = new Map<string, number>();
   for (const edge of edges) {
@@ -120,13 +124,13 @@ export function layoutAutomationGraph(
       soleParentOf.set(edge.target, edge.source);
     }
   }
-  const byRank = [...nodes].sort((a, b) => (g.node(a.id)?.y ?? 0) - (g.node(b.id)?.y ?? 0));
+  const byRank = [...nodes].sort((a, b) => (g.node(a.id)?.x ?? 0) - (g.node(b.id)?.x ?? 0));
   for (const node of byRank) {
     const parentId = soleParentOf.get(node.id);
     if (!parentId) continue;
     const parentPos = g.node(parentId);
     const childPos = g.node(node.id);
-    if (parentPos && childPos) childPos.x = parentPos.x;
+    if (parentPos && childPos) childPos.y = parentPos.y;
   }
 
   const layoutedNodes = nodes.map((node) => {
@@ -148,23 +152,23 @@ export function layoutAutomationGraph(
   // attaches an interior "edge label" point to every edge it lays out (even a plain
   // adjacent-rank one), so `points.length` alone isn't a reliable signal.
   //
-  // Rank is derived from dagre's own computed y (nodes in the same rank always land on
-  // an identical y in TB layout) rather than reimplemented as a longest-path-from-root
+  // Rank is derived from dagre's own computed x (nodes in the same rank always land on
+  // an identical x in LR layout) rather than reimplemented as a longest-path-from-root
   // calculation: dagre's network-simplex ranker can push a node meaningfully further
-  // down than its shortest/longest incoming path alone would suggest, to minimize total
+  // along than its shortest/longest incoming path alone would suggest, to minimize total
   // edge length across the *whole* graph (e.g. a branch with one action, feeding into an
-  // End node that other, longer branches also feed into, gets pulled down to align with
-  // those siblings). A naive recomputation disagreed with dagre's real placement in
+  // End node that other, longer branches also feed into, gets pulled forward to align
+  // with those siblings). A naive recomputation disagreed with dagre's real placement in
   // exactly that case, so a genuinely multi-rank edge was misclassified as adjacent and
   // drawn as one straight segment cutting across the intervening nodes.
-  const rankIndexByY = new Map<number, number>(
-    [...new Set(nodes.map((n) => g.node(n.id)?.y).filter((y): y is number => y !== undefined))]
+  const rankIndexByX = new Map<number, number>(
+    [...new Set(nodes.map((n) => g.node(n.id)?.x).filter((x): x is number => x !== undefined))]
       .sort((a, b) => a - b)
-      .map((y, i) => [y, i])
+      .map((x, i) => [x, i])
   );
   const rankOf = (nodeId: string): number | undefined => {
-    const y = g.node(nodeId)?.y;
-    return y === undefined ? undefined : rankIndexByY.get(y);
+    const x = g.node(nodeId)?.x;
+    return x === undefined ? undefined : rankIndexByX.get(x);
   };
 
   const layoutedEdges = edges.map((edge) => {
@@ -180,28 +184,5 @@ export function layoutAutomationGraph(
     return { ...edge, data: { ...edge.data, bendPoints } };
   });
 
-  // Sibling branches that reconverge on the same node (e.g. two action nodes on
-  // different branches that both feed the shared End node) commonly share an identical
-  // source Y (same rank) and, by definition, an identical target point — so
-  // getSmoothStepPath's default midpoint-based bend computes the exact same Y for every
-  // one of them, and their paths become pixel-identical for the final approach into the
-  // node instead of reading as distinct converging lines. Tag each edge with its index
-  // among siblings sharing a target (ordered left-to-right by source X, for a stable,
-  // deterministic result) so AddStepEdge can stagger each one's bend depth.
-  const siblingsByTarget = new Map<string, AutomationEdge[]>();
-  for (const edge of layoutedEdges) {
-    const list = siblingsByTarget.get(edge.target) ?? [];
-    list.push(edge);
-    siblingsByTarget.set(edge.target, list);
-  }
-
-  const finalEdges = layoutedEdges.map((edge) => {
-    const siblings = siblingsByTarget.get(edge.target);
-    if (!siblings || siblings.length <= 1) return edge;
-    const ordered = [...siblings].sort((a, b) => (g.node(a.source)?.x ?? 0) - (g.node(b.source)?.x ?? 0));
-    const mergeIndex = ordered.findIndex((e) => e.id === edge.id);
-    return { ...edge, data: { ...edge.data, mergeIndex, mergeCount: siblings.length } };
-  });
-
-  return { nodes: layoutedNodes, edges: finalEdges };
+  return { nodes: layoutedNodes, edges: layoutedEdges };
 }

--- a/apps/form-app/src/components/automations/builder/layout.ts
+++ b/apps/form-app/src/components/automations/builder/layout.ts
@@ -20,14 +20,15 @@ const NODE_SEP = 48;
 
 /**
  * Runs dagre's TB (top-to-bottom) auto-layout over the given nodes/edges and returns
- * new node objects with recomputed `position`. Nodes are never user-draggable in this
- * builder, so this is the single source of truth for node position after every graph
- * mutation (insert/remove/load).
+ * new node objects with recomputed `position`, plus the edges enriched with any bend
+ * points dagre computed for them. Nodes are never user-draggable in this builder, so
+ * this is the single source of truth for node position after every graph mutation
+ * (insert/remove/load).
  */
 export function layoutAutomationGraph(
   nodes: AutomationNode[],
   edges: AutomationEdge[]
-): AutomationNode[] {
+): { nodes: AutomationNode[]; edges: AutomationEdge[] } {
   const g = new dagre.graphlib.Graph();
   g.setGraph({ rankdir: 'TB', nodesep: NODE_SEP, ranksep: RANK_SEP });
   g.setDefaultEdgeLabel(() => ({}));
@@ -47,7 +48,41 @@ export function layoutAutomationGraph(
 
   dagre.layout(g);
 
-  return nodes.map((node) => {
+  // dagre's within-rank X-coordinate heuristic (Brandes-Köpf) doesn't always perfectly
+  // center a node under its single parent when that parent's *other* descendants pull the
+  // alignment pass toward a different median — even though aligning them costs nothing,
+  // since neither end has any other position constraint. The resulting few-pixel offset is
+  // too small for getSmoothStepPath's corner rounding to resolve into a clean diagonal, so
+  // it draws as a barely-visible S-shaped wiggle instead of a straight line. Force an exact
+  // x match for every hop that is unambiguously a straight pass-through — the source's only
+  // outgoing edge and the target's only incoming edge — leaving every real branch or merge
+  // point (anything with siblings) exactly as dagre positioned it. Processed in rank (y)
+  // order so a parent snapped from *its* own parent is already resolved before its children
+  // are considered.
+  const outDegree = new Map<string, number>();
+  const inDegree = new Map<string, number>();
+  for (const edge of edges) {
+    if (!g.hasNode(edge.source) || !g.hasNode(edge.target)) continue;
+    outDegree.set(edge.source, (outDegree.get(edge.source) ?? 0) + 1);
+    inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
+  }
+  const soleParentOf = new Map<string, string>();
+  for (const edge of edges) {
+    if (!g.hasNode(edge.source) || !g.hasNode(edge.target)) continue;
+    if (outDegree.get(edge.source) === 1 && inDegree.get(edge.target) === 1) {
+      soleParentOf.set(edge.target, edge.source);
+    }
+  }
+  const byRank = [...nodes].sort((a, b) => (g.node(a.id)?.y ?? 0) - (g.node(b.id)?.y ?? 0));
+  for (const node of byRank) {
+    const parentId = soleParentOf.get(node.id);
+    if (!parentId) continue;
+    const parentPos = g.node(parentId);
+    const childPos = g.node(node.id);
+    if (parentPos && childPos) childPos.x = parentPos.x;
+  }
+
+  const layoutedNodes = nodes.map((node) => {
     const positioned = g.node(node.id);
     if (!positioned) return node;
     return {
@@ -58,4 +93,68 @@ export function layoutAutomationGraph(
       },
     };
   });
+
+  // An edge that skips a rank — e.g. a condition branch with a single action, wired
+  // straight to a node that also has other, longer incoming paths — gets dummy chain
+  // nodes from dagre, exposed as extra interior points on the edge label. Only treat an
+  // edge as needing those bend points when it genuinely spans more than one rank: dagre
+  // attaches an interior "edge label" point to every edge it lays out (even a plain
+  // adjacent-rank one), so `points.length` alone isn't a reliable signal.
+  //
+  // Rank is derived from dagre's own computed y (nodes in the same rank always land on
+  // an identical y in TB layout) rather than reimplemented as a longest-path-from-root
+  // calculation: dagre's network-simplex ranker can push a node meaningfully further
+  // down than its shortest/longest incoming path alone would suggest, to minimize total
+  // edge length across the *whole* graph (e.g. a branch with one action, feeding into an
+  // End node that other, longer branches also feed into, gets pulled down to align with
+  // those siblings). A naive recomputation disagreed with dagre's real placement in
+  // exactly that case, so a genuinely multi-rank edge was misclassified as adjacent and
+  // drawn as one straight segment cutting across the intervening nodes.
+  const rankIndexByY = new Map<number, number>(
+    [...new Set(nodes.map((n) => g.node(n.id)?.y).filter((y): y is number => y !== undefined))]
+      .sort((a, b) => a - b)
+      .map((y, i) => [y, i])
+  );
+  const rankOf = (nodeId: string): number | undefined => {
+    const y = g.node(nodeId)?.y;
+    return y === undefined ? undefined : rankIndexByY.get(y);
+  };
+
+  const layoutedEdges = edges.map((edge) => {
+    if (!g.hasNode(edge.source) || !g.hasNode(edge.target)) return edge;
+    const sourceRank = rankOf(edge.source);
+    const targetRank = rankOf(edge.target);
+    const rankGap = sourceRank !== undefined && targetRank !== undefined ? targetRank - sourceRank : 1;
+    if (rankGap <= 1) return edge;
+
+    const dagreEdge = g.edge(edge.source, edge.target);
+    const bendPoints = dagreEdge?.points?.slice(1, -1);
+    if (!bendPoints || bendPoints.length === 0) return edge;
+    return { ...edge, data: { ...edge.data, bendPoints } };
+  });
+
+  // Sibling branches that reconverge on the same node (e.g. two action nodes on
+  // different branches that both feed the shared End node) commonly share an identical
+  // source Y (same rank) and, by definition, an identical target point — so
+  // getSmoothStepPath's default midpoint-based bend computes the exact same Y for every
+  // one of them, and their paths become pixel-identical for the final approach into the
+  // node instead of reading as distinct converging lines. Tag each edge with its index
+  // among siblings sharing a target (ordered left-to-right by source X, for a stable,
+  // deterministic result) so AddStepEdge can stagger each one's bend depth.
+  const siblingsByTarget = new Map<string, AutomationEdge[]>();
+  for (const edge of layoutedEdges) {
+    const list = siblingsByTarget.get(edge.target) ?? [];
+    list.push(edge);
+    siblingsByTarget.set(edge.target, list);
+  }
+
+  const finalEdges = layoutedEdges.map((edge) => {
+    const siblings = siblingsByTarget.get(edge.target);
+    if (!siblings || siblings.length <= 1) return edge;
+    const ordered = [...siblings].sort((a, b) => (g.node(a.source)?.x ?? 0) - (g.node(b.source)?.x ?? 0));
+    const mergeIndex = ordered.findIndex((e) => e.id === edge.id);
+    return { ...edge, data: { ...edge.data, mergeIndex, mergeCount: siblings.length } };
+  });
+
+  return { nodes: layoutedNodes, edges: finalEdges };
 }

--- a/apps/form-app/src/components/automations/builder/nodes/ConditionNode.tsx
+++ b/apps/form-app/src/components/automations/builder/nodes/ConditionNode.tsx
@@ -42,10 +42,12 @@ export const ConditionNode: React.FC<NodeProps<AutomationNode>> = ({ id, data, s
     >
       {/* Two named source handles — the branch labels ("Yes"/"No") render on the outgoing
           edges themselves (AddStepEdge), not here, to avoid duplicating the same text twice
-          right next to each other. */}
-      <div className="relative h-2" data-testid="condition-branch-handles">
-        <Handle type="source" position={Position.Bottom} id="true" style={{ left: '30%' }} className="!bg-[var(--tf-green)]" />
-        <Handle type="source" position={Position.Bottom} id="false" style={{ left: '70%' }} className="!bg-[var(--tf-error)]" />
+          right next to each other. Absolutely positioned across the card's full height (not
+          nested in the normal content flow) so `top: 30%/70%` places them relative to the
+          whole card, not just a small inline strip. */}
+      <div className="absolute inset-y-0 right-0 w-2" data-testid="condition-branch-handles">
+        <Handle type="source" position={Position.Right} id="true" style={{ top: '30%' }} className="!bg-[var(--tf-green)]" />
+        <Handle type="source" position={Position.Right} id="false" style={{ top: '70%' }} className="!bg-[var(--tf-error)]" />
       </div>
     </NodeCard>
   );

--- a/apps/form-app/src/components/automations/builder/nodes/EndNode.tsx
+++ b/apps/form-app/src/components/automations/builder/nodes/EndNode.tsx
@@ -17,7 +17,7 @@ export const EndNode: React.FC<NodeProps<AutomationNode>> = ({ selected }) => {
       }}
       data-testid="automation-node-card"
     >
-      <Handle type="target" position={Position.Top} className="!bg-[var(--tf-light-muted)]" />
+      <Handle type="target" position={Position.Left} className="!bg-[var(--tf-light-muted)]" />
       <Flag className="h-3.5 w-3.5" style={{ color: 'var(--tf-muted)' }} />
       <span className="text-xs font-medium" style={{ color: 'var(--tf-muted)' }}>
         {t('builder.nodes.end.title')}

--- a/apps/form-app/src/components/automations/builder/nodes/NodeCard.tsx
+++ b/apps/form-app/src/components/automations/builder/nodes/NodeCard.tsx
@@ -23,8 +23,9 @@ interface NodeCardProps {
 
 /**
  * Shared Typeform-style card shell for every automation node. Handles the
- * selected/error outline states and the top/bottom connection handles — the
- * individual node components (TriggerNode, DelayNode, ...) only supply content.
+ * selected/error outline states and the left/right connection handles (the canvas lays
+ * out left-to-right) — the individual node components (TriggerNode, DelayNode, ...) only
+ * supply content.
  */
 export const NodeCard: React.FC<NodeCardProps> = ({
   selected,
@@ -63,7 +64,7 @@ export const NodeCard: React.FC<NodeCardProps> = ({
       }}
       data-testid="automation-node-card"
     >
-      {showTargetHandle && <Handle type="target" position={Position.Top} className="!bg-[var(--tf-light-muted)]" />}
+      {showTargetHandle && <Handle type="target" position={Position.Left} className="!bg-[var(--tf-light-muted)]" />}
 
       {onDelete && (
         <button
@@ -112,7 +113,7 @@ export const NodeCard: React.FC<NodeCardProps> = ({
         </Badge>
       )}
 
-      {showSourceHandle && <Handle type="source" position={Position.Bottom} className="!bg-[var(--tf-light-muted)]" />}
+      {showSourceHandle && <Handle type="source" position={Position.Right} className="!bg-[var(--tf-light-muted)]" />}
     </div>
   );
 

--- a/apps/form-app/src/store/slices/automationBuilderSlice.ts
+++ b/apps/form-app/src/store/slices/automationBuilderSlice.ts
@@ -57,14 +57,15 @@ export interface AutomationBuilderState {
     isReadOnly: boolean;
   }) => void;
   setSelectedNodeId: (id: string | null) => void;
-  /** Re-runs dagre layout using each node's actual rendered size (from React Flow's
-   * `useNodesInitialized`/`getNodes()`) in place of the type-based `DEFAULT_DIMENSIONS`
-   * fallback that layout otherwise assumes before first paint. Node label text length
-   * varies per node (condition rule summaries, i18n — form-app ships English and Tamil)
-   * so the fallback is frequently wrong; without this correction, edges terminate at a
-   * dagre-assumed center that doesn't match where the node's handle actually renders,
-   * producing a visible kink right before the node. No-ops if positions wouldn't
-   * meaningfully change, so it's safe to call on every render once nodes are measured. */
+  /** Re-runs dagre layout using each node's actual rendered size (reported by React
+   * Flow's `onNodesChange` as 'dimensions' change events — see AutomationCanvas.tsx) in
+   * place of the type-based `DEFAULT_DIMENSIONS` fallback that layout otherwise assumes
+   * before first paint. Node label text length varies per node (condition rule
+   * summaries, i18n — form-app ships English and Tamil) so the fallback is frequently
+   * wrong; without this correction, edges terminate at a dagre-assumed center that
+   * doesn't match where the node's handle actually renders, producing a visible kink
+   * right before the node. No-ops if neither positions nor edge bend routes would
+   * meaningfully change, so it's safe to call on every dimensions event. */
   applyMeasuredLayout: (measuredNodes: { id: string; width?: number; height?: number }[]) => void;
   insertStepOnEdge: (edgeId: string, type: AutomationNodeType, data: AutomationNodeData) => string | null;
   updateNodeData: (nodeId: string, data: Partial<AutomationNodeData>) => void;
@@ -202,7 +203,15 @@ export const createAutomationBuilderSlice = (set: SetState, get: Get): Automatio
       const prev = nodes[i];
       return Math.abs(node.position.x - prev.position.x) > 0.5 || Math.abs(node.position.y - prev.position.y) > 0.5;
     });
-    if (!positionsChanged) return;
+    // A rank-skipping edge's curve is derived from spacer-node positions (see layout.ts),
+    // which aren't part of `layoutedNodes` — a dimension change can shift a spacer enough
+    // to change a route without moving any *real* node past the position-change threshold
+    // above, so bend routes need their own comparison rather than piggybacking on it.
+    const bendRoutesChanged = layoutedEdges.some((edge, i) => {
+      const prev = edges[i];
+      return JSON.stringify(edge.data?.bendPoints) !== JSON.stringify(prev?.data?.bendPoints);
+    });
+    if (!positionsChanged && !bendRoutesChanged) return;
 
     set({ nodes: layoutedNodes, edges: layoutedEdges });
   },

--- a/apps/form-app/src/store/slices/automationBuilderSlice.ts
+++ b/apps/form-app/src/store/slices/automationBuilderSlice.ts
@@ -57,6 +57,15 @@ export interface AutomationBuilderState {
     isReadOnly: boolean;
   }) => void;
   setSelectedNodeId: (id: string | null) => void;
+  /** Re-runs dagre layout using each node's actual rendered size (from React Flow's
+   * `useNodesInitialized`/`getNodes()`) in place of the type-based `DEFAULT_DIMENSIONS`
+   * fallback that layout otherwise assumes before first paint. Node label text length
+   * varies per node (condition rule summaries, i18n — form-app ships English and Tamil)
+   * so the fallback is frequently wrong; without this correction, edges terminate at a
+   * dagre-assumed center that doesn't match where the node's handle actually renders,
+   * producing a visible kink right before the node. No-ops if positions wouldn't
+   * meaningfully change, so it's safe to call on every render once nodes are measured. */
+  applyMeasuredLayout: (measuredNodes: { id: string; width?: number; height?: number }[]) => void;
   insertStepOnEdge: (edgeId: string, type: AutomationNodeType, data: AutomationNodeData) => string | null;
   updateNodeData: (nodeId: string, data: Partial<AutomationNodeData>) => void;
   removeNode: (nodeId: string) => void;
@@ -149,7 +158,7 @@ export const createAutomationBuilderSlice = (set: SetState, get: Get): Automatio
         }) as AutomationNode
     );
     const edges: AutomationEdge[] = sourceEdges.map(toAutomationEdge);
-    const layoutedNodes = layoutAutomationGraph(nodes, edges);
+    const { nodes: layoutedNodes, edges: layoutedEdges } = layoutAutomationGraph(nodes, edges);
 
     const restoredSelection = readSelectedNodeId(automationId);
     const selectedNodeId = restoredSelection && nodes.some((n) => n.id === restoredSelection) ? restoredSelection : null;
@@ -161,7 +170,7 @@ export const createAutomationBuilderSlice = (set: SetState, get: Get): Automatio
       triggerType,
       triggerConfig: triggerConfig ?? null,
       nodes: layoutedNodes,
-      edges,
+      edges: layoutedEdges,
       selectedNodeId,
       isDirty: Boolean(draft),
       isReadOnly,
@@ -174,6 +183,28 @@ export const createAutomationBuilderSlice = (set: SetState, get: Get): Automatio
     const { automationId } = get();
     if (automationId) persistSelectedNodeId(automationId, id);
     set({ selectedNodeId: id });
+  },
+
+  applyMeasuredLayout: (measuredNodes) => {
+    const { nodes, edges } = get();
+    const measuredById = new Map(measuredNodes.map((n) => [n.id, n]));
+
+    const nodesWithMeasured = nodes.map((node) => {
+      const measured = measuredById.get(node.id);
+      return measured?.width && measured?.height
+        ? { ...node, measured: { width: measured.width, height: measured.height } }
+        : node;
+    });
+
+    const { nodes: layoutedNodes, edges: layoutedEdges } = layoutAutomationGraph(nodesWithMeasured, edges);
+
+    const positionsChanged = layoutedNodes.some((node, i) => {
+      const prev = nodes[i];
+      return Math.abs(node.position.x - prev.position.x) > 0.5 || Math.abs(node.position.y - prev.position.y) > 0.5;
+    });
+    if (!positionsChanged) return;
+
+    set({ nodes: layoutedNodes, edges: layoutedEdges });
   },
 
   insertStepOnEdge: (edgeId, type, data) => {
@@ -239,16 +270,16 @@ export const createAutomationBuilderSlice = (set: SetState, get: Get): Automatio
     }
 
     const nextNodes = [...nodes, newNode];
-    const layoutedNodes = layoutAutomationGraph(nextNodes, nextEdges);
+    const { nodes: layoutedNodes, edges: layoutedEdges } = layoutAutomationGraph(nextNodes, nextEdges);
 
     if (automationId) {
-      persistDraftGraph(automationId, serializeGraph(layoutedNodes, nextEdges));
+      persistDraftGraph(automationId, serializeGraph(layoutedNodes, layoutedEdges));
       persistSelectedNodeId(automationId, newNodeId);
     }
 
     set({
       nodes: layoutedNodes,
-      edges: nextEdges,
+      edges: layoutedEdges,
       selectedNodeId: newNodeId,
       isDirty: true,
     });
@@ -331,11 +362,11 @@ export const createAutomationBuilderSlice = (set: SetState, get: Get): Automatio
       remainingNodes = nodes.filter((n) => n.id !== nodeId);
     }
 
-    const layoutedNodes = layoutAutomationGraph(remainingNodes, remainingEdges);
+    const { nodes: layoutedNodes, edges: layoutedEdges } = layoutAutomationGraph(remainingNodes, remainingEdges);
     const nextSelectedNodeId = deletedNodeIds.has(selectedNodeId ?? '') ? null : selectedNodeId;
 
     if (automationId) {
-      persistDraftGraph(automationId, serializeGraph(layoutedNodes, remainingEdges));
+      persistDraftGraph(automationId, serializeGraph(layoutedNodes, layoutedEdges));
       persistSelectedNodeId(automationId, nextSelectedNodeId);
     }
 
@@ -345,7 +376,7 @@ export const createAutomationBuilderSlice = (set: SetState, get: Get): Automatio
       );
       return {
         nodes: layoutedNodes,
-        edges: remainingEdges,
+        edges: layoutedEdges,
         selectedNodeId: nextSelectedNodeId,
         isDirty: true,
         validationErrorsByNode: restErrors,


### PR DESCRIPTION
## Summary
- Fixes a series of connector-line rendering bugs in the Automations canvas (inconsistent lines, branch overlaps, invisible edges from stale bend-point data, Yes/No branches rendering in the wrong order/crossing under the condition card)
- Redesigns the canvas to a horizontal, left-to-right layout with curved bezier connectors, matching the reference workflow builder's visual language (arrow markers, solid "+" insert buttons, higher-contrast stroke)
- Replaces hand-rolled bend-point routing for branches that skip ranks with dagre-native spacer nodes, so every edge is either direct or a chain of plain adjacent-rank hops — eliminating an entire class of "route around this" bugs structurally instead of patching each case
- Adds unit test coverage for `layoutAutomationGraph` (previously untested despite being the most bug-prone part of the builder) and two canvas UX additions: a MiniMap, and auto-pan/zoom to a newly inserted step when it lands outside the current viewport

## Test plan
- [x] `pnpm type-check` and `pnpm test` pass (120 tests, 1 skipped, includes new `layout.test.ts`)
- [x] Verified live against several real automations in the local dev environment: simple linear flows, single/nested conditions, branches of uneven length reconverging on a shared node, and the exact add/delete click sequences that previously produced overlapping or invisible lines
- [x] Confirmed the new true/false branch-order tests actually fail when the underlying fix is disabled (not vacuously passing)
- [x] Pre-push hook (tests + builds for form-viewer, backend, admin-app, form-app) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automation workflows now use an improved left-to-right layout with updated edge routing (including bend points).
  * Added arrowhead markers, a minimap, and smarter canvas focusing when new steps are added.
  * Connection handles are repositioned consistently on node sides for clearer wiring.
  * “Add step” controls now follow smoother curved edges with refreshed styling.

* **Bug Fixes**
  * Improved true/false branch ordering and order-independent layout stability.
  * Edge routing now correctly adapts to rendered node sizes and clears stale routing data on re-layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->