### PR TITLE
Fix Google/Microsoft Sheets action-node config leaking across sibling nodes

### DIFF
--- a/apps/backend/src/plugins/google-sheets/handler.ts
+++ b/apps/backend/src/plugins/google-sheets/handler.ts
@@ -286,7 +286,16 @@ export const googleSheetsHandler: PluginHandler = async (plugin, event, context)
 
     const initSpreadsheet = async (): Promise<{ spreadsheetId: string; spreadsheetUrl: string }> => {
       const formTitle = form?.title?.trim() || 'Form Responses';
-      const sheetTitle = `${formTitle} — Responses`;
+      // Append a distinguishing suffix so two Google Sheets actions on the same form (e.g. a
+      // condition's "Yes" and "No" branches) don't create identically-titled files that are
+      // hard to tell apart in Drive. Automation action nodes use a composite
+      // `${runId}:${nodeId}` plugin id (see services/automation/engine.ts) — prefer the
+      // trailing node-id segment, which stays stable across re-runs, over the whole composite
+      // (which would otherwise change every run). Legacy standalone plugins use a plain
+      // FormPlugin id with no colon, so this is a no-op there.
+      const idParts = plugin.id.split(':');
+      const idSuffix = (idParts[idParts.length - 1] || plugin.id).slice(0, 8);
+      const sheetTitle = `${formTitle} — Responses (${idSuffix})`;
 
       context.logger.info('Google Sheets: creating new spreadsheet', {
         pluginId: plugin.id,

--- a/apps/backend/src/plugins/microsoft-sheets/handler.ts
+++ b/apps/backend/src/plugins/microsoft-sheets/handler.ts
@@ -334,8 +334,17 @@ export const microsoftSheetsHandler: PluginHandler = async (plugin, event, conte
 
     const initWorkbook = async (): Promise<{ workbookId: string; workbookUrl: string }> => {
       const formTitle = form?.title?.trim() || 'Form Responses';
-      // Append short plugin ID suffix to prevent collisions when two forms share the same title
-      const workbookTitle = `${formTitle} — Responses (${plugin.id.slice(0, 8)})`;
+      // Append a distinguishing suffix so two Microsoft Excel actions on the same form (e.g. a
+      // condition's "Yes" and "No" branches) don't create identically-titled files that are
+      // hard to tell apart in OneDrive. Automation action nodes use a composite
+      // `${runId}:${nodeId}` plugin id (see services/automation/engine.ts) — prefer the
+      // trailing node-id segment, which stays stable across re-runs, over the whole composite
+      // (which would otherwise change every run, since it used to take the first 8 chars of
+      // the *whole* id — effectively the run id, not the node id). Legacy standalone plugins
+      // use a plain FormPlugin id with no colon, so this is a no-op there.
+      const idParts = plugin.id.split(':');
+      const idSuffix = (idParts[idParts.length - 1] || plugin.id).slice(0, 8);
+      const workbookTitle = `${formTitle} — Responses (${idSuffix})`;
 
       context.logger.info('Microsoft Sheets: creating new workbook', {
         pluginId: plugin.id,

--- a/apps/backend/src/services/automation/__tests__/engine.test.ts
+++ b/apps/backend/src/services/automation/__tests__/engine.test.ts
@@ -684,6 +684,11 @@ describe('automation engine', () => {
       await capturedPersist!(newConfig);
 
       expect(prisma.$executeRaw).toHaveBeenCalledTimes(2);
+      // Both writes must go through a single $transaction, not Promise.all — otherwise one
+      // write succeeding while the other fails would leave Automation.graph and this run's
+      // graphSnapshot permanently diverged.
+      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(prisma.$transaction).mock.calls[0][0]).toHaveLength(2);
 
       const [graphCall, snapshotCall] = vi.mocked(prisma.$executeRaw).mock.calls.map(
         (call) => call[0] as unknown as { strings: TemplateStringsArray; values: any[] }

--- a/apps/backend/src/services/automation/engine.ts
+++ b/apps/backend/src/services/automation/engine.ts
@@ -125,25 +125,40 @@ function mergeStepOutput(context: unknown, nodeId: string, output: any): Automat
 }
 
 /**
- * Replaces one node's `data.config` inside a `{ nodes: [...], edges: [...] }` JSON column,
- * leaving every other node untouched, in a single atomic UPDATE. Postgres serializes
- * concurrent UPDATEs to the same row (the second waits for the first to commit, then
- * re-reads its result), so two action-node executions racing to persist config on the same
- * row — e.g. two form submissions triggering the same automation moments apart — can't lose
- * one's write to the other's the way a JS-level read-modify-write would.
+ * Builds (without executing) an atomic UPDATE that replaces one node's `data.config` inside a
+ * `{ nodes: [...], edges: [...] }` JSON column, leaving every other node untouched. Returns
+ * the unresolved `$executeRaw` PrismaPromise so callers can batch it into `$transaction`.
+ *
+ * Because each single statement's `SET column = jsonb_set(column, ...)` re-reads the row's
+ * latest *committed* value at execution time — not a value cached in application memory —
+ * two concurrent writes targeting DIFFERENT nodes in the same graph correctly compose:
+ * Postgres serializes the two UPDATEs (the second waits for the first to commit, then
+ * evaluates against its result), so neither writer's change is lost to the other.
+ *
+ * This does NOT protect two concurrent *runs* writing to the SAME node from each other. Each
+ * run computes its own full replacement `data.config` from whatever it read when its own
+ * execution started; if two runs of the same automation both reach the "auto-create
+ * spreadsheet/workbook" branch for the same action node before either has persisted an
+ * id, each creates its own resource and whichever write lands last wins — the other run's
+ * newly created spreadsheet/workbook is silently orphaned (created, but never referenced
+ * again). Accepted as a narrow edge case for now: it can only surface on an action's very
+ * first-ever execution, and no response data is lost (every run's row still lands in *some*
+ * spreadsheet). Closing it fully would mean serializing the auto-create branch itself — e.g.
+ * a per-node advisory lock or `SELECT ... FOR UPDATE` before that branch runs — not just this
+ * config write.
  */
-async function jsonSetNodeConfig(
+function jsonSetNodeConfigQuery(
   table: 'automation' | 'automation_run',
   column: 'graph' | 'graphSnapshot',
   rowId: string,
   nodeId: string,
   config: PluginConfig
-): Promise<void> {
+) {
   const tableIdent = Prisma.raw(`"${table}"`);
   const columnIdent = Prisma.raw(`"${column}"`);
   const configJson = JSON.stringify(config);
 
-  await prisma.$executeRaw(Prisma.sql`
+  return prisma.$executeRaw(Prisma.sql`
     UPDATE ${tableIdent}
     SET ${columnIdent} = jsonb_set(
       ${columnIdent},
@@ -167,7 +182,8 @@ async function jsonSetNodeConfig(
  * refreshed OAuth token, etc.) for the Automations system — see `PluginContext.updatePluginConfig`
  * for why handlers can't just write to a `FormPlugin` row here.
  *
- * Writes to two places:
+ * Writes to two places, both inside one Prisma `$transaction` so they can't diverge if one
+ * write fails after the other succeeds:
  *  - `AutomationRun.graphSnapshot` for THIS run, so a retry after a transient failure (e.g.
  *    the workbook was created but the network dropped before this write) sees the
  *    already-created workbook/spreadsheet instead of creating a duplicate.
@@ -180,9 +196,9 @@ async function updateAutomationNodeConfig(
   nodeId: string,
   config: PluginConfig
 ): Promise<void> {
-  await Promise.all([
-    jsonSetNodeConfig('automation', 'graph', automationId, nodeId, config),
-    jsonSetNodeConfig('automation_run', 'graphSnapshot', runId, nodeId, config),
+  await prisma.$transaction([
+    jsonSetNodeConfigQuery('automation', 'graph', automationId, nodeId, config),
+    jsonSetNodeConfigQuery('automation_run', 'graphSnapshot', runId, nodeId, config),
   ]);
 }
 

--- a/apps/form-app/src/components/automations/builder/NodeConfigPanel.tsx
+++ b/apps/form-app/src/components/automations/builder/NodeConfigPanel.tsx
@@ -132,6 +132,7 @@ export const NodeConfigPanel: React.FC<NodeConfigPanelProps> = ({ form }) => {
               config: actionData.config ?? {},
               events: ['form.submitted'],
             }}
+            instanceKey={node.id}
             mode={hasConfig ? 'edit' : 'create'}
             isSaving={false}
             hideEventsSection

--- a/apps/form-app/src/lib/pendingConfigFields.ts
+++ b/apps/form-app/src/lib/pendingConfigFields.ts
@@ -1,0 +1,37 @@
+/**
+ * Survives a full-page OAuth "Connect" redirect for a plugin config form's in-progress,
+ * not-yet-saved field edits (e.g. a typed Plugin Name or Worksheet Name).
+ *
+ * The automation builder's session draft (see automations/builder/draftStorage.ts) only
+ * covers config that's already been committed via "Save action" — anything still mid-edit in
+ * the open config panel is plain React state, which a full page reload discards. Google/
+ * Microsoft Sheets' "Connect Account" buttons redirect the current tab (see their ConfigForm's
+ * handleConnect*), so without this, typing a name and clicking Connect before saving silently
+ * reverts the name once the OAuth flow returns.
+ *
+ * Keyed by the current pathname: at most one Connect flow is in flight per tab at a time, and
+ * the stash is written immediately before navigating away and consumed (read + removed) the
+ * moment the redirect returns, so there's no window where a different config panel's pending
+ * edits could leak into another one.
+ */
+const key = (pluginType: string) => `dculus:pending-config-fields:${pluginType}:${window.location.pathname}`;
+
+export function stashPendingConfigFields(pluginType: string, fields: Record<string, unknown>): void {
+  try {
+    sessionStorage.setItem(key(pluginType), JSON.stringify(fields));
+  } catch {
+    // best-effort only — sessionStorage can throw in private-browsing or quota-exceeded contexts
+  }
+}
+
+export function consumePendingConfigFields<T extends Record<string, unknown>>(pluginType: string): T | null {
+  const storageKey = key(pluginType);
+  try {
+    const raw = sessionStorage.getItem(storageKey);
+    if (!raw) return null;
+    sessionStorage.removeItem(storageKey);
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}

--- a/apps/form-app/src/plugins/core/registry.tsx
+++ b/apps/form-app/src/plugins/core/registry.tsx
@@ -35,6 +35,19 @@ export interface ConfigFormProps {
    * a "plugin" is being created). Falls back to the per-plugin default when omitted.
    */
   submitLabelOverride?: string;
+  /**
+   * Identifies which underlying node/plugin this form instance is configuring — the
+   * automation builder's NodeConfigPanel passes `node.id` here. NodeConfigPanel renders the
+   * same ConfigForm component type (no `key`) for every action node of a given plugin type,
+   * so switching the selected node updates props on the SAME mounted instance rather than
+   * remounting it. Forms that latch local state across renders (e.g. to survive an OAuth
+   * redirect — see google-sheets/microsoft-sheets ConfigForm) need this to detect "the
+   * selected node actually changed" and reset that latch, or a value meant for one node can
+   * leak onto whatever different node the user switches to next. Omitted by callers that
+   * don't have this "reused instance, switchable target" scenario (e.g. the standalone
+   * Plugins page, where each ConfigForm mount is dedicated to one plugin).
+   */
+  instanceKey?: string;
 }
 
 export interface ResponseCellProps {

--- a/apps/form-app/src/plugins/google-sheets/ConfigForm.tsx
+++ b/apps/form-app/src/plugins/google-sheets/ConfigForm.tsx
@@ -100,8 +100,10 @@ export const GoogleSheetsConfigForm: React.FC<ConfigFormProps> = ({
         // Restore whatever the user had typed into "Plugin Name" before Connect navigated the
         // tab away — that edit lived only in local React state and was never saved, so the
         // full-page redirect would otherwise silently revert it back to the last-saved name.
+        // Checked by key presence, not truthiness: clearing the name to '' before Connect is
+        // a valid edit that a truthiness check would fail to restore.
         const pending = consumePendingConfigFields<{ pluginName?: string }>('google-sheets');
-        if (pending?.pluginName) setPluginName(pending.pluginName);
+        if (pending && 'pluginName' in pending) setPluginName(pending.pluginName ?? '');
         justConnectedRef.current = true;
         // Clean hash from URL without triggering a navigation
         window.history.replaceState(null, '', window.location.pathname + window.location.search);
@@ -114,8 +116,8 @@ export const GoogleSheetsConfigForm: React.FC<ConfigFormProps> = ({
       console.warn('[GSheets Config] OAuth error from redirect:', error);
       setConnectionError(t('connection.authFailed'));
       const pending = consumePendingConfigFields<{ pluginName?: string }>('google-sheets');
-      if (pending?.pluginName) {
-        setPluginName(pending.pluginName);
+      if (pending && 'pluginName' in pending) {
+        setPluginName(pending.pluginName ?? '');
         justConnectedRef.current = true;
       }
       window.history.replaceState(null, '', window.location.pathname + window.location.search);

--- a/apps/form-app/src/plugins/google-sheets/ConfigForm.tsx
+++ b/apps/form-app/src/plugins/google-sheets/ConfigForm.tsx
@@ -22,6 +22,7 @@ import {
 import { useTranslation } from '../../hooks/useTranslation';
 import { getApiBaseUrl } from '../../lib/config';
 import { markIntentionalNavigation } from '../../lib/intentionalNavigation';
+import { stashPendingConfigFields, consumePendingConfigFields } from '../../lib/pendingConfigFields';
 import type { ConfigFormProps } from '../core/registry';
 
 interface GoogleToken {
@@ -34,6 +35,7 @@ interface GoogleToken {
 export const GoogleSheetsConfigForm: React.FC<ConfigFormProps> = ({
   form,
   initialData,
+  instanceKey,
   mode,
   isSaving,
   onSave,
@@ -50,28 +52,39 @@ export const GoogleSheetsConfigForm: React.FC<ConfigFormProps> = ({
   const [googleToken, setGoogleToken] = useState<GoogleToken | undefined>(
     initialData?.config?.googleToken
   );
-  const [spreadsheetId] = useState<string | undefined>(
-    initialData?.config?.spreadsheetId
-  );
-  const [spreadsheetUrl] = useState<string | undefined>(
-    initialData?.config?.spreadsheetUrl
-  );
+  // Not local state: read directly from `initialData` (fresh per selected node) rather than
+  // capturing once at mount. NodeConfigPanel reuses the same ConfigForm instance across
+  // different action nodes of the same type without remounting it — local state captured
+  // once would keep whichever node's spreadsheetId was set on first mount and silently
+  // persist it onto a completely different node's config on the next Save, making two
+  // unrelated action nodes (e.g. a condition's "Yes" and "No" branches) end up pointing at
+  // the same spreadsheet.
+  const spreadsheetId = initialData?.config?.spreadsheetId;
+  const spreadsheetUrl = initialData?.config?.spreadsheetUrl;
 
   // NodeConfigPanel (the automation builder's host for this form) passes a brand-new
   // `initialData` object literal on every render, not just when the selected node changes —
   // so the sync effect below re-fires far more often than its name suggests. On the mount
   // that follows an OAuth redirect, both effects run in the same commit: this one first,
   // then the sync effect second, since effects run in declaration order. Left unguarded, the
-  // sync effect immediately resets `googleToken` to `initialData.config?.googleToken` (still
-  // undefined — the token isn't persisted to the node until "Save action" is clicked),
-  // silently discarding the token this effect just parsed. The ref is never reset back to
-  // false: React StrictMode's dev-only double-invoke of effects on mount runs this same pair
-  // a second time, and by then `window.location.hash` has already been stripped (so the
-  // parse branch below is a no-op on that second pass) — a self-resetting guard would leave
-  // that second sync-effect invocation unguarded and wipe the token anyway. Latching it for
-  // the component's whole lifetime is safe because a real "switch to a different node"
-  // always unmounts and remounts this form (see NodeConfigPanel's close()-on-Save/Cancel).
+  // sync effect immediately resets `googleToken`/`pluginName` back to `initialData`'s (still
+  // last-*Saved*) values — the token isn't persisted to the node until "Save action" is
+  // clicked, and neither is any in-progress "Plugin Name" edit — silently discarding both
+  // this effect just restored (the token freshly parsed, the name from the pending-fields
+  // stash). The ref is never self-resetting: React StrictMode's dev-only double-invoke of
+  // effects on mount runs this same pair a second time, and by then `window.location.hash` has
+  // already been stripped (so the parse branch below is a no-op on that second pass) — a
+  // self-resetting guard would leave that second sync-effect invocation unguarded and wipe
+  // everything anyway.
+  //
+  // NodeConfigPanel does NOT remount this form when the user switches to a different node of
+  // the same plugin type without saving/canceling first — it renders the same ConfigForm
+  // component instance with new props, since there's no `key`. So the latch must be reset
+  // explicitly on a genuine node switch (tracked via `instanceKey`, NodeConfigPanel's
+  // node.id), or a token/name meant for the node open during OAuth would silently leak onto
+  // whatever different node the user clicks next.
   const justConnectedRef = useRef(false);
+  const prevInstanceKeyRef = useRef(instanceKey);
 
   // On mount: check if we just returned from Google OAuth redirect
   useEffect(() => {
@@ -84,6 +97,11 @@ export const GoogleSheetsConfigForm: React.FC<ConfigFormProps> = ({
         const token: GoogleToken = JSON.parse(atob(padded));
         console.log('[GSheets Config] ✅ token from redirect for:', token.email);
         setGoogleToken(token);
+        // Restore whatever the user had typed into "Plugin Name" before Connect navigated the
+        // tab away — that edit lived only in local React state and was never saved, so the
+        // full-page redirect would otherwise silently revert it back to the last-saved name.
+        const pending = consumePendingConfigFields<{ pluginName?: string }>('google-sheets');
+        if (pending?.pluginName) setPluginName(pending.pluginName);
         justConnectedRef.current = true;
         // Clean hash from URL without triggering a navigation
         window.history.replaceState(null, '', window.location.pathname + window.location.search);
@@ -95,20 +113,30 @@ export const GoogleSheetsConfigForm: React.FC<ConfigFormProps> = ({
       const error = new URLSearchParams(hash.slice(1)).get('google_oauth_error') ?? '';
       console.warn('[GSheets Config] OAuth error from redirect:', error);
       setConnectionError(t('connection.authFailed'));
+      const pending = consumePendingConfigFields<{ pluginName?: string }>('google-sheets');
+      if (pending?.pluginName) {
+        setPluginName(pending.pluginName);
+        justConnectedRef.current = true;
+      }
       window.history.replaceState(null, '', window.location.pathname + window.location.search);
     }
   }, []);
 
   useEffect(() => {
-    if (initialData) {
-      setPluginName(initialData.name ?? 'Google Sheets');
-      if (!justConnectedRef.current) {
-        setGoogleToken(initialData.config?.googleToken);
-      }
+    if (prevInstanceKeyRef.current !== instanceKey) {
+      prevInstanceKeyRef.current = instanceKey;
+      justConnectedRef.current = false;
     }
-  }, [initialData]);
+    if (initialData && !justConnectedRef.current) {
+      setPluginName(initialData.name ?? 'Google Sheets');
+      setGoogleToken(initialData.config?.googleToken);
+    }
+  }, [initialData, instanceKey]);
 
   const handleConnectGoogle = () => {
+    // Stash whatever's currently typed into "Plugin Name" — it's only local React state until
+    // Save is clicked, and the redirect below fully reloads the page, discarding it otherwise.
+    stashPendingConfigFields('google-sheets', { pluginName });
     // Redirect the current tab — avoids all popup/COOP/BroadcastChannel issues. Mark this
     // navigation as intentional first so the automation builder's beforeunload guard (which
     // would otherwise treat this like an accidental tab close) lets it through unprompted.

--- a/apps/form-app/src/plugins/microsoft-sheets/ConfigForm.tsx
+++ b/apps/form-app/src/plugins/microsoft-sheets/ConfigForm.tsx
@@ -22,6 +22,7 @@ import {
 import { useTranslation } from '../../hooks/useTranslation';
 import { getApiBaseUrl } from '../../lib/config';
 import { markIntentionalNavigation } from '../../lib/intentionalNavigation';
+import { stashPendingConfigFields, consumePendingConfigFields } from '../../lib/pendingConfigFields';
 import type { ConfigFormProps } from '../core/registry';
 
 interface MicrosoftToken {
@@ -35,6 +36,7 @@ interface MicrosoftToken {
 export const MicrosoftSheetsConfigForm: React.FC<ConfigFormProps> = ({
   form,
   initialData,
+  instanceKey,
   mode,
   isSaving,
   onSave,
@@ -63,16 +65,23 @@ export const MicrosoftSheetsConfigForm: React.FC<ConfigFormProps> = ({
   // so the sync effect below re-fires far more often than its name suggests. On the mount
   // that follows an OAuth redirect, both effects run in the same commit: this one first,
   // then the sync effect second, since effects run in declaration order. Left unguarded, the
-  // sync effect immediately resets `microsoftToken` to `initialData.config?.microsoftToken`
-  // (still undefined — the token isn't persisted to the node until "Save action" is clicked),
-  // silently discarding the token this effect just parsed. The ref is never reset back to
-  // false: React StrictMode's dev-only double-invoke of effects on mount runs this same pair
-  // a second time, and by then `window.location.hash` has already been stripped (so the
-  // parse branch below is a no-op on that second pass) — a self-resetting guard would leave
-  // that second sync-effect invocation unguarded and wipe the token anyway. Latching it for
-  // the component's whole lifetime is safe because a real "switch to a different node"
-  // always unmounts and remounts this form (see NodeConfigPanel's close()-on-Save/Cancel).
+  // sync effect immediately resets `microsoftToken`/`pluginName`/`worksheetName` back to
+  // `initialData`'s (still last-*Saved*) values — none of the three are persisted to the node
+  // until "Save action" is clicked — silently discarding what this effect just restored (the
+  // token freshly parsed, the name/worksheet from the pending-fields stash). The ref is never
+  // self-resetting: React StrictMode's dev-only double-invoke of effects on mount runs this
+  // same pair a second time, and by then `window.location.hash` has already been stripped (so
+  // the parse branch below is a no-op on that second pass) — a self-resetting guard would
+  // leave that second sync-effect invocation unguarded and wipe everything anyway.
+  //
+  // NodeConfigPanel does NOT remount this form when the user switches to a different node of
+  // the same plugin type without saving/canceling first — it renders the same ConfigForm
+  // component instance with new props, since there's no `key`. So the latch must be reset
+  // explicitly on a genuine node switch (tracked via `instanceKey`, NodeConfigPanel's
+  // node.id), or a token/name meant for the node open during OAuth would silently leak onto
+  // whatever different node the user clicks next.
   const justConnectedRef = useRef(false);
+  const prevInstanceKeyRef = useRef(instanceKey);
 
   // On mount: check if we just returned from Microsoft OAuth redirect
   useEffect(() => {
@@ -84,6 +93,14 @@ export const MicrosoftSheetsConfigForm: React.FC<ConfigFormProps> = ({
         const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
         const token: MicrosoftToken = JSON.parse(atob(padded));
         setMicrosoftToken(token);
+        // Restore whatever the user had typed into "Plugin Name"/"Worksheet Name" before
+        // Connect navigated the tab away — those edits lived only in local React state and
+        // were never saved, so the full-page redirect would otherwise silently revert them.
+        const pending = consumePendingConfigFields<{ pluginName?: string; worksheetName?: string }>(
+          'microsoft-sheets'
+        );
+        if (pending?.pluginName) setPluginName(pending.pluginName);
+        if (pending?.worksheetName) setWorksheetName(pending.worksheetName);
         justConnectedRef.current = true;
         window.history.replaceState(
           null,
@@ -99,6 +116,12 @@ export const MicrosoftSheetsConfigForm: React.FC<ConfigFormProps> = ({
         new URLSearchParams(hash.slice(1)).get('microsoft_oauth_error') ?? '';
       console.warn('[MicrosoftSheets Config] OAuth error from redirect:', error);
       setConnectionError(t('connection.authFailed'));
+      const pending = consumePendingConfigFields<{ pluginName?: string; worksheetName?: string }>(
+        'microsoft-sheets'
+      );
+      if (pending?.pluginName) setPluginName(pending.pluginName);
+      if (pending?.worksheetName) setWorksheetName(pending.worksheetName);
+      if (pending) justConnectedRef.current = true;
       window.history.replaceState(
         null,
         '',
@@ -108,16 +131,22 @@ export const MicrosoftSheetsConfigForm: React.FC<ConfigFormProps> = ({
   }, []);
 
   useEffect(() => {
-    if (initialData) {
+    if (prevInstanceKeyRef.current !== instanceKey) {
+      prevInstanceKeyRef.current = instanceKey;
+      justConnectedRef.current = false;
+    }
+    if (initialData && !justConnectedRef.current) {
       setPluginName(initialData.name ?? 'Microsoft Excel');
       setWorksheetName(initialData.config?.worksheetName ?? 'Sheet1');
-      if (!justConnectedRef.current) {
-        setMicrosoftToken(initialData.config?.microsoftToken);
-      }
+      setMicrosoftToken(initialData.config?.microsoftToken);
     }
-  }, [initialData]);
+  }, [initialData, instanceKey]);
 
   const handleConnectMicrosoft = () => {
+    // Stash whatever's currently typed into "Plugin Name"/"Worksheet Name" — they're only
+    // local React state until Save is clicked, and the redirect below fully reloads the page,
+    // discarding them otherwise.
+    stashPendingConfigFields('microsoft-sheets', { pluginName, worksheetName });
     // Mark this navigation as intentional first so the automation builder's beforeunload
     // guard (which would otherwise treat this like an accidental tab close) lets it through
     // unprompted.

--- a/apps/form-app/src/plugins/microsoft-sheets/ConfigForm.tsx
+++ b/apps/form-app/src/plugins/microsoft-sheets/ConfigForm.tsx
@@ -56,9 +56,12 @@ export const MicrosoftSheetsConfigForm: React.FC<ConfigFormProps> = ({
   const [microsoftToken, setMicrosoftToken] = useState<MicrosoftToken | undefined>(
     initialData?.config?.microsoftToken
   );
-  const [workbookUrl] = useState<string | undefined>(
-    initialData?.config?.workbookUrl
-  );
+  // Not local state: read directly from `initialData` (fresh per selected node) rather than
+  // capturing once at mount — same reasoning as google-sheets/ConfigForm.tsx's
+  // spreadsheetId/spreadsheetUrl. `handleSave` below already read `workbookId`/`workbookUrl`
+  // fresh from `initialData`, so this was display-only staleness (the "Open in..." link could
+  // point at a sibling node's workbook after switching without saving), not a persisted leak.
+  const workbookUrl = initialData?.config?.workbookUrl;
 
   // NodeConfigPanel (the automation builder's host for this form) passes a brand-new
   // `initialData` object literal on every render, not just when the selected node changes —
@@ -96,11 +99,13 @@ export const MicrosoftSheetsConfigForm: React.FC<ConfigFormProps> = ({
         // Restore whatever the user had typed into "Plugin Name"/"Worksheet Name" before
         // Connect navigated the tab away — those edits lived only in local React state and
         // were never saved, so the full-page redirect would otherwise silently revert them.
+        // Checked by key presence, not truthiness: clearing either field to '' before Connect
+        // is a valid edit that a truthiness check would fail to restore.
         const pending = consumePendingConfigFields<{ pluginName?: string; worksheetName?: string }>(
           'microsoft-sheets'
         );
-        if (pending?.pluginName) setPluginName(pending.pluginName);
-        if (pending?.worksheetName) setWorksheetName(pending.worksheetName);
+        if (pending && 'pluginName' in pending) setPluginName(pending.pluginName ?? '');
+        if (pending && 'worksheetName' in pending) setWorksheetName(pending.worksheetName ?? '');
         justConnectedRef.current = true;
         window.history.replaceState(
           null,
@@ -119,8 +124,8 @@ export const MicrosoftSheetsConfigForm: React.FC<ConfigFormProps> = ({
       const pending = consumePendingConfigFields<{ pluginName?: string; worksheetName?: string }>(
         'microsoft-sheets'
       );
-      if (pending?.pluginName) setPluginName(pending.pluginName);
-      if (pending?.worksheetName) setWorksheetName(pending.worksheetName);
+      if (pending && 'pluginName' in pending) setPluginName(pending.pluginName ?? '');
+      if (pending && 'worksheetName' in pending) setWorksheetName(pending.worksheetName ?? '');
       if (pending) justConnectedRef.current = true;
       window.history.replaceState(
         null,


### PR DESCRIPTION
## Summary

Follow-up to #223. While testing #223's fix live, found that a condition's "Yes" and "No" branch action nodes (both Google Sheets, or both Microsoft Excel) could end up pointing at the *same* spreadsheet/workbook, and that typed-but-unsaved fields (Plugin Name, Worksheet Name) reverted after clicking "Connect" — plus two issues surfaced by automated review on #223 itself.

- **Config leaking across sibling nodes** — `GoogleSheetsConfigForm` read `spreadsheetId`/`spreadsheetUrl` from local component state captured once on mount and never re-synced. `NodeConfigPanel` reuses the same form instance across different action nodes of the same plugin type (no remount when switching selection), so whichever node's spreadsheet was loaded first would get silently persisted onto whatever node was saved next. Fixed by reading those fields directly from `initialData` (always current) instead of stale local state — matching how Microsoft's form already worked.
- **Plugin Name / Worksheet Name reverting after Connect** — these fields are plain local React state until "Save action" is clicked, and the OAuth redirect is a full-page reload that discards them. Added `lib/pendingConfigFields.ts`, which stashes them to `sessionStorage` immediately before navigating and restores them when the form remounts after returning from Google/Microsoft.
- **File-naming parity** — Google Sheets' auto-created files had no distinguishing suffix (Microsoft's did). Added one, and fixed Microsoft's own suffix, which was accidentally derived from the run ID (changes every run) instead of the stable per-node ID — defeating its own purpose of telling sibling nodes' files apart.
- **Automated review feedback from #223** (both addressed here since they touch the same files):
  - The OAuth "just connected" latch (added in #223 to protect a freshly-parsed token from being clobbered by a sync effect) was held for the component's entire lifetime. Since switching to a different node doesn't remount the form, this could leak a token/name from one node onto another. Now reset via a new optional `instanceKey` prop (`NodeConfigPanel` passes `node.id`) whenever the selected node actually changes.
  - The two automation config writes (`Automation.graph` + `AutomationRun.graphSnapshot`) went through `Promise.all`, not atomic together — if one write failed after the other succeeded, they'd permanently diverge. Now both go through a single Prisma `$transaction`.
  - Corrected the `jsonSetNodeConfig` docstring, which overstated protection: the atomic UPDATE prevents concurrent writes to *different* nodes from clobbering each other, but not two concurrent *runs* of the *same* node racing on a stale read during first-ever auto-create (documented as an accepted narrow edge case — no response data is lost, only a possible orphaned spreadsheet).

## Test plan

- [x] `pnpm --filter backend exec tsc --noEmit` and `pnpm --filter form-app exec tsc --noEmit` — clean
- [x] `pnpm test:unit` — 2843/2843 backend tests pass, including new/updated coverage for the transaction wrap
- [x] `pnpm --filter backend lint` / `pnpm --filter form-app lint` — 0 issues in every file touched
- [x] Verified live: renamed a Google Sheets action node, disconnected/reconnected its Google account, confirmed the typed name survived the OAuth redirect and the node's spreadsheet ID stayed independent from its sibling branch node — checked directly against the database (`automation.graph` JSON), not just the UI
- [x] Pre-push hook ran full test suites + builds for backend, form-viewer, admin-app, and form-app — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Google Sheets and Microsoft Excel files now use distinguishing workbook/spreadsheet names to reduce ambiguity across multiple automation actions.
  - Plugin config forms persist unsaved “Plugin Name” and related fields across full-page OAuth redirects.

- **Bug Fixes**
  - Automation action node switching now better isolates configuration so values don’t leak between node instances.
  - Automation configuration persistence is now atomic, updating both the live graph and run snapshot together to avoid inconsistent saves.

- **Tests**
  - Added stronger assertions ensuring the automation graph updates occur within a single transaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->