### PR TITLE
Fix Google/Microsoft Sheets automation connect flow and config persistence

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -63,6 +63,15 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:4000/api/integrations/google/callback
 
+# Microsoft OAuth (optional — enables the Microsoft Excel automation plugin)
+# Register an app at: https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade
+# Redirect URI to register:
+#   https://your-domain.com/api/integrations/microsoft/callback
+#   http://localhost:4000/api/integrations/microsoft/callback (dev)
+MICROSOFT_CLIENT_ID=
+MICROSOFT_CLIENT_SECRET=
+MICROSOFT_REDIRECT_URI=http://localhost:4000/api/integrations/microsoft/callback
+
 # -----------------------------------------------------------------------------
 # Admin User Setup (optional, for initial super admin creation)
 # -----------------------------------------------------------------------------

--- a/apps/backend/src/plugins/ai-tagger/__tests__/handler.test.ts
+++ b/apps/backend/src/plugins/ai-tagger/__tests__/handler.test.ts
@@ -41,6 +41,7 @@ describe('AI Tagger Handler', () => {
       getOrganization: vi.fn(),
       getUserById: vi.fn(),
       sendEmail: vi.fn(),
+      updatePluginConfig: vi.fn(),
       prisma: mockPrisma,
     };
 

--- a/apps/backend/src/plugins/core/__tests__/context.test.ts
+++ b/apps/backend/src/plugins/core/__tests__/context.test.ts
@@ -485,4 +485,33 @@ describe('context', () => {
       ).rejects.toThrow('Email send failed');
     });
   });
+
+  describe('updatePluginConfig', () => {
+    it('defaults to a stub that throws when no persistence strategy is supplied', async () => {
+      const context = createPluginContext();
+
+      await expect(
+        context.updatePluginConfig({ type: 'google-sheets' })
+      ).rejects.toThrow(/updatePluginConfig was not configured/);
+    });
+
+    it('delegates to the persistence strategy passed into createPluginContext', async () => {
+      const persist = vi.fn().mockResolvedValue(undefined);
+      const context = createPluginContext(persist);
+
+      const config = { type: 'google-sheets', spreadsheetId: 'sheet-1' };
+      await context.updatePluginConfig(config);
+
+      expect(persist).toHaveBeenCalledWith(config);
+    });
+
+    it('propagates errors from the persistence strategy', async () => {
+      const persist = vi.fn().mockRejectedValue(new Error('no record found'));
+      const context = createPluginContext(persist);
+
+      await expect(
+        context.updatePluginConfig({ type: 'microsoft-sheets' })
+      ).rejects.toThrow('no record found');
+    });
+  });
 });

--- a/apps/backend/src/plugins/core/__tests__/executor.test.ts
+++ b/apps/backend/src/plugins/core/__tests__/executor.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../../lib/prisma.js', () => ({
     formPlugin: {
       findUnique: vi.fn(),
       findMany: vi.fn(),
+      update: vi.fn(),
     },
     pluginDelivery: {
       create: vi.fn(),
@@ -106,6 +107,40 @@ describe('executor', () => {
         },
       });
       expect(result).toEqual({ success: true });
+    });
+
+    it('wires createPluginContext with a persistence strategy that writes back to the FormPlugin row', async () => {
+      const mockPlugin = {
+        id: 'plugin-1',
+        name: 'Google Sheets',
+        type: 'google-sheets',
+        enabled: true,
+        config: { type: 'google-sheets' },
+      };
+      const mockHandler: PluginHandler = vi.fn().mockResolvedValue({ success: true });
+
+      vi.mocked(prisma.formPlugin.findUnique).mockResolvedValue(mockPlugin as any);
+      vi.mocked(getPluginHandler).mockReturnValue(mockHandler);
+      vi.mocked(prisma.pluginDelivery.create).mockResolvedValue({} as any);
+      vi.mocked(prisma.formPlugin.update).mockResolvedValue({} as any);
+
+      await executePlugin('plugin-1', mockEvent);
+
+      // executor.ts passes createPluginContext a closure, not a pre-built context — capture
+      // it and invoke it the way google-sheets/microsoft-sheets handlers do, to verify it
+      // actually persists to the FormPlugin row this plugin is backed by (#222 regression:
+      // handlers previously wrote to context.prisma.formPlugin.update directly, which this
+      // replaces).
+      const persist = vi.mocked(createPluginContext).mock.calls[0][0];
+      expect(persist).toBeInstanceOf(Function);
+
+      const newConfig = { type: 'google-sheets', spreadsheetId: 'sheet-123' };
+      await persist!(newConfig as any);
+
+      expect(prisma.formPlugin.update).toHaveBeenCalledWith({
+        where: { id: 'plugin-1' },
+        data: { config: newConfig },
+      });
     });
 
     it('returns error when plugin is not found', async () => {

--- a/apps/backend/src/plugins/core/context.ts
+++ b/apps/backend/src/plugins/core/context.ts
@@ -7,6 +7,7 @@ import {
 } from '../../services/responseService.js';
 import { sendEmail, type EmailOptions } from '../../services/emailService.js';
 import { logger } from '../../lib/logger.js';
+import type { PluginConfig } from './types.js';
 
 export interface PluginContext {
   prisma: PrismaClient;
@@ -16,6 +17,21 @@ export interface PluginContext {
   getOrganization: (orgId: string) => Promise<any>;
   getUserById: (userId: string) => Promise<any>;
   sendEmail: (options: EmailOptions) => Promise<void>;
+  /**
+   * Persists an updated config for the plugin/action node currently being executed (e.g. a
+   * refreshed OAuth token, or an auto-created spreadsheet/workbook ID) — the durable-storage
+   * equivalent of "save this back to wherever my config actually lives."
+   *
+   * Handlers must go through this instead of writing `context.prisma.formPlugin.update(...)`
+   * directly: the legacy standalone Plugins system backs each plugin with a real `FormPlugin`
+   * row, but the Automations system has no such row — action-node config lives inline inside
+   * `Automation.graph`'s JSON — so a handler that assumes a `FormPlugin` row always exists
+   * throws "record not found" the moment it runs inside an automation (see google-sheets and
+   * microsoft-sheets handlers). Each caller of `createPluginContext` supplies the persistence
+   * strategy appropriate to how it invoked the handler (see `executor.ts` vs
+   * `services/automation/engine.ts`).
+   */
+  updatePluginConfig: (config: PluginConfig) => Promise<void>;
   logger: {
     info: (message: string, meta?: any) => void;
     error: (message: string, error?: any) => void;
@@ -23,7 +39,13 @@ export interface PluginContext {
   };
 }
 
-export const createPluginContext = (): PluginContext => ({
+export const createPluginContext = (
+  updatePluginConfig: (config: PluginConfig) => Promise<void> = async () => {
+    throw new Error(
+      'updatePluginConfig was not configured for this PluginContext — the caller of createPluginContext() must supply a persistence strategy before invoking a handler that calls it'
+    );
+  }
+): PluginContext => ({
   prisma,
   getFormById,
   getResponseById,
@@ -39,6 +61,8 @@ export const createPluginContext = (): PluginContext => ({
     prisma.user.findUnique({ where: { id: userId } }),
 
   sendEmail,
+
+  updatePluginConfig,
 
   logger: {
     info: (message, meta?) => logger.info(`[Plugin] ${message}`, meta ?? ''),

--- a/apps/backend/src/plugins/core/executor.ts
+++ b/apps/backend/src/plugins/core/executor.ts
@@ -9,7 +9,12 @@ export const executePlugin = async (
   pluginId: string,
   event: PluginEvent
 ): Promise<{ success: boolean; error?: string }> => {
-  const context = createPluginContext();
+  // The legacy Plugins system backs every plugin with a real FormPlugin row, so a handler's
+  // context.updatePluginConfig(...) call (e.g. persisting a refreshed OAuth token) just
+  // writes straight back to that row.
+  const context = createPluginContext(async (config) => {
+    await prisma.formPlugin.update({ where: { id: pluginId }, data: { config: config as any } });
+  });
 
   try {
     const plugin = await prisma.formPlugin.findUnique({ where: { id: pluginId } });

--- a/apps/backend/src/plugins/email/__tests__/handler.test.ts
+++ b/apps/backend/src/plugins/email/__tests__/handler.test.ts
@@ -46,6 +46,7 @@ describe('Email Handler', () => {
       getOrganization: vi.fn(),
       getUserById: vi.fn(),
       sendEmail: vi.fn(),
+      updatePluginConfig: vi.fn(),
       prisma: { pdfTemplate: { findUnique: vi.fn() } } as any,
     };
 

--- a/apps/backend/src/plugins/google-sheets/handler.ts
+++ b/apps/backend/src/plugins/google-sheets/handler.ts
@@ -63,12 +63,7 @@ const refreshTokenIfNeeded = async (
     };
 
     // Persist the refreshed token back to the plugin config
-    await context.prisma.formPlugin.update({
-      where: { id: pluginId },
-      data: {
-        config: { ...config, googleToken: newToken } as any,
-      },
-    });
+    await context.updatePluginConfig({ ...config, googleToken: newToken });
 
     context.logger.info('Google Sheets: token refreshed successfully', { pluginId });
     return newToken;
@@ -301,11 +296,11 @@ export const googleSheetsHandler: PluginHandler = async (plugin, event, context)
       const created = await createSpreadsheet(sheetTitle, accessToken);
       await writeHeaderRow(created.spreadsheetId, buildHeaders(), accessToken);
 
-      await context.prisma.formPlugin.update({
-        where: { id: plugin.id },
-        data: {
-          config: { ...config, googleToken: freshToken, spreadsheetId: created.spreadsheetId, spreadsheetUrl: created.spreadsheetUrl } as any,
-        },
+      await context.updatePluginConfig({
+        ...config,
+        googleToken: freshToken,
+        spreadsheetId: created.spreadsheetId,
+        spreadsheetUrl: created.spreadsheetUrl,
       });
 
       context.logger.info('Google Sheets: spreadsheet created and header row written', {

--- a/apps/backend/src/plugins/microsoft-sheets/handler.ts
+++ b/apps/backend/src/plugins/microsoft-sheets/handler.ts
@@ -60,12 +60,7 @@ const refreshMicrosoftTokenIfNeeded = async (
       displayName: token.displayName,
     };
 
-    await context.prisma.formPlugin.update({
-      where: { id: pluginId },
-      data: {
-        config: { ...config, microsoftToken: newToken } as any,
-      },
-    });
+    await context.updatePluginConfig({ ...config, microsoftToken: newToken });
 
     context.logger.info('Microsoft Sheets: token refreshed successfully', { pluginId });
     return newToken;
@@ -350,16 +345,11 @@ export const microsoftSheetsHandler: PluginHandler = async (plugin, event, conte
       const created = await createWorkbook(workbookTitle, worksheetName, accessToken);
       await writeHeaderRow(created.workbookId, worksheetName, buildHeaders(), accessToken);
 
-      await context.prisma.formPlugin.update({
-        where: { id: plugin.id },
-        data: {
-          config: {
-            ...config,
-            microsoftToken: freshToken,
-            workbookId: created.workbookId,
-            workbookUrl: created.workbookUrl,
-          } as any,
-        },
+      await context.updatePluginConfig({
+        ...config,
+        microsoftToken: freshToken,
+        workbookId: created.workbookId,
+        workbookUrl: created.workbookUrl,
       });
 
       context.logger.info('Microsoft Sheets: workbook created and header row written', {

--- a/apps/backend/src/plugins/quiz/__tests__/handler.test.ts
+++ b/apps/backend/src/plugins/quiz/__tests__/handler.test.ts
@@ -40,6 +40,7 @@ describe('Quiz Grading Handler', () => {
       getOrganization: vi.fn(),
       getUserById: vi.fn(),
       sendEmail: vi.fn(),
+      updatePluginConfig: vi.fn(),
       prisma: mockPrisma,
     };
 

--- a/apps/backend/src/plugins/webhook/__tests__/handler.test.ts
+++ b/apps/backend/src/plugins/webhook/__tests__/handler.test.ts
@@ -32,6 +32,7 @@ describe('Webhook Handler', () => {
       getOrganization: vi.fn(),
       getUserById: vi.fn(),
       sendEmail: vi.fn(),
+      updatePluginConfig: vi.fn(),
       prisma: {} as any,
     };
 

--- a/apps/backend/src/services/automation/__tests__/engine.test.ts
+++ b/apps/backend/src/services/automation/__tests__/engine.test.ts
@@ -27,6 +27,14 @@ vi.mock('../../../lib/prisma.js', () => ({
     // Array-form $transaction: operations are already-invoked PrismaPromises by the time
     // $transaction receives them, so resolving them as-is mirrors the real API.
     $transaction: vi.fn((ops: unknown[]) => Promise.all(ops)),
+    $executeRaw: vi.fn().mockResolvedValue(1),
+  },
+}));
+
+vi.mock('#prisma-client', () => ({
+  Prisma: {
+    sql: (strings: TemplateStringsArray, ...values: any[]) => ({ strings, values }),
+    raw: (value: string) => ({ raw: value }),
   },
 }));
 
@@ -72,6 +80,7 @@ function makeRun(overrides: Record<string, any> = {}) {
     context: {},
     startedAt: new Date('2026-01-01T00:00:00.000Z'),
     automation: {
+      id: 'automation-1',
       status: 'ACTIVE',
       formId: 'form-1',
       organizationId: 'org-1',
@@ -641,6 +650,57 @@ describe('automation engine', () => {
       await expect(
         executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'action-1' }, 0, ACTION_RETRY_LIMIT))
       ).rejects.toThrow('No handler registered for action type: unregistered-type');
+    });
+
+    it('wires createPluginContext with a persistence strategy that jsonb_sets the node config into both the live Automation.graph and this run\'s graphSnapshot (#222 regression: handlers previously wrote to a nonexistent FormPlugin row for automation-triggered actions)', async () => {
+      const graph: AutomationGraph = {
+        nodes: [{ id: 'action-1', type: 'action', data: { actionType: 'google-sheets', config: { type: 'google-sheets' } } }],
+        edges: [],
+      };
+
+      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
+      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+        makeRun({ graphSnapshot: graph }) as any
+      );
+
+      const handler = vi.fn().mockResolvedValue({ success: true });
+      vi.mocked(getPluginHandler).mockReturnValue(handler);
+
+      // createPluginContext is mocked wholesale for the rest of this suite (see the
+      // module-level vi.mock above) — override it just for this test so the real closure
+      // built by handleActionNode is captured and can be invoked directly, the way the
+      // google-sheets/microsoft-sheets handlers call context.updatePluginConfig(...).
+      let capturedPersist: ((config: any) => Promise<void>) | undefined;
+      vi.mocked(createPluginContext).mockImplementation((persist: any) => {
+        capturedPersist = persist;
+        return { prisma: {} as any, logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() }, updatePluginConfig: persist } as any;
+      });
+
+      await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'action-1' }, 0, ACTION_RETRY_LIMIT));
+
+      expect(capturedPersist).toBeInstanceOf(Function);
+
+      const newConfig = { type: 'google-sheets', spreadsheetId: 'sheet-123', spreadsheetUrl: 'https://sheets.google.com/sheet-123' };
+      await capturedPersist!(newConfig);
+
+      expect(prisma.$executeRaw).toHaveBeenCalledTimes(2);
+
+      const [graphCall, snapshotCall] = vi.mocked(prisma.$executeRaw).mock.calls.map(
+        (call) => call[0] as unknown as { strings: TemplateStringsArray; values: any[] }
+      );
+
+      // Update against the live Automation row — keyed by automationId, not runId — so the
+      // NEXT run's fresh graphSnapshot picks up the same spreadsheet instead of recreating one.
+      expect(graphCall.strings.join('')).toContain('UPDATE');
+      expect(graphCall.values).toContain('action-1');
+      expect(graphCall.values).toContain('automation-1');
+      expect(graphCall.values).toContain(JSON.stringify(newConfig));
+
+      // Update against this run's graphSnapshot — keyed by runId — so a retry of THIS run
+      // doesn't recreate the spreadsheet after a transient failure post-creation.
+      expect(snapshotCall.values).toContain('action-1');
+      expect(snapshotCall.values).toContain('run-1');
+      expect(snapshotCall.values).toContain(JSON.stringify(newConfig));
     });
   });
 

--- a/apps/backend/src/services/automation/engine.ts
+++ b/apps/backend/src/services/automation/engine.ts
@@ -1,5 +1,6 @@
 import type { PgBoss, JobWithMetadata } from 'pg-boss';
 import * as Sentry from '@sentry/node';
+import { Prisma } from '#prisma-client';
 import { generateId, substituteMentions } from '@dculus/utils';
 import { prisma } from '../../lib/prisma.js';
 import { logger } from '../../lib/logger.js';
@@ -121,6 +122,68 @@ function mergeStepOutput(context: unknown, nodeId: string, output: any): Automat
     ...ctx,
     stepOutputs: { ...(ctx.stepOutputs ?? {}), [nodeId]: output ?? null },
   };
+}
+
+/**
+ * Replaces one node's `data.config` inside a `{ nodes: [...], edges: [...] }` JSON column,
+ * leaving every other node untouched, in a single atomic UPDATE. Postgres serializes
+ * concurrent UPDATEs to the same row (the second waits for the first to commit, then
+ * re-reads its result), so two action-node executions racing to persist config on the same
+ * row — e.g. two form submissions triggering the same automation moments apart — can't lose
+ * one's write to the other's the way a JS-level read-modify-write would.
+ */
+async function jsonSetNodeConfig(
+  table: 'automation' | 'automation_run',
+  column: 'graph' | 'graphSnapshot',
+  rowId: string,
+  nodeId: string,
+  config: PluginConfig
+): Promise<void> {
+  const tableIdent = Prisma.raw(`"${table}"`);
+  const columnIdent = Prisma.raw(`"${column}"`);
+  const configJson = JSON.stringify(config);
+
+  await prisma.$executeRaw(Prisma.sql`
+    UPDATE ${tableIdent}
+    SET ${columnIdent} = jsonb_set(
+      ${columnIdent},
+      '{nodes}',
+      (
+        SELECT COALESCE(jsonb_agg(
+          CASE WHEN elem->>'id' = ${nodeId}
+            THEN jsonb_set(elem, '{data,config}', ${configJson}::jsonb, true)
+            ELSE elem
+          END
+        ), '[]'::jsonb)
+        FROM jsonb_array_elements(${columnIdent}->'nodes') AS elem
+      )
+    )
+    WHERE id = ${rowId}
+  `);
+}
+
+/**
+ * Persists an action-node handler's updated config (auto-created spreadsheet/workbook ID,
+ * refreshed OAuth token, etc.) for the Automations system — see `PluginContext.updatePluginConfig`
+ * for why handlers can't just write to a `FormPlugin` row here.
+ *
+ * Writes to two places:
+ *  - `AutomationRun.graphSnapshot` for THIS run, so a retry after a transient failure (e.g.
+ *    the workbook was created but the network dropped before this write) sees the
+ *    already-created workbook/spreadsheet instead of creating a duplicate.
+ *  - `Automation.graph`, the live graph, so the NEXT run — which snapshots fresh from this
+ *    column — reuses the same workbook/spreadsheet and refreshed token too.
+ */
+async function updateAutomationNodeConfig(
+  automationId: string,
+  runId: string,
+  nodeId: string,
+  config: PluginConfig
+): Promise<void> {
+  await Promise.all([
+    jsonSetNodeConfig('automation', 'graph', automationId, nodeId, config),
+    jsonSetNodeConfig('automation_run', 'graphSnapshot', runId, nodeId, config),
+  ]);
 }
 
 async function handleDelayNode(
@@ -247,7 +310,7 @@ async function handleActionNode(
     id: string;
     context: unknown;
     startedAt: Date;
-    automation: { status: string; formId: string; organizationId: string; triggerType: string };
+    automation: { id: string; status: string; formId: string; organizationId: string; triggerType: string };
   },
   node: Extract<AutomationNode, { type: 'action' }>,
   graph: AutomationGraph,
@@ -294,7 +357,9 @@ async function handleActionNode(
     const result = await handler(
       { id: `${run.id}:${node.id}`, config: substitutedConfig },
       event,
-      createPluginContext()
+      createPluginContext((newConfig) =>
+        updateAutomationNodeConfig(run.automation.id, run.id, node.id, newConfig)
+      )
     );
 
     await prisma.automationStepRun.create({

--- a/apps/form-app/src/lib/intentionalNavigation.ts
+++ b/apps/form-app/src/lib/intentionalNavigation.ts
@@ -1,0 +1,21 @@
+/**
+ * Signals an imminent same-tab top-level navigation that the app itself initiated and that
+ * carries no data-loss risk — e.g. the automation builder's Google/Microsoft "Connect"
+ * buttons, which redirect the current tab to the OAuth provider (see
+ * plugins/google-sheets/ConfigForm.tsx, plugins/microsoft-sheets/ConfigForm.tsx). The
+ * automation graph draft is already persisted to sessionStorage before that redirect fires
+ * (see components/automations/builder/draftStorage.ts), so the navigation is safe.
+ *
+ * `beforeunload` guards (e.g. AutomationBuilder.tsx's unsaved-changes warning) should check
+ * this flag and skip their native "leave site?" prompt when it's set — otherwise the browser
+ * intercepts the OAuth redirect before the user ever reaches the provider's sign-in page.
+ */
+let pending = false;
+
+export function markIntentionalNavigation(): void {
+  pending = true;
+}
+
+export function isIntentionalNavigationPending(): boolean {
+  return pending;
+}

--- a/apps/form-app/src/pages/AutomationBuilder.tsx
+++ b/apps/form-app/src/pages/AutomationBuilder.tsx
@@ -14,6 +14,7 @@ import { FormPermissionProvider, type PermissionLevel } from '../contexts/FormPe
 import { useFormPermissions } from '../hooks/useFormPermissions';
 import { useTestAutomation } from '../hooks/useTestAutomation';
 import { extractValidationErrors } from '../components/automations/builder/validation';
+import { isIntentionalNavigationPending } from '../lib/intentionalNavigation';
 
 const AutomationBuilderContent: React.FC<{ form: any; automation: any }> = ({ form, automation }) => {
   const { t } = useTranslation('automations');
@@ -132,10 +133,15 @@ const AutomationBuilderContent: React.FC<{ form: any; automation: any }> = ({ fo
     }
   };
 
-  // Warn on tab close/refresh while there are unsaved graph changes.
+  // Warn on tab close/refresh while there are unsaved graph changes. Skipped when the
+  // navigation is one the app itself intentionally triggered and already knows is safe —
+  // e.g. the Google/Microsoft Sheets "Connect" buttons redirect this same tab to the OAuth
+  // provider, and the graph draft is already persisted to sessionStorage before that redirect
+  // fires (see draftStorage.ts) — without this check the browser's native "leave site?"
+  // prompt intercepts that redirect before the user ever reaches the sign-in page.
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => {
-      if (!isDirty) return;
+      if (!isDirty || isIntentionalNavigationPending()) return;
       e.preventDefault();
       e.returnValue = '';
     };

--- a/apps/form-app/src/plugins/google-sheets/ConfigForm.tsx
+++ b/apps/form-app/src/plugins/google-sheets/ConfigForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   Card,
   CardContent,
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react';
 import { useTranslation } from '../../hooks/useTranslation';
 import { getApiBaseUrl } from '../../lib/config';
+import { markIntentionalNavigation } from '../../lib/intentionalNavigation';
 import type { ConfigFormProps } from '../core/registry';
 
 interface GoogleToken {
@@ -56,6 +57,22 @@ export const GoogleSheetsConfigForm: React.FC<ConfigFormProps> = ({
     initialData?.config?.spreadsheetUrl
   );
 
+  // NodeConfigPanel (the automation builder's host for this form) passes a brand-new
+  // `initialData` object literal on every render, not just when the selected node changes —
+  // so the sync effect below re-fires far more often than its name suggests. On the mount
+  // that follows an OAuth redirect, both effects run in the same commit: this one first,
+  // then the sync effect second, since effects run in declaration order. Left unguarded, the
+  // sync effect immediately resets `googleToken` to `initialData.config?.googleToken` (still
+  // undefined — the token isn't persisted to the node until "Save action" is clicked),
+  // silently discarding the token this effect just parsed. The ref is never reset back to
+  // false: React StrictMode's dev-only double-invoke of effects on mount runs this same pair
+  // a second time, and by then `window.location.hash` has already been stripped (so the
+  // parse branch below is a no-op on that second pass) — a self-resetting guard would leave
+  // that second sync-effect invocation unguarded and wipe the token anyway. Latching it for
+  // the component's whole lifetime is safe because a real "switch to a different node"
+  // always unmounts and remounts this form (see NodeConfigPanel's close()-on-Save/Cancel).
+  const justConnectedRef = useRef(false);
+
   // On mount: check if we just returned from Google OAuth redirect
   useEffect(() => {
     const hash = window.location.hash;
@@ -67,6 +84,7 @@ export const GoogleSheetsConfigForm: React.FC<ConfigFormProps> = ({
         const token: GoogleToken = JSON.parse(atob(padded));
         console.log('[GSheets Config] ✅ token from redirect for:', token.email);
         setGoogleToken(token);
+        justConnectedRef.current = true;
         // Clean hash from URL without triggering a navigation
         window.history.replaceState(null, '', window.location.pathname + window.location.search);
       } catch (e) {
@@ -84,12 +102,17 @@ export const GoogleSheetsConfigForm: React.FC<ConfigFormProps> = ({
   useEffect(() => {
     if (initialData) {
       setPluginName(initialData.name ?? 'Google Sheets');
-      setGoogleToken(initialData.config?.googleToken);
+      if (!justConnectedRef.current) {
+        setGoogleToken(initialData.config?.googleToken);
+      }
     }
   }, [initialData]);
 
   const handleConnectGoogle = () => {
-    // Redirect the current tab — avoids all popup/COOP/BroadcastChannel issues
+    // Redirect the current tab — avoids all popup/COOP/BroadcastChannel issues. Mark this
+    // navigation as intentional first so the automation builder's beforeunload guard (which
+    // would otherwise treat this like an accidental tab close) lets it through unprompted.
+    markIntentionalNavigation();
     const returnTo = window.location.pathname + window.location.search;
     window.location.href = `${getApiBaseUrl()}/api/integrations/google/auth?return_to=${encodeURIComponent(returnTo)}`;
   };

--- a/apps/form-app/src/plugins/microsoft-sheets/ConfigForm.tsx
+++ b/apps/form-app/src/plugins/microsoft-sheets/ConfigForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   Card,
   CardContent,
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react';
 import { useTranslation } from '../../hooks/useTranslation';
 import { getApiBaseUrl } from '../../lib/config';
+import { markIntentionalNavigation } from '../../lib/intentionalNavigation';
 import type { ConfigFormProps } from '../core/registry';
 
 interface MicrosoftToken {
@@ -57,6 +58,22 @@ export const MicrosoftSheetsConfigForm: React.FC<ConfigFormProps> = ({
     initialData?.config?.workbookUrl
   );
 
+  // NodeConfigPanel (the automation builder's host for this form) passes a brand-new
+  // `initialData` object literal on every render, not just when the selected node changes —
+  // so the sync effect below re-fires far more often than its name suggests. On the mount
+  // that follows an OAuth redirect, both effects run in the same commit: this one first,
+  // then the sync effect second, since effects run in declaration order. Left unguarded, the
+  // sync effect immediately resets `microsoftToken` to `initialData.config?.microsoftToken`
+  // (still undefined — the token isn't persisted to the node until "Save action" is clicked),
+  // silently discarding the token this effect just parsed. The ref is never reset back to
+  // false: React StrictMode's dev-only double-invoke of effects on mount runs this same pair
+  // a second time, and by then `window.location.hash` has already been stripped (so the
+  // parse branch below is a no-op on that second pass) — a self-resetting guard would leave
+  // that second sync-effect invocation unguarded and wipe the token anyway. Latching it for
+  // the component's whole lifetime is safe because a real "switch to a different node"
+  // always unmounts and remounts this form (see NodeConfigPanel's close()-on-Save/Cancel).
+  const justConnectedRef = useRef(false);
+
   // On mount: check if we just returned from Microsoft OAuth redirect
   useEffect(() => {
     const hash = window.location.hash;
@@ -67,6 +84,7 @@ export const MicrosoftSheetsConfigForm: React.FC<ConfigFormProps> = ({
         const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
         const token: MicrosoftToken = JSON.parse(atob(padded));
         setMicrosoftToken(token);
+        justConnectedRef.current = true;
         window.history.replaceState(
           null,
           '',
@@ -92,12 +110,18 @@ export const MicrosoftSheetsConfigForm: React.FC<ConfigFormProps> = ({
   useEffect(() => {
     if (initialData) {
       setPluginName(initialData.name ?? 'Microsoft Excel');
-      setMicrosoftToken(initialData.config?.microsoftToken);
       setWorksheetName(initialData.config?.worksheetName ?? 'Sheet1');
+      if (!justConnectedRef.current) {
+        setMicrosoftToken(initialData.config?.microsoftToken);
+      }
     }
   }, [initialData]);
 
   const handleConnectMicrosoft = () => {
+    // Mark this navigation as intentional first so the automation builder's beforeunload
+    // guard (which would otherwise treat this like an accidental tab close) lets it through
+    // unprompted.
+    markIntentionalNavigation();
     const returnTo = window.location.pathname + window.location.search;
     window.location.href = `${getApiBaseUrl()}/api/integrations/microsoft/auth?return_to=${encodeURIComponent(returnTo)}`;
   };


### PR DESCRIPTION
## Summary

Fixes three chained bugs that together made connecting a Google/Microsoft account from the Automations builder effectively unusable end-to-end.

- **"Leave page?" popup blocked the OAuth redirect** — the Automations builder's unsaved-changes `beforeunload` guard fired on the Connect buttons' own app-initiated tab redirect to Google/Microsoft, since it had no way to distinguish that from an accidental tab close. Added `lib/intentionalNavigation.ts`, a flag the Connect handlers set immediately before navigating that the guard now checks and skips.
- **OAuth token silently discarded after a successful connect** — `NodeConfigPanel` passes a brand-new `initialData` object to the config form on every render, which re-fires a sync effect in the same mount as the token-parsing effect, resetting the freshly-parsed token back to `undefined` before the user ever sees "Connected." Fixed with a latched ref guard in both `google-sheets/ConfigForm.tsx` and `microsoft-sheets/ConfigForm.tsx` (accounts for React StrictMode's dev-only double-invoke of effects, which broke an earlier self-resetting version of the guard).
- **Running the automation threw `formPlugin.update()` "No record was found for an update"** — google-sheets/microsoft-sheets handlers are shared between the legacy standalone Plugins system (backed by a real `FormPlugin` row) and the newer Automations system (action-node config lives inline in `Automation.graph`'s JSON, no `FormPlugin` row at all). Added `context.updatePluginConfig()` to the shared `PluginContext`; each caller supplies its own persistence strategy — `executor.ts` writes to the real `FormPlugin` row, `services/automation/engine.ts` writes into both the live `Automation.graph` (so the next run reuses the same spreadsheet/workbook) and the current run's `AutomationRun.graphSnapshot` (so a retry doesn't create a duplicate) via an atomic `jsonb_set` UPDATE, safe against concurrent runs.

Also added the missing `MICROSOFT_CLIENT_ID`/`MICROSOFT_CLIENT_SECRET`/`MICROSOFT_REDIRECT_URI` documentation to `.env.example` (Google's were already there).

## Test plan

- [x] `pnpm --filter backend exec tsc --noEmit` and `pnpm --filter form-app exec tsc --noEmit` — clean
- [x] `pnpm test:unit` — 2843/2843 backend tests pass (2838 pre-existing + 5 new covering the `updatePluginConfig` wiring on both the legacy and automation paths)
- [x] `pnpm --filter backend lint` — 0 errors/warnings in every file touched
- [x] Verified live in the browser: added Google Sheets and Microsoft Excel action nodes to a real automation (marking it dirty), clicked both "Connect" buttons — no popup interception, straight to the provider. Completed the Google OAuth flow end-to-end and confirmed "Connected as ..." persists through Save.
- [x] Verified the `jsonb_set` SQL directly against the dev database inside a rolled-back transaction — confirmed it replaces exactly the target node's config and leaves sibling nodes untouched.
- [x] Pre-push hook ran full test suites + builds for backend, form-viewer, admin-app, and form-app — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Microsoft OAuth configuration options for connecting Microsoft Sheets.
  * Updated Google Sheets and Microsoft Sheets integrations to retain refreshed access tokens and newly created spreadsheet/workbook details.
  * Automation runs now preserve updated integration settings for future retries.

* **Bug Fixes**
  * Prevented OAuth connection redirects from triggering unnecessary unsaved-changes warnings.
  * Prevented newly received OAuth tokens from being overwritten during form updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->