### PR TITLE
Docs: form builder redesign spec (epic #226)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,6 @@ dculus-chargebee-webhook-passwords.txt
 /pdf-template/
 /ui-design-refernce/
 /screenshot/
+
+# Claude Code local (per-machine) settings — never commit
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 See `package.json` scripts for the full list (`dev`, `backend:dev`, `db:generate`, `build`, `test:unit`, `test:integration`, `test:e2e`, etc.). Notable non-obvious usage: `pnpm test:e2e -- --tags "@tagname"` runs specific tagged Cucumber scenarios.
 
 **Test credentials** (E2E): set via environment variables — do not hardcode in this file.  
+The shared dev/E2E login (email **and** password) is the `E2E_EMAIL` / `E2E_PASSWORD` **fallback values baked into the `test:e2e` script in `package.json`** — read them from there. Use that account for manual sign-in at `http://localhost:3000` when verifying changes in the browser; do not register new accounts and do not commit any other credentials.  
 **Admin credentials**: set via `ADMIN_EMAIL` / `ADMIN_PASSWORD` env vars and `pnpm admin:setup` — do not hardcode in this file.
+
+---
+
+## Git Worktrees — read this FIRST if your working directory is a worktree
+
+Worktrees (created under `.claude/worktrees/` or via `git worktree add`) share git history but **not** gitignored files. A fresh worktree has no `.env` files, no `node_modules`, no built `@dculus/*` package dist output, and no generated Prisma client — so `pnpm dev`, type-check, and tests all fail confusingly.
+
+Before doing anything else in a worktree, run once:
+
+```bash
+./scripts/setup-worktree.sh
+```
+
+It copies `.env` files and `.claude/settings.local.json` from the main checkout, runs `pnpm install` if needed, builds the workspace packages, and generates the Prisma client. Failure signatures when skipped: `Cannot find module '@dculus/types'` (packages not built), Prisma client import errors (`db:generate` not run), backend exiting on missing env vars.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 See `package.json` scripts for the full list (`dev`, `backend:dev`, `db:generate`, `build`, `test:unit`, `test:integration`, `test:e2e`, etc.). Notable non-obvious usage: `pnpm test:e2e -- --tags "@tagname"` runs specific tagged Cucumber scenarios.
 
 **Test credentials** (E2E): set via environment variables — do not hardcode in this file.  
-The shared dev/E2E login (email **and** password) is the `E2E_EMAIL` / `E2E_PASSWORD` **fallback values baked into the `test:e2e` script in `package.json`** — read them from there. Use that account for manual sign-in at `http://localhost:3000` when verifying changes in the browser; do not register new accounts and do not commit any other credentials.  
+The shared dev/E2E login (email **and** password) is the `E2E_EMAIL` / `E2E_PASSWORD` **fallback values baked into the `test:e2e` script in `package.json`** — read them from there. This is a deliberately public, disposable test account for local/E2E environments only: it must never hold real data, and its password must never be reused anywhere. Use it for manual sign-in at `http://localhost:3000` when verifying changes in the browser; do not register new accounts and do not commit any other credentials.  
 **Admin credentials**: set via `ADMIN_EMAIL` / `ADMIN_PASSWORD` env vars and `pnpm admin:setup` — do not hardcode in this file.
 
 ---

--- a/docs/form-builder-redesign-agent-prompts.md
+++ b/docs/form-builder-redesign-agent-prompts.md
@@ -7,6 +7,8 @@ One copy-paste prompt per ticket of Epic [#226](https://github.com/dculussoftwar
 
 Every prompt already instructs the agent to: read the GitHub issue + epic, read the design docs (`docs/form-builder-redesign.md`, `docs/form-builder-redesign-implementation.md`) and open the prototype (`docs/prototypes/form-builder-redesign-prototype.html`), work on a feature branch, and open a PR. After each PR merges, tick the matching checkbox in epic #226. Recommended model: **Sonnet** (`/model sonnet`) — the design decisions are locked in the epic; tickets are execution-scoped.
 
+**Worktree note** — if the session runs in a git worktree (default under `.claude/worktrees/`), run `./scripts/setup-worktree.sh` before anything else (see the "Git Worktrees" section of `CLAUDE.md`). It copies `.env` files + local Claude settings, installs deps, builds the `@dculus/*` packages, and generates the Prisma client. The dev/E2E login for manual browser verification is the `E2E_EMAIL`/`E2E_PASSWORD` fallback pair in `package.json`'s `test:e2e` script.
+
 ---
 
 ## 1 · Issue #227 — Shell: 3 tabs, redirects, Preview overlay, Settings gear

--- a/docs/form-builder-redesign-agent-prompts.md
+++ b/docs/form-builder-redesign-agent-prompts.md
@@ -1,0 +1,250 @@
+# Form Builder Redesign — Coding-Agent Prompts
+
+One copy-paste prompt per ticket of Epic [#226](https://github.com/dculussoftwares/dculus-forms/issues/226) (Unified Content Workspace). Run them **in order** — each prompt assumes its dependency PRs are merged into `main`.
+
+**Execution order**: #227 → #228 → #229 → #230 ∥ #231 · #232 and #233 any time after #227 (parallel-safe) → #234 last.
+(∥ = can run in parallel.)
+
+Every prompt already instructs the agent to: read the GitHub issue + epic, read the design docs (`docs/form-builder-redesign.md`, `docs/form-builder-redesign-implementation.md`) and open the prototype (`docs/prototypes/form-builder-redesign-prototype.html`), work on a feature branch, and open a PR. After each PR merges, tick the matching checkbox in epic #226. Recommended model: **Sonnet** (`/model sonnet`) — the design decisions are locked in the epic; tickets are execution-scoped.
+
+---
+
+## 1 · Issue #227 — Shell: 3 tabs, redirects, Preview overlay, Settings gear
+
+```text
+Implement GitHub issue #227 of this repo (run: gh issue view 227 — follow it as the spec).
+Context first: read the epic body (gh issue view 226) for locked decisions and cross-cutting
+requirements, then docs/form-builder-redesign.md §1.3/§2.5/§2.6 and
+docs/form-builder-redesign-implementation.md §1 (route map). Open
+docs/prototypes/form-builder-redesign-prototype.html in a browser — match its app bar,
+Preview overlay, and gear placement exactly.
+
+Task: collapse the 5 builder tabs into Content | Logic | Automations:
+- TabNavigation.tsx: BuilderTab = 'content'|'logic'|'automations'; move field-count badge to
+  Content and circular-ref warning to Logic; delete the Preview/Settings tools cluster and
+  unused top/bottom position modes.
+- CollaborativeFormBuilder.tsx: new VALID_TABS/DEFAULT_TAB; content→PageBuilderTab (unchanged),
+  logic→ConditionsTab, automations→placeholder card linking to the existing automations page.
+  Redirects: layout→content?screen=intro, page-builder→content, conditions→logic,
+  preview→content?preview=1, settings→content?settings=1. Cmd+1/2/3 shortcuts updated.
+- New PreviewOverlay.tsx: full-screen Dialog hosting the existing PreviewTab as-is; opened by
+  a ▶ Preview button in FormBuilderHeader, Cmd+P, and ?preview=1; Esc closes.
+- Settings: gear in FormBuilderHeader opening a Dialog hosting SettingsTab as-is; ?settings=1
+  deep link; gear hidden for VIEWER.
+
+Mandatory: @dculus/ui components only, --tf-* tokens, no new CSS vars/hex colors; all new
+strings via useTranslation in BOTH en and ta; keep data-testid="tab-<id>".
+
+Verify: pnpm type-check, pnpm lint, pnpm test:unit pass; all five old URLs redirect; preview
+and settings overlays open via button, shortcut, and URL; E2E per the issue's policy.
+
+When done: branch feat/builder-shell-3-tabs, commit (no .env/secrets), push, open a PR titled
+"Builder redesign: 3-tab shell, redirects, preview/settings overlays" with body "Closes #227".
+```
+
+## 2 · Issue #228 — Journey rail + selection model + screenOverride canvas
+
+```text
+Implement GitHub issue #228 of this repo (run: gh issue view 228 — follow it as the spec).
+Requires #227 merged. Context first: epic body (gh issue view 226),
+docs/form-builder-redesign.md §2.1–§2.3, docs/form-builder-redesign-implementation.md §2–§3,
+and the prototype docs/prototypes/form-builder-redesign-prototype.html (left rail: Intro /
+Pages with numbered field chips / Thank You) — match it visually.
+
+Task:
+- selectionSlice.ts: add selection {kind:'intro'|'page'|'field'|'thankYou', pageId?, fieldId?}
+  + setSelection, keeping selectedPageId/selectedFieldId working as compatible derived API.
+- New hooks/useBuilderSelectionUrlSync.ts: two-way sync with ?screen=…&field=… search params.
+- New components/form-builder/rail/JourneyRail.tsx (~236px, leftmost in Content): ＋ Add
+  content button (opens existing FieldTypesPanel in a Popover for now), INTRO card, PAGES
+  section (page groups with numbered field chips, rename/duplicate/delete via existing
+  DraggablePageItem logic, add-page gated by permissions.canAddPages()), THANK YOU card.
+  DnD via the existing dnd-kit setup and the insert-slot math documented in
+  PageBuilderTab.handleDragEnd — reuse, do not reimplement. testids: rail-intro,
+  rail-page-<index>, rail-field-<fieldId>, rail-thankyou; keep pages-list and
+  add-page-button names on the rail.
+- PageBuilderTab.tsx canvas modes: intro/thankYou selections render FormRenderer
+  (mode=BUILDER, screenOverride='intro'|'thankYou', onLayoutChange=updateLayout — copy the
+  exact wiring from LayoutTab.tsx); page/field selections render FormArea unchanged.
+- PageBuilderSidebar.tsx: remove the Pages tab (rail owns it); keep Properties + JSON.
+- Keep the existing left field-types column in place — it is removed by #230, not here.
+
+Mandatory: @dculus/ui only, --tf-* tokens; i18n namespace journeyRail in BOTH en and ta;
+VIEWER = fully read-only rail; verify collab with two browser windows.
+
+Verify: pnpm type-check, pnpm lint, pnpm test:unit; rail selection drives canvas + URL and
+survives reload/back; all rail DnD paths work; E2E per the issue.
+
+When done: branch feat/builder-journey-rail, push, PR titled
+"Builder redesign: journey rail + selection model + screen canvas" with body "Closes #228".
+```
+
+## 3 · Issue #229 — Contextual right panel (Intro / Ending / page / field+logic)
+
+```text
+Implement GitHub issue #229 of this repo (run: gh issue view 229 — follow it as the spec).
+Requires #228 merged. Context first: epic body (gh issue view 226),
+docs/form-builder-redesign.md §2.2–§2.3, and the prototype's right-panel panes (Welcome
+screen / Page settings / Field / Ending) — match them.
+
+Task: make the right panel contextual on selection.kind:
+- New panels/IntroSettingsPanel.tsx composing EXISTING pieces (move, don't rebuild):
+  LayoutThumbnails, the customCTAButtonName input, and the full background block
+  (BackgroundImageUpload/Gallery, Pexels/Pixabay modals, custom color) from LayoutSidebar.tsx
+  — preserve the exact backgroundImageKey/backgroundVideoKey/backgroundDominantColor logic.
+- New panels/EndingSettingsPanel.tsx: rich-text editing of layout.thankYouContent (lift the
+  existing thank-you editor from components/form-settings/).
+- Page pane: title (updatePageTitle), duplicate/delete, permission-gated.
+- Field pane: FieldSettingsV2 unchanged + a logic-summary row "⚡ N logic rules use this
+  field →" (scan store conditions; hide when 0) linking to /builder/logic?field=<id>;
+  ConditionsTab reads ?field= and filters with a dismissible chip.
+
+Mandatory: @dculus/ui only; i18n namespaces introSettings + endingSettings in BOTH en and ta;
+VIEWER read-only; do NOT delete LayoutTab/LayoutSidebar files yet (#231 does).
+
+Verify: pnpm type-check, pnpm lint, pnpm test:unit; parity checklist from the issue (every
+old Design-tab intro control reachable and functional, incl. Pexels/Pixabay + video); collab
+sync verified in a second window; E2E per the issue.
+
+When done: branch feat/builder-contextual-panels, push, PR titled
+"Builder redesign: contextual Intro/Ending/page/field panels" with body "Closes #229".
+```
+
+## 4 · Issue #230 — Field Library: mega-panel + pin-to-dock
+
+```text
+Implement GitHub issue #230 of this repo (run: gh issue view 230 — follow it as the spec).
+Requires #228 merged. Context first: epic body (gh issue view 226),
+docs/form-builder-redesign.md §2.1 "Field Library", and the prototype (＋ Add content →
+mega-panel; 📌 Pin → docked column) — the "all field types visible in one shot" requirement
+is hard; match the prototype's grid and docked layouts.
+
+Task: new components/form-builder/field-library/FieldLibrary.tsx with two modes, both fed by
+getFieldTypesConfig + the existing drag sources from FieldTypesPanel.tsx (dnd payload
+{type:'field-type', fieldType} must stay byte-identical so every drop handler keeps working):
+- Mega-panel (default): ~560px Popover from the rail's ＋ Add content button — search input,
+  "Recently used" row (localStorage dculus.fieldLibrary.recent), Input/Choice/Content/
+  Advanced sections as a 3-column tile grid; click appends via useFieldCreation/addField,
+  drag inserts as today. Enter adds first search match; "/" opens with search focused.
+- Docked: 📌 Pin persists (localStorage dculus.fieldLibrary.pinned) a ~200px single-column
+  compact panel between rail and canvas, visually equivalent to the classic FieldTypesPanel.
+- Delete the permanent LeftSidebar mounting from PageBuilderTab.tsx (FieldTypesPanel itself
+  stays as the shared engine). Keep data-testid="field-type-<label>" on tiles.
+
+Mandatory: @dculus/ui only; i18n namespace fieldLibrary in BOTH en and ta; VIEWER: no add
+entry point, "/" inert.
+
+Verify: pnpm type-check, pnpm lint, pnpm test:unit; drag from both modes hits every existing
+drop path (insert slots, append, cross-page); pin survives reload; E2E drag scenarios
+migrated per the issue.
+
+When done: branch feat/builder-field-library, push, PR titled
+"Builder redesign: Field Library mega-panel with pin-to-dock" with body "Closes #230".
+```
+
+## 5 · Issue #231 — Design drawer + retire the Design tab
+
+```text
+Implement GitHub issue #231 of this repo (run: gh issue view 231 — follow it as the spec).
+Requires #229 merged. Context first: epic body (gh issue view 226),
+docs/form-builder-redesign.md §2.4, and the prototype's 🎨 Design drawer — match it.
+
+Task:
+- New CanvasToolbar.tsx atop the Content canvas: 🎨 Design button, desktop/mobile device
+  toggle, ▶ Preview button (relocated from the header per the prototype).
+- New design/DesignDrawer.tsx (Sheet over the right panel): LayoutThumbnails L1–L9, theme +
+  spacing + pageMode (lifted from LayoutOptions/LayoutSidebar), and the global background
+  block — extract a shared BackgroundControls.tsx used by both this drawer and
+  IntroSettingsPanel instead of duplicating. All writes via updateLayout, gated by
+  permissions.canEditLayout().
+- Delete tabs/LayoutTab.tsx and tabs/layout/LayoutSidebar.tsx; keep reused leaf components;
+  clean dead references. The /builder/layout redirect from #227 stays.
+
+Mandatory: @dculus/ui only; i18n namespace designDrawer in BOTH en and ta; run the issue's
+parity checklist — no old Design-tab capability may be lost.
+
+Verify: pnpm type-check, pnpm lint, pnpm test:unit; drawer changes sync live to canvas and a
+second collab window; E2E: replace Design-tab scenarios per the skip-tag policy.
+
+When done: branch feat/builder-design-drawer, push, PR titled
+"Builder redesign: global Design drawer, Design tab retired" with body "Closes #231".
+```
+
+## 6 · Issue #232 — Unified AI: Ask-AI pill + context seeding
+
+```text
+Implement GitHub issue #232 of this repo (run: gh issue view 232 — follow it as the spec).
+Requires #227 merged (parallel-safe with #228–#231 — guard on selection state existing).
+Context first: epic body (gh issue view 226), docs/form-builder-redesign.md §2.7, the
+prototype's ✨ Ask AI drawer (context line at top), and docs/ai-builder-chat-capabilities.md
+for the existing chat contract — do not change the backend contract.
+
+Task:
+- New AskAIPill.tsx: bottom-center pill on ALL three tabs of CollaborativeFormBuilder,
+  opening the root-mounted AIEditDrawer; replaces the corner AIFloatingButton mounting.
+- Context seeding: pass builderContext {activeTab, selection {kind,pageId?,fieldId?,
+  fieldLabel?}} into AIEditDrawer; render the context line at the drawer top; include the
+  context in the outgoing message payload following the existing initialMessage threading;
+  update live while the drawer is open.
+- Verify convergence: ConditionsTab describe-with-AI keeps flowing through the same drawer;
+  Cmd+K works on every tab; ?aiMessage= deep link unchanged.
+
+Mandatory: @dculus/ui only; i18n namespace askAI in BOTH en and ta; pill hidden for VIEWER.
+
+Verify: pnpm type-check, pnpm lint, pnpm test:unit; context line correct for intro/page/
+field/thank-you selections and reaches the request payload; condition drafting still lands
+as pending suggestions in Logic.
+
+When done: branch feat/builder-unified-ai, push, PR titled
+"Builder redesign: unified Ask-AI pill with builder-context seeding" with body "Closes #232".
+```
+
+## 7 · Issue #233 — Embed Automations as a builder tab
+
+```text
+Implement GitHub issue #233 of this repo (run: gh issue view 233 — follow it as the spec).
+Requires #227 merged (parallel-safe with #228–#232). Context first: epic body
+(gh issue view 226) and docs/form-builder-redesign.md §4.
+
+Task:
+- Nested routes /builder/automations, /builder/automations/:automationId, and
+  /builder/automations/:automationId/runs rendered inside the builder shell (FormBuilderHeader
+  + TabNavigation stay); replace #227's placeholder pane.
+- Adapt Automations.tsx / AutomationBuilder.tsx / AutomationRuns.tsx mechanically: strip
+  duplicate chrome, use the new nested paths for list↔builder↔runs navigation, fix the
+  automation canvas height inside the tab container (verify 1280×720 and 1920×1080).
+- Redirect the old /dashboard/form/:formId/automations/* routes; update every in-app
+  navigate/Link that targets them (grep '/automations' across apps/form-app/src).
+- Zero automation-feature changes — routing and chrome only.
+
+Verify: pnpm type-check, pnpm lint, pnpm test:unit; full flow list→create→configure→runs
+works inside the tab; all old URLs redirect; E2E automations scenarios migrated per policy.
+
+When done: branch feat/builder-automations-embed, push, PR titled
+"Builder redesign: automations embedded as builder tab" with body "Closes #233".
+```
+
+## 8 · Issue #234 — Polish & release hardening
+
+```text
+Implement GitHub issue #234 of this repo (run: gh issue view 234 — follow it as the spec).
+Requires ALL other epic #226 tickets merged. Context first: epic body (gh issue view 226).
+
+Task (six workstreams, per the issue):
+1. ⚡ logic badges on rail field chips (shared getRulesForField helper; deep link to
+   /builder/logic?field=<id>).
+2. Shortcut audit: Cmd+1/2/3, Cmd+P, Cmd+K, "/", layered Esc; none fire while typing.
+3. One-time coach marks (rail / Design / gear) via @dculus/ui primitives, localStorage-
+   flagged, suppressed in E2E runs.
+4. JSON debug view: removed from the panel, re-homed behind a dev-only header menu entry.
+5. i18n audit of every file the epic touched — all epic namespaces complete in en AND ta.
+6. E2E consolidation: every @skip-ci introduced by this epic re-enabled or replaced
+   (grep -rn "@skip-ci" test/); add the end-to-end journey scenario from the issue.
+
+Verify: pnpm type-check, pnpm lint, pnpm test:unit, pnpm test:e2e all green; zero epic-
+introduced @skip-ci remaining.
+
+When done: branch feat/builder-redesign-polish, push, PR titled
+"Builder redesign: polish + release hardening" with body "Closes #234". After merge, tick
+the last checkbox on epic #226 and close it with a summary comment.
+```

--- a/docs/form-builder-redesign-agent-prompts.md
+++ b/docs/form-builder-redesign-agent-prompts.md
@@ -7,6 +7,10 @@ One copy-paste prompt per ticket of Epic [#226](https://github.com/dculussoftwar
 
 Every prompt already instructs the agent to: read the GitHub issue + epic, read the design docs (`docs/form-builder-redesign.md`, `docs/form-builder-redesign-implementation.md`) and open the prototype (`docs/prototypes/form-builder-redesign-prototype.html`), work on a feature branch, and open a PR. After each PR merges, tick the matching checkbox in epic #226. Recommended model: **Sonnet** (`/model sonnet`) — the design decisions are locked in the epic; tickets are execution-scoped.
 
+**Shared requirements for every ticket** (in addition to what each prompt says):
+- Before every commit: review `git status` and the staged `git diff`; stage only intended files and **stop immediately** if any `.env` file, key, token, password, or other credential appears — this repo is public.
+- `pnpm test:unit` only runs the **backend** suite. Frontend tickets must also run the form-app suite: `pnpm --filter form-app test`. Treat every "Verify:" line below as including both.
+
 **Worktree note** — if the session runs in a git worktree (default under `.claude/worktrees/`), run `./scripts/setup-worktree.sh` before anything else (see the "Git Worktrees" section of `CLAUDE.md`). It copies `.env` files + local Claude settings, installs deps, builds the `@dculus/*` packages, and generates the Prisma client. The dev/E2E login for manual browser verification is the `E2E_EMAIL`/`E2E_PASSWORD` fallback pair in `package.json`'s `test:e2e` script.
 
 ---
@@ -37,7 +41,7 @@ Task: collapse the 5 builder tabs into Content | Logic | Automations:
 Mandatory: @dculus/ui components only, --tf-* tokens, no new CSS vars/hex colors; all new
 strings via useTranslation in BOTH en and ta; keep data-testid="tab-<id>".
 
-Verify: pnpm type-check, pnpm lint, pnpm test:unit pass; all five old URLs redirect; preview
+Verify: pnpm type-check, pnpm lint, pnpm test:unit, pnpm --filter form-app test pass; all five old URLs redirect; preview
 and settings overlays open via button, shortcut, and URL; E2E per the issue's policy.
 
 When done: branch feat/builder-shell-3-tabs, commit (no .env/secrets), push, open a PR titled
@@ -74,7 +78,7 @@ Task:
 Mandatory: @dculus/ui only, --tf-* tokens; i18n namespace journeyRail in BOTH en and ta;
 VIEWER = fully read-only rail; verify collab with two browser windows.
 
-Verify: pnpm type-check, pnpm lint, pnpm test:unit; rail selection drives canvas + URL and
+Verify: pnpm type-check, pnpm lint, pnpm test:unit, pnpm --filter form-app test; rail selection drives canvas + URL and
 survives reload/back; all rail DnD paths work; E2E per the issue.
 
 When done: branch feat/builder-journey-rail, push, PR titled
@@ -104,7 +108,7 @@ Task: make the right panel contextual on selection.kind:
 Mandatory: @dculus/ui only; i18n namespaces introSettings + endingSettings in BOTH en and ta;
 VIEWER read-only; do NOT delete LayoutTab/LayoutSidebar files yet (#231 does).
 
-Verify: pnpm type-check, pnpm lint, pnpm test:unit; parity checklist from the issue (every
+Verify: pnpm type-check, pnpm lint, pnpm test:unit, pnpm --filter form-app test; parity checklist from the issue (every
 old Design-tab intro control reachable and functional, incl. Pexels/Pixabay + video); collab
 sync verified in a second window; E2E per the issue.
 
@@ -136,7 +140,7 @@ getFieldTypesConfig + the existing drag sources from FieldTypesPanel.tsx (dnd pa
 Mandatory: @dculus/ui only; i18n namespace fieldLibrary in BOTH en and ta; VIEWER: no add
 entry point, "/" inert.
 
-Verify: pnpm type-check, pnpm lint, pnpm test:unit; drag from both modes hits every existing
+Verify: pnpm type-check, pnpm lint, pnpm test:unit, pnpm --filter form-app test; drag from both modes hits every existing
 drop path (insert slots, append, cross-page); pin survives reload; E2E drag scenarios
 migrated per the issue.
 
@@ -165,7 +169,7 @@ Task:
 Mandatory: @dculus/ui only; i18n namespace designDrawer in BOTH en and ta; run the issue's
 parity checklist — no old Design-tab capability may be lost.
 
-Verify: pnpm type-check, pnpm lint, pnpm test:unit; drawer changes sync live to canvas and a
+Verify: pnpm type-check, pnpm lint, pnpm test:unit, pnpm --filter form-app test; drawer changes sync live to canvas and a
 second collab window; E2E: replace Design-tab scenarios per the skip-tag policy.
 
 When done: branch feat/builder-design-drawer, push, PR titled
@@ -193,7 +197,7 @@ Task:
 
 Mandatory: @dculus/ui only; i18n namespace askAI in BOTH en and ta; pill hidden for VIEWER.
 
-Verify: pnpm type-check, pnpm lint, pnpm test:unit; context line correct for intro/page/
+Verify: pnpm type-check, pnpm lint, pnpm test:unit, pnpm --filter form-app test; context line correct for intro/page/
 field/thank-you selections and reaches the request payload; condition drafting still lands
 as pending suggestions in Logic.
 
@@ -219,7 +223,7 @@ Task:
   navigate/Link that targets them (grep '/automations' across apps/form-app/src).
 - Zero automation-feature changes — routing and chrome only.
 
-Verify: pnpm type-check, pnpm lint, pnpm test:unit; full flow list→create→configure→runs
+Verify: pnpm type-check, pnpm lint, pnpm test:unit, pnpm --filter form-app test; full flow list→create→configure→runs
 works inside the tab; all old URLs redirect; E2E automations scenarios migrated per policy.
 
 When done: branch feat/builder-automations-embed, push, PR titled
@@ -243,7 +247,7 @@ Task (six workstreams, per the issue):
 6. E2E consolidation: every @skip-ci introduced by this epic re-enabled or replaced
    (grep -rn "@skip-ci" test/); add the end-to-end journey scenario from the issue.
 
-Verify: pnpm type-check, pnpm lint, pnpm test:unit, pnpm test:e2e all green; zero epic-
+Verify: pnpm type-check, pnpm lint, pnpm test:unit, pnpm --filter form-app test, pnpm test:e2e all green; zero epic-
 introduced @skip-ci remaining.
 
 When done: branch feat/builder-redesign-polish, push, PR titled

--- a/docs/form-builder-redesign-implementation.md
+++ b/docs/form-builder-redesign-implementation.md
@@ -1,0 +1,89 @@
+# Form Builder Redesign — Implementation Plan
+
+> Companion to [`form-builder-redesign.md`](./form-builder-redesign.md) (read that first).
+> No backend/schema changes required for phases 1–6. All state stays in the existing
+> Zustand ⇄ Y.js store, so real-time collaboration works unchanged.
+
+---
+
+## 1. Route map
+
+```
+NEW (canonical)                                  OLD → redirect
+/dashboard/form/:id/builder/content              /builder/page-builder → /builder/content
+  ?screen=intro | thankyou | page:<pageId>       /builder/layout       → /builder/content?screen=intro
+  &field=<fieldId>                               /builder/preview      → /builder/content + preview overlay open
+/dashboard/form/:id/builder/logic                /builder/conditions   → /builder/logic
+/dashboard/form/:id/builder/automations          /dashboard/form/:id/automations/* → /builder/automations/*
+/dashboard/form/:id/builder/settings (overlay route, opened by header ⚙)
+```
+
+`BuilderTab` type becomes `'content' | 'logic' | 'automations'`. Selection (`screen`, `field`)
+lives in search params so deep links, browser back, and E2E tests can target exact states.
+
+## 2. Component mapping — reuse first
+
+| New piece | Built from (existing) | New work |
+|---|---|---|
+| Top nav (3 tabs) | `TabNavigation` inline mode | Trim rail to 3 entries; keep count/warning badges; drop Preview/Settings cluster (move to toolbar/header) |
+| **Journey rail** | `DraggablePageItem`, `PageBuilderSidebar` pages tab, dnd-kit `SortableContext` | New `JourneyRail` component: INTRO / PAGES / THANK YOU sections; expandable page cards listing field chips (icon + label + ⚡ logic badge); `+ Add content` button |
+| Field Library (mega-panel + pin-to-dock) | `FieldTypesPanel` (grouped categories, draggable items), `AddFieldPopover` | New `FieldLibrary` shell with two render modes: 3-col grid mega-panel (search + recently-used + keyboard nav) and docked compact column (visually ≈ today's panel); pin state in `localStorage`; drag-to-canvas AND click-to-append in both modes |
+| Canvas — page mode | `PageBuilderFormArea`, `PageBuilderFieldCard`, `DropIndicator`, drag/drop handlers from `PageBuilderTab` | Extract DnD orchestration into a hook shared by rail + canvas |
+| Canvas — intro / thank-you mode | `FormRenderer` (`mode=BUILDER`, `screenOverride='intro'|'thankYou'`) — already shipped, used by today's `LayoutTab` | Wire selection → `screenOverride`; keep inline rich-text editing |
+| Canvas toolbar | `PreviewTab` device toggle, new Design + Preview buttons | Small new component |
+| Right panel — field | `FieldSettingsV2` (auto-switch on selection already implemented) | Add "Logic on this field" summary row (uses `conditions` from store) |
+| Right panel — intro | `LayoutThumbnails` (L1–L9), CTA input, background controls from `LayoutSidebar` | New `IntroSettingsPanel` composing them; per-screen framing |
+| Right panel — thank-you | thank-you content controls (rich text) | New `EndingSettingsPanel`; stub sections for future redirect/share |
+| Design drawer (global) | `LayoutSidebar` (thumbnails, theme, spacing, background + Pexels/Pixabay modals) | Re-house in a `Sheet`/drawer; remove screen toggle (now the rail's job) |
+| Preview overlay | `PreviewTab` (mobile CSS overrides, test-submit flow) | Wrap in full-screen `Dialog`; `Cmd+P`; open via `?preview=1` for the old-route redirect |
+| Settings overlay | `SettingsTab` / `FormSettingsContainer` | Route-driven overlay from header ⚙ |
+| Logic tab | `ConditionsTab` unchanged | Accept `?field=` filter for deep links |
+| Automations tab | `Automations`, `AutomationBuilder`, `AutomationRuns` pages | Render inside builder shell (keep `FormBuilderHeader`); old routes redirect |
+| **Unified AI** | `AIEditDrawer`, `AIFloatingButton`, pending-condition-suggestion flow | Mount drawer at builder root (all tabs); "✨ Ask AI" pill on every tab; seed context `{activeTab, selectedScreen, selectedPageId, selectedFieldId}` into the drawer's initial system context; route automation asks to automation tools |
+
+Deleted after migration: `LayoutTab` (contents absorbed), standalone Preview/Settings tabs,
+permanent left field-types column, JSON tab (moves behind a dev toggle in the ⚙ menu).
+
+## 3. Store changes (Zustand only — no Y.js schema change)
+
+- `selectionSlice`: generalize `selectedFieldId`/`selectedPageId` into
+  `selection: { kind: 'intro' | 'page' | 'field' | 'thankYou'; pageId?; fieldId? }`
+  (keep old selectors as derived getters so `FieldSettingsV2`, `FormArea`, tests keep working).
+- URL ⇄ store sync hook (`useBuilderSelectionUrlSync`) mapping `?screen`/`?field` to selection.
+- No changes to `fieldsSlice` / `pagesSlice` / `layoutSlice` mutations — rail and panels call the
+  same actions (`updateLayout`, `addFieldAtIndex`, `reorderPages`, …).
+
+## 4. Phases (each independently shippable)
+
+| Phase | Scope | Notes |
+|---|---|---|
+| **P1 — Shell** | New 3-tab nav, routes + redirects, header ⚙ settings overlay, preview overlay behind ▶ | Old tabs still render inside new shell; zero behavior change otherwise |
+| **P2 — Journey rail** | `JourneyRail` replaces right-sidebar Pages tab + left column stays temporarily; Intro/Thank-You cards render `screenOverride` canvas | The "unified content" moment |
+| **P3 — Contextual right panel** | `IntroSettingsPanel`, `EndingSettingsPanel`, field logic summary row | Design tab now redundant for screens |
+| **P4 — Add-content popover + Design drawer** | Remove permanent field-types column; global design drawer; delete `LayoutTab` | Canvas gains ~300px |
+| **P5 — Unified AI** | Root-mounted drawer, per-tab pill, selection context seeding, logic + automation tool routing | Depends on P1 only — can run parallel to P2–P4 |
+| **P6 — Automations embed** | Move automation pages under `/builder/automations`, redirects | Mostly routing/chrome work |
+| **P7 — Polish** | Keyboard shortcuts (Cmd+1/2/3 = tabs, Cmd+P preview), rail ⚡ badges, empty states, i18n audit, E2E migration | |
+
+## 5. Testing & i18n checklist
+
+- **i18n**: new namespaces `journeyRail`, `introSettings`, `endingSettings`, `designDrawer`,
+  `askAI` — each registered in `locales/index.ts` for **both `en` and `ta`**.
+- **E2E**: keep `data-testid`s: `tab-*`, `pages-list`, `add-page-button`, `draggable-field-*`,
+  `layout-screen-toggle-*` (re-point to rail cards: `rail-intro`, `rail-page-<n>`,
+  `rail-thankyou`), `new-page-builder-tab` → `content-workspace`. Update Cucumber steps that
+  navigate to `/builder/page-builder` etc. — redirects keep them passing during migration, then
+  migrate step definitions.
+- **Permissions**: rail/canvas/panels all consult `useFormPermissions` exactly as the components
+  they're built from; VIEWER = read-only rail (no drag, no add), settings panels disabled.
+- **Collab**: multi-client test — page reorder from client A while client B has intro selected;
+  selection is local-only state, so no conflict surface is added.
+
+## 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| DnD regressions when rail + canvas share one `DndContext` | Extract current collision strategy into shared hook; keep existing insert-slot math (documented in `PageBuilderTab.handleDragEnd`) untouched |
+| Users lost by moved Design/Preview/Settings | Redirects + one-time "things moved" coach marks on first open |
+| Inline intro/thank-you editing conflicts with canvas selection | Intro/thank-you canvas is `FormRenderer`-owned (already works on Design tab today); only selection wiring is new |
+| Automations embed inherits builder header actions that don't apply | Header stays; tab content controls its own sub-toolbar (list/canvas/runs) |

--- a/docs/form-builder-redesign-implementation.md
+++ b/docs/form-builder-redesign-implementation.md
@@ -8,7 +8,7 @@
 
 ## 1. Route map
 
-```
+```text
 NEW (canonical)                                  OLD → redirect
 /dashboard/form/:id/builder/content              /builder/page-builder → /builder/content
   ?screen=intro | thankyou | page:<pageId>       /builder/layout       → /builder/content?screen=intro
@@ -29,7 +29,7 @@ lives in search params so deep links, browser back, and E2E tests can target exa
 | **Journey rail** | `DraggablePageItem`, `PageBuilderSidebar` pages tab, dnd-kit `SortableContext` | New `JourneyRail` component: INTRO / PAGES / THANK YOU sections; expandable page cards listing field chips (icon + label + ⚡ logic badge); `+ Add content` button |
 | Field Library (mega-panel + pin-to-dock) | `FieldTypesPanel` (grouped categories, draggable items), `AddFieldPopover` | New `FieldLibrary` shell with two render modes: 3-col grid mega-panel (search + recently-used + keyboard nav) and docked compact column (visually ≈ today's panel); pin state in `localStorage`; drag-to-canvas AND click-to-append in both modes |
 | Canvas — page mode | `PageBuilderFormArea`, `PageBuilderFieldCard`, `DropIndicator`, drag/drop handlers from `PageBuilderTab` | Extract DnD orchestration into a hook shared by rail + canvas |
-| Canvas — intro / thank-you mode | `FormRenderer` (`mode=BUILDER`, `screenOverride='intro'|'thankYou'`) — already shipped, used by today's `LayoutTab` | Wire selection → `screenOverride`; keep inline rich-text editing |
+| Canvas — intro / thank-you mode | `FormRenderer` (`mode=BUILDER`, `screenOverride='intro' / 'thankYou'`) — already shipped, used by today's `LayoutTab` | Wire selection → `screenOverride`; keep inline rich-text editing |
 | Canvas toolbar | `PreviewTab` device toggle, new Design + Preview buttons | Small new component |
 | Right panel — field | `FieldSettingsV2` (auto-switch on selection already implemented) | Add "Logic on this field" summary row (uses `conditions` from store) |
 | Right panel — intro | `LayoutThumbnails` (L1–L9), CTA input, background controls from `LayoutSidebar` | New `IntroSettingsPanel` composing them; per-screen framing |

--- a/docs/form-builder-redesign.md
+++ b/docs/form-builder-redesign.md
@@ -35,7 +35,7 @@ Content, one **journey rail** on the left that lists everything the respondent w
 
 ### 1.3 Target information architecture
 
-```
+```text
 CURRENT                                    PROPOSED
 ───────────────────────────────            ───────────────────────────────
 Design | Build | Logic | Preview | Settings    Content | Logic | Automations
@@ -60,12 +60,12 @@ being top-level destinations.
 
 ## 2. The Content workspace — detailed design
 
-The Content tab is a persistent **3-pane layout**: journey rail (left, 264px) · canvas (center,
+The Content tab is a persistent **3-pane layout**: journey rail (left, ~236px — canonical width, matches the prototype) · canvas (center,
 fluid) · contextual panel (right, 320px resizable — reuses today's resize handle).
 
 ### 2.1 Mode A — a Page is selected (default landing state)
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────────────────────────────┐
 │ ← Customer Feedback ✎        Content · Logic · Automations        Share  Publish  ⚙ │
 ├───────────────┬──────────────────────────────────────────────────┬───────────────────┤
@@ -124,7 +124,7 @@ fluid) · contextual panel (right, 320px resizable — reuses today's resize han
 
 Clicking the **Welcome** card flips all three panes together:
 
-```
+```text
 ┌───────────────┬──────────────────────────────────────────────────┬───────────────────┐
 │ + Add content │  🎨 Design   💻/📱   ▶ Preview                   │  WELCOME SCREEN   │
 │               │                                                  │  ───────────────  │
@@ -193,7 +193,7 @@ surface. Three entry points, three behaviors — no single "the AI" the user can
 
 The redesign makes AI **one ambient layer over the whole builder**:
 
-```
+```text
             ┌────────────────────────────────────────────┐
             │        ✨ Ask AI anything…             ➤   │   ← one pill, every tab
             └────────────────────────────────────────────┘

--- a/docs/form-builder-redesign.md
+++ b/docs/form-builder-redesign.md
@@ -1,0 +1,266 @@
+# Form Builder Redesign — Unified Content Workspace
+
+> Status: **Proposal** · Author: UX deep-dive with Claude · Date: 2026-07-28
+> Companion doc: [`form-builder-redesign-implementation.md`](./form-builder-redesign-implementation.md)
+
+---
+
+## 1. Why redesign — the business case
+
+### 1.1 Problems with the current builder
+
+The builder today has **5 sibling tabs** (`Design → Build → Logic | Preview · Settings`), and
+Automations lives on a **completely separate route** outside the builder shell.
+
+| Problem | Evidence in current UX | Cost |
+|---|---|---|
+| **Tab ping-pong** | Editing a form = Build (fields) → Design (look) → Preview (check) → Build … Each hop is a full context switch with different sidebars. | Slow iteration loop; the #1 activity (tweak → check) needs 2 navigations every cycle. |
+| **Intro / Thank You are buried** | They only exist as a small 3-way toggle *inside* the Design tab. Users editing questions in Build never see them. | Low discoverability → forms ship with default welcome/thank-you screens → weaker respondent experience → lower completion rates. |
+| **Design is global-only and separated from content** | Layout (L1–L9), background, CTA text live in Design, but the CTA belongs to the Intro screen and thank-you content belongs to the ending. | Users can't find "where do I change the start button text?" — it's a *screen* property presented as a *theme* property. |
+| **Automations are orphaned** | `/dashboard/form/:id/automations` is a separate page tree with its own chrome. | Feature invisible from the builder → low adoption of a differentiating feature. |
+| **Preview is a destination, not a glance** | Full tab switch, loses selection state. | Users check less often; errors caught later. |
+| **AI is fragmented** | Build tab has the Cmd+K `AIEditDrawer`; Conditions has its own "describe with AI" input; automations AI is a separate surface again. | No unified "the assistant" — users can't build a habit around one entry point, and cross-domain asks ("add a question and alert me on low scores") are impossible. |
+
+### 1.2 What Typeform gets right (reference: `screenshot/`)
+
+Typeform's builder has exactly **three top-level modes** — `Content · Workflow · Connect` — and inside
+Content, one **journey rail** on the left that lists everything the respondent will see, in order:
+**Welcome screen → questions → Endings**. Key principles worth adopting:
+
+1. **The left rail *is* the respondent journey.** One ordered list, one mental model. No separate "design vs build" split.
+2. **Selection drives everything.** Click the Welcome screen → the canvas shows it AND the right panel becomes Welcome-screen settings (button text, time-to-complete, image/video). Click a question → question settings. Nothing is more than one click from its context.
+3. **Design is a tool, not a place.** A "Design" button opens theme controls over the canvas; you keep seeing your content while restyling it.
+4. **Preview is instant** — play button in the toolbar, overlay, no navigation.
+5. **AI entry point is ambient** — "Chat to create" bar floats at the bottom of the canvas.
+
+### 1.3 Target information architecture
+
+```
+CURRENT                                    PROPOSED
+───────────────────────────────            ───────────────────────────────
+Design | Build | Logic | Preview | Settings    Content | Logic | Automations
+  │        │      │        │         │            │        │         │
+  │        │      │        │         └ Settings   │        │         └ embedded automations
+  │        │      │        └ full-tab preview     │        └ condition rules (kept, + rail badges)
+  │        │      └ condition rules               │
+  │        └ fields/pages editor                  └ ONE workspace:
+  └ layout/theme + intro/thankyou toggle              rail:   Intro · Pages · Thank You
+                                                      canvas: WYSIWYG of selected screen
+Automations = separate route                          right:  contextual settings
+                                                      tools:  Design drawer · Preview overlay
+                                                      header: Share · Publish · Settings (gear)
+```
+
+Naming note: the top-level tabs mirror Typeform's `Content / Workflow / Connect` but use our
+domain words: **Content** (what respondents see), **Logic** (existing Conditions — "Logic" reads
+better next to Content), **Automations** (what happens after submit). Settings and Preview stop
+being top-level destinations.
+
+---
+
+## 2. The Content workspace — detailed design
+
+The Content tab is a persistent **3-pane layout**: journey rail (left, 264px) · canvas (center,
+fluid) · contextual panel (right, 320px resizable — reuses today's resize handle).
+
+### 2.1 Mode A — a Page is selected (default landing state)
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────────┐
+│ ← Customer Feedback ✎        Content · Logic · Automations        Share  Publish  ⚙ │
+├───────────────┬──────────────────────────────────────────────────┬───────────────────┤
+│ + Add content │  ┌─ canvas toolbar ────────────────────────────┐ │  PAGE 1 SETTINGS  │
+│               │  │ 🎨 Design   💻/📱   ▶ Preview               │ │  ───────────────  │
+│ INTRO         │  └─────────────────────────────────────────────┘ │  Title            │
+│ ┌───────────┐ │                                                  │  [About you     ] │
+│ │▛ Welcome  │ │   ┌────────────────────────────────────────┐    │                   │
+│ └───────────┘ │   │  Page 1 · About you                    │    │  — or, with a     │
+│               │   │                                        │    │  field selected → │
+│ PAGES     ⊕  │   │  ┌──────────────────────────────────┐  │    │                   │
+│ ┌───────────┐ │   │  │ 1 What is your full name?     ⠿ │  │    │  FIELD SETTINGS   │
+│ │≡ Page 1   │ │   │  └──────────────────────────────────┘  │    │  (FieldSettingsV2)│
+│ │ ├ 1 Name  │ │   │  ┌──────────────────────────────────┐  │    │  Label, required, │
+│ │ ├ 2 Email │ │   │  │ 2 What is your email?    [sel] ⠿ │  │    │  validation,      │
+│ │ └ 3 Phone │ │   │  └──────────────────────────────────┘  │    │  options…         │
+│ ├───────────┤ │   │      + Add field (popover)             │    │                   │
+│ │≡ Page 2   │ │   └────────────────────────────────────────┘    │  ⚡ Logic on this │
+│ └───────────┘ │                                                  │  field → 2 rules  │
+│               │                                                  │                   │
+│ THANK YOU     │   ┌────────────────────────────────────────┐    │                   │
+│ ┌───────────┐ │   │      ✨ Chat to create…            ➤  │    │                   │
+│ │▟ Thanks!  │ │   └────────────────────────────────────────┘    │                   │
+│ └───────────┘ │                                                  │                   │
+└───────────────┴──────────────────────────────────────────────────┴───────────────────┘
+```
+
+- **Rail** — merges today's right-sidebar "Pages" tab with two fixed sections. Page cards expand
+  to show their fields as numbered chips (type icon + truncated label, exactly like Typeform's
+  question list). Drag to reorder pages, fields, and move fields across pages (all store actions
+  already exist: `reorderPages`, `reorderFields`, `moveFieldBetweenPages`).
+- **`+ Add content` → the Field Library** — one primary button (top of rail, Typeform-style).
+  The old builder's best trait — *seeing every field type in a single shot* — is preserved and
+  improved, not popover-ized away:
+  - Opens a **mega-panel** (~560px wide, anchored beside the rail): a 3-column grid of **all**
+    field types with icons, grouped Input / Choice / Content / Advanced — *more* visible at once
+    than the old 288px single column, plus a **search box** with keyboard navigation
+    (type "em" ↵ to add an Email field) and a "Recently used" row on top.
+  - Tiles are **draggable onto the canvas** exactly like the old panel (same dnd-kit sources);
+    clicking a tile appends to the selected page.
+  - A **📌 pin control docks the library** as a persistent compact column between rail and
+    canvas — the old always-visible palette, one click away for power users, remembered per
+    user (`localStorage`). Unpinned (default) the canvas keeps the ~300px it gained.
+  - Keyboard: `/` or `F` opens the library with search focused; Esc closes.
+
+  This replaces the permanent 288px left field-types column for everyone who doesn't pin it,
+  while pinners lose nothing relative to today.
+- **Canvas** — the current `FormArea` (field cards, drop indicators, inline add). Unchanged
+  interaction model; gains the toolbar.
+- **Right panel** — contextual: page selected → page settings; field selected → `FieldSettingsV2`
+  (auto-switch behavior already exists). New: a **Logic summary** row showing rules touching the
+  selected field, deep-linking to the Logic tab. The JSON debug view moves behind a dev-only
+  toggle in the ⚙ menu.
+
+### 2.2 Mode B — Intro selected  ← the key UX upgrade
+
+Clicking the **Welcome** card flips all three panes together:
+
+```
+┌───────────────┬──────────────────────────────────────────────────┬───────────────────┐
+│ + Add content │  🎨 Design   💻/📱   ▶ Preview                   │  WELCOME SCREEN   │
+│               │                                                  │  ───────────────  │
+│ INTRO         │   ┌────────────────────────────────────────┐    │  Layout           │
+│ ┌───────────┐ │   │                                        │    │  ┌──┐┌──┐┌──┐    │
+│ │▛ Welcome ●│ │   │        Customer Feedback               │    │  │L1││L2││L3│ …  │
+│ └───────────┘ │   │   We'd love to hear what you think.    │    │  └──┘└──┘└──┘    │
+│               │   │   (inline-editable rich text —         │    │  (L1–L9 thumbs)   │
+│ PAGES     ⊕  │   │    FormRenderer BUILDER mode,           │    │                   │
+│ ┌───────────┐ │   │    screenOverride='intro')             │    │  Button text      │
+│ │≡ Page 1   │ │   │                                        │    │  [ Start ]  5/24  │
+│ ├───────────┤ │   │          ┌─────────┐                   │    │                   │
+│ │≡ Page 2   │ │   │          │  Start  │                   │    │  Background       │
+│ └───────────┘ │   │          └─────────┘                   │    │  ○ Color  [#…]    │
+│               │   │                                        │    │  ○ Image / Video  │
+│ THANK YOU     │   └────────────────────────────────────────┘    │    [Upload]       │
+│ ┌───────────┐ │                                                  │    [Pexels]       │
+│ │▟ Thanks!  │ │                                                  │    [Pixabay]      │
+│ └───────────┘ │                                                  │                   │
+└───────────────┴──────────────────────────────────────────────────┴───────────────────┘
+```
+
+This is exactly what the user asked for: *"on intro click, field types should change with layout
+options."* Since the left column is now a journey rail (not a field-types column), the morph
+happens in the **right panel**: field settings are replaced by **screen settings** — layout
+thumbnails, CTA button text (`customCTAButtonName`, today hidden in Design), and the background
+controls (today's `LayoutSidebar` background section). The canvas renders the real intro screen
+via the already-shipped `screenOverride='intro'`.
+
+### 2.3 Mode C — Thank You selected
+
+Same pattern: canvas renders `screenOverride='thankYou'` with the rich-text thank-you content
+inline-editable; right panel shows **Ending settings**: thank-you content controls, and (future)
+redirect URL, social share buttons, "create your own form" branding toggle — the panel gives these
+a natural home that doesn't exist today. The rail section is named **Thank You** now but is built
+as an "Endings" list (array of one) so conditional multiple endings can land later without another
+redesign — Typeform's Endings section validates this direction.
+
+### 2.4 Design drawer — theme as a tool, not a tab
+
+The 🎨 **Design** button in the canvas toolbar opens a right-side drawer *over* the contextual
+panel (or replaces it while open), containing the **global** look controls from today's Design
+tab: L1–L9 layout thumbnails, theme/text color, spacing, page mode, global background. Screen-
+specific things (CTA text, per-screen backgrounds if we add them) stay in the screen's contextual
+panel. You restyle while watching your actual content re-render live — the tightest possible
+feedback loop, and the Design *tab* disappears.
+
+### 2.5 Preview overlay
+
+▶ opens a **full-screen overlay** (Esc / ✕ to close) reusing `PreviewTab`'s renderer with its
+desktop/mobile toggle and test-submission flow. No navigation, selection state preserved, always
+one keystroke away (`Cmd+P`).
+
+### 2.6 Settings
+
+Form settings (title, short URL, submission limits, access control, respondent-email copy) are
+administrative, not creative — they move to the **⚙ gear in the header**, opening a focused
+settings overlay/route (`/builder/settings` still works as a deep link). This keeps the top nav
+purely about the three creative modes.
+
+### 2.7 Unified AI — one assistant, everywhere
+
+Today the AI experience is fragmented: an `AIEditDrawer` on the Build tab (Cmd+K), a separate
+"describe with AI" input inside Conditions, and automation agent prompts live in yet another
+surface. Three entry points, three behaviors — no single "the AI" the user can trust.
+
+The redesign makes AI **one ambient layer over the whole builder**:
+
+```
+            ┌────────────────────────────────────────────┐
+            │        ✨ Ask AI anything…             ➤   │   ← one pill, every tab
+            └────────────────────────────────────────────┘
+   Content tab:  "add a rating question after email"      → edits fields/pages
+                 "make the welcome screen friendlier"     → edits intro content
+   Logic tab:    "hide page 3 unless they pick 'Other'"   → drafts a pending rule
+   Automations:  "send responses to a Google Sheet"       → scaffolds an automation
+```
+
+- **One entry point** — the bottom-center "✨ Ask AI" pill (Typeform's "Chat to create" position)
+  plus `Cmd+K`, on **all three tabs**. Both open the same drawer with the same conversation.
+- **Context-aware** — the drawer is seeded with builder context: active tab, selected screen
+  (intro / page / thank-you), selected field. "Make this required" just works because the AI
+  knows what *this* is.
+- **One conversation, cross-domain tools** — content edits, condition-rule drafting
+  (`upsertConditionRule` pending-suggestion flow already exists), and automation scaffolding are
+  tools of the *same* assistant, so "add a satisfaction question and email me low scores"
+  resolves in one thread instead of three UIs.
+- **Suggestions render where they land** — AI-drafted conditions still appear as pending cards in
+  Logic; AI-added fields highlight in the rail and canvas (existing drop-highlight animation).
+  The AI never feels like a separate app writing to your form from outside.
+- Existing deep links ("Fix with AI" from analytics, `?aiMessage=`) keep working — they open the
+  same unified drawer.
+
+---
+
+## 3. Logic tab
+
+Kept as a top-level tab (dculus conditions are cross-page rules, which fit a dedicated surface
+better than Typeform's per-question branching), with three additions:
+
+1. **Rail badges in Content** — a small ⚡ on rail field chips that have rules, so logic is
+   visible where content is edited.
+2. **Field → Logic deep link** — "Logic on this field" row in field settings (see Mode A) opens
+   the Logic tab pre-filtered to that field's rules.
+3. Existing circular-reference warning badge moves onto the new tab trigger unchanged.
+
+---
+
+## 4. Automations tab
+
+The existing Automations pages (`Automations`, `AutomationBuilder`, `AutomationRuns`) are
+**embedded into the builder shell** as the third tab, keeping the builder header (title, Share,
+Publish, presence). List → canvas builder → runs become in-tab views. Old routes 301-redirect.
+This turns an orphaned feature into a first-class step of form creation, mirroring Typeform's
+"Connect" placement — the moment users finish content is exactly when "what happens with
+responses?" is on their mind.
+
+---
+
+## 5. What this wins
+
+| Metric to watch | Expected effect |
+|---|---|
+| Intro/Thank-You customization rate | ↑ sharply — screens are now first-class rail items instead of a hidden toggle |
+| Time from edit → preview | ~0 (overlay) vs. 2 navigations today |
+| Automation creation per form | ↑ — promoted into the builder journey |
+| Canvas width on 13" laptops | +~300px (field-types column → popover) |
+| Nav complexity | 5 tabs + external route → 3 tabs |
+| AI usage breadth | ↑ — one assistant reachable from every tab, seeded with selection context, able to act across content + logic + automations in one thread |
+
+## 6. Risks / constraints honored
+
+- **Collaboration**: no data-model change — same Zustand ⇄ Y.js store; rail/canvas/panels are
+  views over existing state. Presence and permission gating (`VIEWER` read-only) apply per pane
+  exactly as today.
+- **i18n**: every new string ships in `en` + `ta` namespaces (mandatory).
+- **E2E**: existing `data-testid`s preserved where components are reused; redirects keep old
+  `/builder/layout|page-builder|preview|settings` URLs working (see implementation doc).
+- **No backend change** for phases 1–5; multiple endings (future) would need schema work.

--- a/docs/prototypes/form-builder-redesign-prototype.html
+++ b/docs/prototypes/form-builder-redesign-prototype.html
@@ -1,0 +1,755 @@
+<title>Dculus Forms — Builder Redesign Prototype</title>
+<style>
+:root{
+  --bg:#f7f5f8; --paper:#ffffff; --ink:#2e2733; --muted:#756c7c;
+  --border:#e5e0e8; --border-soft:#efecf2;
+  --accent:#6b4fd8; --accent-ink:#ffffff; --accent-soft:#f0ecfb;
+  --warn:#b45309; --warn-bg:#fdf0d9;
+  --canvas:#fbfafc; --shadow:0 1px 2px rgba(46,39,51,.06),0 8px 24px rgba(46,39,51,.07);
+}
+@media (prefers-color-scheme: dark){
+  :root{
+    --bg:#141118; --paper:#1e1a23; --ink:#ece8f0; --muted:#a49aad;
+    --border:#372f3e; --border-soft:#2a2430;
+    --accent:#a08cf0; --accent-ink:#1b1030; --accent-soft:#2c2445;
+    --warn:#e8a44a; --warn-bg:#3a2c14;
+    --canvas:#181420; --shadow:0 1px 2px rgba(0,0,0,.4),0 8px 24px rgba(0,0,0,.35);
+  }
+}
+:root[data-theme="dark"]{
+  --bg:#141118; --paper:#1e1a23; --ink:#ece8f0; --muted:#a49aad;
+  --border:#372f3e; --border-soft:#2a2430;
+  --accent:#a08cf0; --accent-ink:#1b1030; --accent-soft:#2c2445;
+  --warn:#e8a44a; --warn-bg:#3a2c14;
+  --canvas:#181420; --shadow:0 1px 2px rgba(0,0,0,.4),0 8px 24px rgba(0,0,0,.35);
+}
+:root[data-theme="light"]{
+  --bg:#f7f5f8; --paper:#ffffff; --ink:#2e2733; --muted:#756c7c;
+  --border:#e5e0e8; --border-soft:#efecf2;
+  --accent:#6b4fd8; --accent-ink:#ffffff; --accent-soft:#f0ecfb;
+  --warn:#b45309; --warn-bg:#fdf0d9;
+  --canvas:#fbfafc; --shadow:0 1px 2px rgba(46,39,51,.06),0 8px 24px rgba(46,39,51,.07);
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+  font:14px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;}
+.wrap{max-width:1180px;margin:0 auto;padding:40px 24px 72px}
+.pitch h1{font-family:Charter,Georgia,"Times New Roman",serif;font-weight:600;
+  font-size:clamp(26px,3.4vw,36px);line-height:1.15;margin:0 0 10px;text-wrap:balance}
+.pitch p{max-width:62ch;color:var(--muted);margin:0 0 6px}
+.eyebrow{font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);
+  font-weight:700;margin-bottom:10px}
+.hints{display:flex;flex-wrap:wrap;gap:8px;margin:18px 0 26px}
+.hint{font-size:12px;padding:4px 10px;border:1px solid var(--border);border-radius:999px;
+  background:var(--paper);color:var(--muted)}
+.hint b{color:var(--ink);font-weight:600}
+
+/* ── browser frame ── */
+.frame-scroll{overflow-x:auto;border-radius:14px;box-shadow:var(--shadow)}
+.frame{min-width:980px;border:1px solid var(--border);border-radius:14px;overflow:hidden;background:var(--paper)}
+.chrome{display:flex;align-items:center;gap:8px;padding:9px 14px;border-bottom:1px solid var(--border);background:var(--bg)}
+.dot{width:10px;height:10px;border-radius:50%;background:var(--border)}
+.urlbar{flex:1;max-width:420px;margin:0 auto;font-size:11px;color:var(--muted);background:var(--paper);
+  border:1px solid var(--border);border-radius:7px;padding:3px 12px;text-align:center;white-space:nowrap;overflow:hidden}
+
+/* ── app bar ── */
+.app{position:relative;background:var(--paper)}
+.appbar{display:flex;align-items:center;gap:12px;padding:0 16px;height:52px;border-bottom:1px solid var(--border)}
+.backlink{color:var(--muted);font-size:13px;white-space:nowrap}
+.formtitle{font-weight:600;font-size:13px;white-space:nowrap}
+.tabs{display:flex;gap:2px;margin:0 auto;height:100%}
+.tab{position:relative;display:flex;align-items:center;gap:6px;padding:0 14px;font-size:13px;font-weight:500;
+  color:var(--muted);cursor:pointer;background:none;border:none;font-family:inherit;height:100%}
+.tab:hover{color:var(--ink)}
+.tab[aria-selected="true"]{color:var(--ink);font-weight:600}
+.tab[aria-selected="true"]::after{content:"";position:absolute;left:10px;right:10px;bottom:-1px;height:2px;
+  border-radius:2px 2px 0 0;background:var(--ink)}
+.tab .cnt{font-size:10px;border:1px solid var(--border);border-radius:999px;padding:0 6px;line-height:15px;color:var(--muted)}
+.tab .warn{font-size:10px;background:var(--warn-bg);color:var(--warn);border-radius:999px;padding:0 6px;line-height:16px}
+.appbar-right{display:flex;align-items:center;gap:8px}
+.btn{font:inherit;font-size:12.5px;font-weight:500;border:1px solid var(--border);background:var(--paper);
+  color:var(--ink);border-radius:8px;padding:5px 12px;cursor:pointer}
+.btn:hover{border-color:var(--muted)}
+.btn.primary{background:var(--ink);border-color:var(--ink);color:var(--paper)}
+.btn.icon{padding:5px 8px;color:var(--muted)}
+button:focus-visible,.railcard:focus-visible,.chip:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+/* ── 3-pane body ── */
+.body{display:flex;height:560px}
+.view{display:none;width:100%}
+.view.active{display:flex}
+
+/* rail */
+.rail{width:236px;flex-shrink:0;border-right:1px solid var(--border);background:var(--bg);
+  padding:12px;overflow-y:auto;display:flex;flex-direction:column;gap:6px}
+.addcontent{display:flex;align-items:center;justify-content:center;gap:6px;width:100%;padding:8px;
+  font:inherit;font-size:13px;font-weight:600;border-radius:9px;border:none;cursor:pointer;
+  background:var(--ink);color:var(--paper);margin-bottom:10px}
+.railsec{font-size:10.5px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;
+  color:var(--muted);margin:10px 2px 4px;display:flex;justify-content:space-between;align-items:center}
+.railsec button{border:none;background:none;color:var(--muted);cursor:pointer;font-size:14px;line-height:1;padding:0 2px}
+.railcard{border:1px solid var(--border);border-radius:10px;background:var(--paper);padding:9px 10px;
+  cursor:pointer;font-size:12.5px;display:flex;align-items:center;gap:8px;text-align:left;width:100%;font-family:inherit;color:var(--ink)}
+.railcard:hover{border-color:var(--muted)}
+.railcard.sel{border-color:var(--accent);background:var(--accent-soft)}
+.rc-ico{width:22px;height:22px;border-radius:6px;display:flex;align-items:center;justify-content:center;
+  font-size:11px;background:var(--border-soft);flex-shrink:0}
+.railcard.sel .rc-ico{background:var(--accent);color:var(--accent-ink)}
+.pagegroup{border:1px solid var(--border);border-radius:10px;background:var(--paper);overflow:hidden}
+.pagegroup.sel{border-color:var(--accent)}
+.pagehead{display:flex;align-items:center;gap:8px;padding:9px 10px;font-size:12.5px;font-weight:600;cursor:pointer;
+  background:none;border:none;width:100%;text-align:left;font-family:inherit;color:var(--ink)}
+.pagegroup.sel .pagehead{background:var(--accent-soft)}
+.chips{padding:4px 6px 8px;display:flex;flex-direction:column;gap:3px}
+.chip{display:flex;align-items:center;gap:7px;font-size:12px;color:var(--muted);padding:5px 7px;border-radius:7px;
+  cursor:pointer;background:none;border:none;width:100%;text-align:left;font-family:inherit}
+.chip:hover{background:var(--border-soft);color:var(--ink)}
+.chip.sel{background:var(--accent-soft);color:var(--ink);font-weight:600}
+.chip .n{font-size:10px;font-weight:700;color:var(--accent);width:14px;text-align:center;flex-shrink:0}
+.chip .zap{margin-left:auto;font-size:10px;color:var(--warn)}
+
+/* canvas */
+.canvas{flex:1;display:flex;flex-direction:column;background:var(--canvas);position:relative;min-width:0}
+.toolbar{display:flex;align-items:center;gap:8px;padding:10px 14px}
+.toolbar .spacer{flex:1}
+.tool{font:inherit;font-size:12px;font-weight:500;display:flex;align-items:center;gap:6px;
+  border:1px solid var(--border);background:var(--paper);color:var(--ink);border-radius:8px;padding:5px 11px;cursor:pointer}
+.tool:hover{border-color:var(--muted)}
+.tool.active{background:var(--accent-soft);border-color:var(--accent);color:var(--accent)}
+.devtoggle{display:flex;border:1px solid var(--border);border-radius:8px;overflow:hidden}
+.devtoggle button{font:inherit;font-size:12px;border:none;background:var(--paper);color:var(--muted);padding:5px 10px;cursor:pointer}
+.devtoggle button.on{background:var(--border-soft);color:var(--ink)}
+.stage{flex:1;overflow-y:auto;padding:8px 26px 70px}
+.screen{display:none;max-width:640px;margin:0 auto}
+.screen.active{display:block}
+/* intro / thankyou screens */
+.hero{background:var(--paper);border:1px solid var(--border);border-radius:14px;padding:64px 48px;text-align:center;box-shadow:var(--shadow)}
+.hero h2{font-size:26px;margin:0 0 10px;font-weight:700;text-wrap:balance}
+.hero p{color:var(--muted);margin:0 auto 26px;max-width:44ch}
+.hero .cta{background:var(--ink);color:var(--paper);border:none;font:inherit;font-weight:600;
+  padding:10px 26px;border-radius:9px;cursor:default}
+.hero .meta{font-size:12px;color:var(--muted);margin-top:12px}
+.editable{outline:1.5px dashed transparent;border-radius:6px;transition:outline-color .15s}
+.hero:hover .editable{outline-color:var(--accent)}
+.edit-note{font-size:11px;color:var(--accent);text-align:center;margin-top:10px}
+/* page fields */
+.pagelabel{font-size:12px;font-weight:600;color:var(--muted);margin:4px 2px 10px}
+.fieldcard{background:var(--paper);border:1px solid var(--border);border-radius:12px;padding:14px 16px;
+  margin-bottom:10px;cursor:pointer;display:flex;gap:12px;align-items:flex-start}
+.fieldcard:hover{border-color:var(--muted)}
+.fieldcard.sel{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-soft)}
+.fq{font-size:11px;font-weight:700;color:var(--accent);padding-top:2px;width:16px;flex-shrink:0}
+.fbody{flex:1;min-width:0}
+.flabel{font-weight:600;font-size:13.5px}
+.finput{margin-top:8px;height:32px;border:1px solid var(--border);border-radius:7px;background:var(--canvas)}
+.fgrip{color:var(--border);font-size:14px;cursor:grab}
+.addfield{width:100%;border:1.5px dashed var(--border);background:none;color:var(--muted);font:inherit;
+  font-size:12.5px;border-radius:10px;padding:10px;cursor:pointer}
+.addfield:hover{border-color:var(--accent);color:var(--accent)}
+/* AI pill */
+.aipill{position:absolute;bottom:18px;left:50%;transform:translateX(-50%);display:flex;align-items:center;gap:9px;
+  background:var(--paper);border:1px solid var(--accent);border-radius:999px;padding:9px 18px;font-size:13px;
+  color:var(--muted);cursor:pointer;box-shadow:var(--shadow);white-space:nowrap;font-family:inherit}
+.aipill b{color:var(--accent)}
+
+/* right panel */
+.panel{width:280px;flex-shrink:0;border-left:1px solid var(--border);background:var(--paper);overflow-y:auto;position:relative}
+.pane{display:none;padding:16px}
+.pane.active{display:block}
+.pane h3{font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);margin:0 0 14px}
+.field-group{margin-bottom:16px}
+.field-group label{display:block;font-size:12px;font-weight:600;margin-bottom:6px}
+.field-group .help{font-size:11px;color:var(--muted);margin-top:5px}
+.tinput{width:100%;font:inherit;font-size:13px;padding:7px 10px;border:1px solid var(--border);
+  border-radius:8px;background:var(--paper);color:var(--ink)}
+.thumbs{display:grid;grid-template-columns:repeat(3,1fr);gap:6px}
+.thumb{aspect-ratio:4/3;border:1.5px solid var(--border);border-radius:7px;cursor:pointer;background:var(--canvas);
+  position:relative;overflow:hidden}
+.thumb::after{content:attr(data-l);position:absolute;bottom:2px;right:5px;font-size:9px;color:var(--muted)}
+.thumb .bar{position:absolute;background:var(--border)}
+.thumb.on{border-color:var(--accent);background:var(--accent-soft)}
+.rowbtns{display:flex;gap:6px;flex-wrap:wrap}
+.minibtn{font:inherit;font-size:11.5px;border:1px solid var(--border);background:var(--paper);color:var(--ink);
+  border-radius:7px;padding:4px 10px;cursor:pointer}
+.togglerow{display:flex;align-items:center;justify-content:space-between;font-size:12.5px;padding:7px 0}
+.sw{width:30px;height:17px;border-radius:999px;background:var(--border);position:relative;flex-shrink:0}
+.sw.on{background:var(--accent)}
+.sw::after{content:"";position:absolute;top:2px;left:2px;width:13px;height:13px;border-radius:50%;background:#fff;transition:left .15s}
+.sw.on::after{left:15px}
+.logiclink{display:flex;align-items:center;gap:8px;border:1px solid var(--border);border-radius:9px;
+  padding:9px 11px;font-size:12px;cursor:pointer;background:var(--bg);width:100%;font-family:inherit;color:var(--ink)}
+.logiclink:hover{border-color:var(--accent)}
+.logiclink .zap{color:var(--warn)}
+.divider{height:1px;background:var(--border-soft);margin:14px 0}
+
+/* ── field library: mega-panel + pinned dock ── */
+.fieldlib{display:none;background:var(--paper);z-index:35}
+.fieldlib.pop{display:block;position:absolute;left:248px;top:60px;width:560px;max-height:440px;overflow-y:auto;
+  border:1px solid var(--border);border-radius:14px;box-shadow:var(--shadow);padding:14px}
+.fieldlib.docked{display:block;position:static;width:196px;flex-shrink:0;border-right:1px solid var(--border);
+  overflow-y:auto;padding:12px 10px;border-radius:0;box-shadow:none}
+.libhead{display:flex;align-items:center;gap:8px;margin-bottom:10px}
+.libhead h3{margin:0;font-size:13px;font-weight:700;flex:1}
+.libsearch{width:100%;font:inherit;font-size:12.5px;border:1px solid var(--border);border-radius:8px;
+  padding:6px 10px;background:var(--bg);color:var(--ink);margin-bottom:10px}
+.libsec{font-size:10px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);margin:10px 2px 6px}
+.libgrid{display:grid;grid-template-columns:repeat(3,1fr);gap:6px}
+.fieldlib.docked .libgrid{grid-template-columns:1fr}
+.tile{display:flex;align-items:center;gap:8px;border:1px solid var(--border);border-radius:9px;
+  padding:8px 10px;font-size:12.5px;cursor:grab;background:var(--paper);font-family:inherit;color:var(--ink);text-align:left}
+.tile:hover{border-color:var(--accent);background:var(--accent-soft)}
+.tile .ti{width:24px;height:24px;border-radius:6px;background:var(--border-soft);display:flex;
+  align-items:center;justify-content:center;font-size:12px;flex-shrink:0}
+.tile.recent{border-style:dashed}
+.pinbtn{border:1px solid var(--border);background:var(--paper);border-radius:7px;font-size:12px;
+  cursor:pointer;padding:4px 8px;color:var(--muted)}
+.pinbtn.on{background:var(--accent-soft);border-color:var(--accent);color:var(--accent)}
+.libnote{font-size:11px;color:var(--muted);margin-top:10px}
+
+/* drawers & overlays inside app */
+.drawer{position:absolute;top:0;right:0;bottom:0;width:300px;background:var(--paper);border-left:1px solid var(--border);
+  box-shadow:-12px 0 32px rgba(0,0,0,.10);transform:translateX(105%);transition:transform .22s ease;z-index:30;
+  overflow-y:auto;padding:16px}
+.drawer.open{transform:translateX(0)}
+.drawer .dhead{display:flex;align-items:center;justify-content:space-between;margin-bottom:14px}
+.drawer .dhead h3{margin:0;font-size:13px;font-weight:700}
+.xbtn{border:none;background:none;font-size:15px;color:var(--muted);cursor:pointer;padding:2px 6px}
+.overlay{position:absolute;inset:0;background:var(--canvas);z-index:40;display:none;flex-direction:column}
+.overlay.open{display:flex}
+.ovbar{display:flex;align-items:center;gap:10px;padding:10px 16px;border-bottom:1px solid var(--border);background:var(--paper)}
+.ovbar .t{font-size:13px;font-weight:600;margin-right:auto}
+.ovstage{flex:1;display:flex;align-items:center;justify-content:center;padding:24px}
+/* AI drawer chat */
+.chat{display:flex;flex-direction:column;gap:10px;font-size:12.5px}
+.msg{border-radius:11px;padding:9px 12px;max-width:92%}
+.msg.user{align-self:flex-end;background:var(--ink);color:var(--paper)}
+.msg.ai{align-self:flex-start;background:var(--bg);border:1px solid var(--border)}
+.msg .act{display:flex;align-items:center;gap:6px;font-size:11px;color:var(--accent);margin-top:6px;font-weight:600}
+.aiinput{display:flex;gap:8px;margin-top:14px}
+.aiinput input{flex:1;font:inherit;font-size:12.5px;border:1px solid var(--border);border-radius:8px;padding:7px 10px;
+  background:var(--paper);color:var(--ink)}
+.aictx{font-size:11px;color:var(--muted);background:var(--bg);border:1px solid var(--border-soft);
+  border-radius:8px;padding:7px 10px;margin-bottom:12px}
+.aictx b{color:var(--accent)}
+
+/* logic + automations views */
+.listview{flex:1;overflow-y:auto;padding:26px;background:var(--canvas);position:relative}
+.listinner{max-width:700px;margin:0 auto}
+.lhead{display:flex;align-items:center;justify-content:space-between;margin-bottom:16px}
+.lhead h2{font-size:16px;margin:0}
+.rulecard{background:var(--paper);border:1px solid var(--border);border-radius:12px;padding:14px 16px;margin-bottom:10px}
+.rulecard .rt{font-weight:600;font-size:13px;display:flex;align-items:center;gap:8px}
+.rulecard .rd{font-size:12.5px;color:var(--muted);margin-top:4px}
+.pill{font-size:10.5px;border-radius:999px;padding:1px 8px;font-weight:600}
+.pill.ok{background:var(--accent-soft);color:var(--accent)}
+.pill.warn{background:var(--warn-bg);color:var(--warn)}
+.autocard{display:flex;align-items:center;gap:12px;background:var(--paper);border:1px solid var(--border);
+  border-radius:12px;padding:14px 16px;margin-bottom:10px}
+.autoico{width:34px;height:34px;border-radius:9px;background:var(--accent-soft);display:flex;align-items:center;
+  justify-content:center;font-size:15px;flex-shrink:0}
+.autocard .at{font-weight:600;font-size:13px}
+.autocard .ad{font-size:12px;color:var(--muted)}
+.autocard .pill{margin-left:auto}
+
+/* notes */
+.notes{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:14px;margin-top:30px}
+.note{background:var(--paper);border:1px solid var(--border);border-radius:12px;padding:18px}
+.note h4{margin:0 0 6px;font-size:13.5px}
+.note p{margin:0;font-size:12.5px;color:var(--muted)}
+.note .k{display:inline-block;font-size:10.5px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;
+  color:var(--accent);margin-bottom:8px}
+@media (prefers-reduced-motion: reduce){ .drawer,.sw::after{transition:none} }
+</style>
+
+<div class="wrap">
+  <div class="pitch">
+    <div class="eyebrow">Design proposal · Dculus Forms</div>
+    <h1>One Content workspace, three panes, one AI</h1>
+    <p>Five builder tabs collapse into <b>Content · Logic · Automations</b>. The left rail is the
+    respondent's journey — Intro, Pages, Thank You — and selecting any step morphs the canvas and
+    the right panel together. Design becomes a drawer, Preview an overlay, and one AI assistant
+    follows you across every tab.</p>
+    <div class="hints">
+      <span class="hint">Click <b>Welcome</b>, a <b>field chip</b>, or <b>Thank you</b> in the rail</span>
+      <span class="hint">Open <b>＋ Add content</b> — then <b>📌 Pin</b> it to dock the classic field column</span>
+      <span class="hint">Try <b>🎨 Design</b> and <b>▶ Preview</b> in the toolbar</span>
+      <span class="hint">Open <b>✨ Ask AI</b> — same assistant on all three tabs</span>
+    </div>
+  </div>
+
+  <div class="frame-scroll"><div class="frame">
+    <div class="chrome">
+      <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+      <span class="urlbar">app.dculus.com/dashboard/form/f_84h2/builder/content?screen=intro</span>
+    </div>
+    <div class="app" id="app">
+
+      <div class="appbar">
+        <span class="backlink">←</span>
+        <span class="formtitle">Customer Feedback ✎</span>
+        <div class="tabs" role="tablist">
+          <button class="tab" role="tab" id="tab-content" aria-selected="true" onclick="setTab('content')">Content <span class="cnt">7</span></button>
+          <button class="tab" role="tab" id="tab-logic" aria-selected="false" onclick="setTab('logic')">Logic <span class="warn">⚠ 1</span></button>
+          <button class="tab" role="tab" id="tab-automations" aria-selected="false" onclick="setTab('automations')">Automations <span class="cnt">2</span></button>
+        </div>
+        <div class="appbar-right">
+          <button class="btn">Share</button>
+          <button class="btn primary">Publish</button>
+          <button class="btn icon" title="Form settings — opens settings overlay">⚙</button>
+        </div>
+      </div>
+
+      <div class="body">
+
+        <!-- ═══ CONTENT VIEW ═══ -->
+        <div class="view active" id="view-content">
+          <div class="rail">
+            <button class="addcontent" onclick="toggleLib()">＋ Add content</button>
+
+            <div class="railsec">Intro</div>
+            <button class="railcard" id="rail-intro" onclick="select('intro')">
+              <span class="rc-ico">▛</span> Welcome screen
+            </button>
+
+            <div class="railsec">Pages <button title="Add page">＋</button></div>
+            <div class="pagegroup" id="rail-p1">
+              <button class="pagehead" onclick="select('p1')"><span class="rc-ico">≡</span> Page 1 · About you</button>
+              <div class="chips">
+                <button class="chip" id="rail-f1" onclick="select('f1')"><span class="n">1</span> ✏️ Full name</button>
+                <button class="chip" id="rail-f2" onclick="select('f2')"><span class="n">2</span> ✉️ Work email <span class="zap" title="2 logic rules">⚡</span></button>
+                <button class="chip" id="rail-f3" onclick="select('f3')"><span class="n">3</span> ☎️ Phone number</button>
+              </div>
+            </div>
+            <div class="pagegroup" id="rail-p2">
+              <button class="pagehead" onclick="select('p2')"><span class="rc-ico">≡</span> Page 2 · Your request</button>
+              <div class="chips">
+                <button class="chip"><span class="n">4</span> ▾ Request type</button>
+                <button class="chip"><span class="n">5</span> ¶ Details</button>
+              </div>
+            </div>
+
+            <div class="railsec">Thank you</div>
+            <button class="railcard" id="rail-ty" onclick="select('ty')">
+              <span class="rc-ico">▟</span> Thanks! We'll be in touch.
+            </button>
+          </div>
+
+          <!-- Field Library: popover by default, 📌 docks it as the old always-visible column -->
+          <div class="fieldlib" id="fieldlib">
+            <div class="libhead">
+              <h3>Add content</h3>
+              <button class="pinbtn" id="pinbtn" onclick="togglePin()" title="Pin as a docked column">📌 Pin</button>
+              <button class="xbtn" id="libclose" onclick="toggleLib()">✕</button>
+            </div>
+            <input class="libsearch" placeholder="Search field types…  ( / )" oninput="filterLib(this.value)">
+            <div class="libsec">Recently used</div>
+            <div class="libgrid">
+              <button class="tile recent"><span class="ti">✏️</span> Short text</button>
+              <button class="tile recent"><span class="ti">✉️</span> Email</button>
+              <button class="tile recent"><span class="ti">▾</span> Dropdown</button>
+            </div>
+            <div class="libsec">Input</div>
+            <div class="libgrid">
+              <button class="tile"><span class="ti">✏️</span> Short text</button>
+              <button class="tile"><span class="ti">¶</span> Long text</button>
+              <button class="tile"><span class="ti">✉️</span> Email</button>
+              <button class="tile"><span class="ti">#</span> Number</button>
+              <button class="tile"><span class="ti">📅</span> Date</button>
+              <button class="tile"><span class="ti">☎️</span> Phone</button>
+            </div>
+            <div class="libsec">Choice</div>
+            <div class="libgrid">
+              <button class="tile"><span class="ti">▾</span> Dropdown</button>
+              <button class="tile"><span class="ti">◉</span> Radio</button>
+              <button class="tile"><span class="ti">☑</span> Checkbox</button>
+            </div>
+            <div class="libsec">Content</div>
+            <div class="libgrid">
+              <button class="tile"><span class="ti">𝐀</span> Rich text</button>
+            </div>
+            <div class="libsec">Advanced</div>
+            <div class="libgrid">
+              <button class="tile"><span class="ti">📎</span> File upload</button>
+            </div>
+            <div class="libnote">Drag onto the canvas, or click to append to the selected page.
+            All 11 types visible in one shot — pin 📌 to keep it docked like the classic panel.</div>
+          </div>
+
+          <div class="canvas">
+            <div class="toolbar">
+              <button class="tool" id="designbtn" onclick="toggleDrawer('design')">🎨 Design</button>
+              <span class="spacer"></span>
+              <div class="devtoggle">
+                <button class="on">Desktop</button><button>Mobile</button>
+              </div>
+              <button class="tool" onclick="openPreview()">▶ Preview</button>
+            </div>
+            <div class="stage">
+
+              <div class="screen" id="scr-intro">
+                <div class="hero">
+                  <h2 class="editable" contenteditable="false">Customer Feedback</h2>
+                  <p class="editable">We'd love to hear what you think. It only takes two minutes
+                  and directly shapes what we build next.</p>
+                  <button class="cta">Start</button>
+                  <div class="meta">⏱ Takes 2 minutes</div>
+                </div>
+                <div class="edit-note">Rendered by FormRenderer (builder mode, screenOverride = "intro") — title &amp; description edit inline</div>
+              </div>
+
+              <div class="screen" id="scr-page">
+                <div class="pagelabel" id="pagelabel">Page 1 · About you</div>
+                <div id="pagefields">
+                  <div class="fieldcard" id="fc-f1" onclick="select('f1')">
+                    <span class="fq">1</span>
+                    <div class="fbody"><div class="flabel">What is your full name?</div><div class="finput"></div></div>
+                    <span class="fgrip">⠿</span>
+                  </div>
+                  <div class="fieldcard" id="fc-f2" onclick="select('f2')">
+                    <span class="fq">2</span>
+                    <div class="fbody"><div class="flabel">What is your work email? *</div><div class="finput"></div></div>
+                    <span class="fgrip">⠿</span>
+                  </div>
+                  <div class="fieldcard" id="fc-f3" onclick="select('f3')">
+                    <span class="fq">3</span>
+                    <div class="fbody"><div class="flabel">What is your phone number?</div><div class="finput"></div></div>
+                    <span class="fgrip">⠿</span>
+                  </div>
+                </div>
+                <button class="addfield">＋ Add field — or drag from “Add content”</button>
+              </div>
+
+              <div class="screen" id="scr-ty">
+                <div class="hero">
+                  <h2 class="editable">Thanks! We'll be in touch. 🎉</h2>
+                  <p class="editable">Your feedback landed safely. Our team reads every single
+                  response — expect a reply within two working days.</p>
+                  <div class="meta">Ending settings on the right — redirect &amp; share coming soon</div>
+                </div>
+                <div class="edit-note">screenOverride = "thankYou" — rich text edits inline</div>
+              </div>
+
+            </div>
+            <button class="aipill" onclick="toggleDrawer('ai')"><b>✨</b> Ask AI anything… <b>➤</b></button>
+          </div>
+
+          <div class="panel">
+            <div class="pane" id="pane-intro">
+              <h3>Welcome screen</h3>
+              <div class="field-group">
+                <label>Layout</label>
+                <div class="thumbs">
+                  <div class="thumb on" data-l="L1"><div class="bar" style="left:12%;top:20%;width:76%;height:8%"></div><div class="bar" style="left:24%;top:38%;width:52%;height:6%"></div></div>
+                  <div class="thumb" data-l="L2"><div class="bar" style="left:8%;top:12%;width:38%;height:76%"></div></div>
+                  <div class="thumb" data-l="L3"><div class="bar" style="left:54%;top:12%;width:38%;height:76%"></div></div>
+                  <div class="thumb" data-l="L4"><div class="bar" style="left:12%;top:52%;width:76%;height:8%"></div></div>
+                  <div class="thumb" data-l="L5"><div class="bar" style="left:12%;top:14%;width:76%;height:36%"></div></div>
+                  <div class="thumb" data-l="L6"><div class="bar" style="left:30%;top:30%;width:40%;height:26%"></div></div>
+                </div>
+                <div class="help">L1–L9 form layouts (existing LayoutThumbnails)</div>
+              </div>
+              <div class="field-group">
+                <label>Button text</label>
+                <input class="tinput" value="Start" maxlength="24">
+                <div class="help">5/24 — today's hidden “custom CTA” setting, now in context</div>
+              </div>
+              <div class="divider"></div>
+              <div class="field-group">
+                <label>Background</label>
+                <div class="rowbtns">
+                  <button class="minibtn">🎨 Color</button>
+                  <button class="minibtn">⬆ Upload</button>
+                  <button class="minibtn">Pexels</button>
+                  <button class="minibtn">Pixabay</button>
+                </div>
+              </div>
+              <div class="togglerow">Show time to complete <span class="sw on"></span></div>
+            </div>
+
+            <div class="pane" id="pane-page">
+              <h3>Page settings</h3>
+              <div class="field-group">
+                <label>Page title</label>
+                <input class="tinput" id="pagetitleinput" value="About you">
+              </div>
+              <div class="togglerow">Shuffle fields on this page <span class="sw"></span></div>
+              <div class="divider"></div>
+              <div class="rowbtns">
+                <button class="minibtn">Duplicate page</button>
+                <button class="minibtn">Delete page</button>
+              </div>
+            </div>
+
+            <div class="pane" id="pane-field">
+              <h3 id="fieldpanetitle">Field · Work email</h3>
+              <div class="field-group">
+                <label>Label</label>
+                <input class="tinput" id="fieldlabelinput" value="What is your work email?">
+              </div>
+              <div class="togglerow">Required <span class="sw on"></span></div>
+              <div class="field-group">
+                <label>Placeholder</label>
+                <input class="tinput" value="you@company.com">
+              </div>
+              <div class="divider"></div>
+              <button class="logiclink" onclick="setTab('logic')">
+                <span class="zap">⚡</span> 2 logic rules use this field <span style="margin-left:auto">→</span>
+              </button>
+              <div class="help" style="font-size:11px;color:var(--muted);margin-top:6px">Existing FieldSettingsV2, plus this logic summary row</div>
+            </div>
+
+            <div class="pane" id="pane-ty">
+              <h3>Ending</h3>
+              <div class="field-group">
+                <label>Message</label>
+                <div class="tinput" style="height:64px;font-size:12px;color:var(--muted)">Thanks! We'll be in touch. 🎉 — rich text editor</div>
+              </div>
+              <div class="togglerow">Show “Create your own form” <span class="sw on"></span></div>
+              <div class="togglerow">Redirect after submit <span class="sw"></span></div>
+              <div class="togglerow">Social share buttons <span class="sw"></span></div>
+              <div class="help" style="font-size:11px;color:var(--muted)">Built as an Endings list — conditional multiple endings can land here later</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ═══ LOGIC VIEW ═══ -->
+        <div class="view" id="view-logic">
+          <div class="listview">
+            <div class="listinner">
+              <div class="lhead"><h2>Logic rules</h2><button class="btn">＋ New rule</button></div>
+              <div class="rulecard">
+                <div class="rt">Skip phone number for personal emails <span class="pill ok">Enabled</span></div>
+                <div class="rd">When <b>Work email</b> ends with gmail.com → hide <b>Phone number</b></div>
+              </div>
+              <div class="rulecard">
+                <div class="rt">Route enterprise requests <span class="pill warn">⚠ Circular reference</span></div>
+                <div class="rd">When <b>Request type</b> is “Enterprise” → jump to <b>Page 2</b></div>
+              </div>
+              <div class="rulecard">
+                <div class="rt">Require details for bug reports <span class="pill ok">Enabled</span></div>
+                <div class="rd">When <b>Request type</b> is “Bug” → make <b>Details</b> required</div>
+              </div>
+            </div>
+            <button class="aipill" onclick="toggleDrawer('ai')"><b>✨</b> Ask AI anything… <b>➤</b></button>
+          </div>
+        </div>
+
+        <!-- ═══ AUTOMATIONS VIEW ═══ -->
+        <div class="view" id="view-automations">
+          <div class="listview">
+            <div class="listinner">
+              <div class="lhead"><h2>Automations</h2><button class="btn">＋ New automation</button></div>
+              <div class="autocard">
+                <span class="autoico">📊</span>
+                <div><div class="at">Sync to Google Sheets</div><div class="ad">On submit → append row to “Feedback 2026”</div></div>
+                <span class="pill ok">Active</span>
+              </div>
+              <div class="autocard">
+                <span class="autoico">✉️</span>
+                <div><div class="at">Low-score alert</div><div class="ad">On submit, if rating &lt; 3 → email natheesh@…</div></div>
+                <span class="pill ok">Active</span>
+              </div>
+              <div class="autocard" style="opacity:.65">
+                <span class="autoico">🪝</span>
+                <div><div class="at">CRM webhook</div><div class="ad">On submit → POST to hooks.crm.example</div></div>
+                <span class="pill warn">Paused</span>
+              </div>
+            </div>
+            <button class="aipill" onclick="toggleDrawer('ai')"><b>✨</b> Ask AI anything… <b>➤</b></button>
+          </div>
+        </div>
+
+      </div><!-- /body -->
+
+      <!-- Design drawer -->
+      <div class="drawer" id="drawer-design">
+        <div class="dhead"><h3>🎨 Design — whole form</h3><button class="xbtn" onclick="toggleDrawer('design')">✕</button></div>
+        <div class="field-group">
+          <label>Layout family</label>
+          <div class="thumbs">
+            <div class="thumb on" data-l="L1"></div><div class="thumb" data-l="L2"></div><div class="thumb" data-l="L3"></div>
+            <div class="thumb" data-l="L4"></div><div class="thumb" data-l="L5"></div><div class="thumb" data-l="L6"></div>
+            <div class="thumb" data-l="L7"></div><div class="thumb" data-l="L8"></div><div class="thumb" data-l="L9"></div>
+          </div>
+        </div>
+        <div class="field-group">
+          <label>Theme</label>
+          <div class="rowbtns"><button class="minibtn">Light</button><button class="minibtn">Dark</button><button class="minibtn">Auto</button></div>
+        </div>
+        <div class="field-group">
+          <label>Spacing</label>
+          <div class="rowbtns"><button class="minibtn">Compact</button><button class="minibtn">Normal</button><button class="minibtn">Relaxed</button></div>
+        </div>
+        <div class="field-group">
+          <label>Global background</label>
+          <div class="rowbtns"><button class="minibtn">🎨 Color</button><button class="minibtn">⬆ Upload</button><button class="minibtn">Pexels</button><button class="minibtn">Pixabay</button></div>
+          <div class="help">Reuses today's LayoutSidebar controls — you restyle while watching real content re-render</div>
+        </div>
+      </div>
+
+      <!-- AI drawer -->
+      <div class="drawer" id="drawer-ai">
+        <div class="dhead"><h3>✨ Ask AI</h3><button class="xbtn" onclick="toggleDrawer('ai')">✕</button></div>
+        <div class="aictx" id="aictx">Context: <b>Content</b> · Welcome screen selected</div>
+        <div class="chat">
+          <div class="msg user">Add a 1–5 rating question after the email field, and email me whenever someone rates below 3.</div>
+          <div class="msg ai">Done — two changes across the builder:
+            <div class="act">✚ Added “How satisfied are you?” to Page 1</div>
+            <div class="act">⚙ Drafted automation “Low-score alert” for review</div>
+          </div>
+          <div class="msg user">Hide the phone field unless they choose “Enterprise”.</div>
+          <div class="msg ai">Drafted a logic rule — it's waiting as a <b>pending suggestion</b> in the Logic tab.
+            <div class="act">⚡ Pending: show Phone when Request type = Enterprise</div>
+          </div>
+        </div>
+        <div class="aiinput"><input placeholder="One assistant — content, logic &amp; automations…"><button class="btn primary">➤</button></div>
+      </div>
+
+      <!-- Preview overlay -->
+      <div class="overlay" id="preview">
+        <div class="ovbar">
+          <span class="t">Preview</span>
+          <div class="devtoggle"><button class="on">Desktop</button><button>Mobile</button></div>
+          <button class="btn" onclick="closePreview()">✕ Close (Esc)</button>
+        </div>
+        <div class="ovstage">
+          <div class="hero" style="max-width:560px;width:100%">
+            <h2>Customer Feedback</h2>
+            <p>We'd love to hear what you think. It only takes two minutes and directly shapes what we build next.</p>
+            <button class="cta">Start</button>
+            <div class="meta">⏱ Takes 2 minutes · full test-submit flow, no navigation, selection preserved</div>
+          </div>
+        </div>
+      </div>
+
+    </div><!-- /app -->
+  </div></div>
+
+  <section class="notes">
+    <div class="note"><span class="k">Mode A · Pages</span>
+      <h4>Fields edit where they live</h4>
+      <p>Select a page or field chip: the canvas shows the page's field cards and the right panel
+      becomes field settings with a logic-summary row. “＋ Add content” opens a mega-panel showing
+      all 11 field types at once — searchable, draggable — and 📌 pins into a docked column for
+      anyone who wants the classic always-visible palette.</p></div>
+    <div class="note"><span class="k">Mode B · Intro</span>
+      <h4>Screens are first-class</h4>
+      <p>Clicking Welcome flips all three panes: real intro render in the canvas, and layout
+      thumbnails, button text, and background controls in the right panel — settings that today
+      hide inside the separate Design tab.</p></div>
+    <div class="note"><span class="k">Mode C · Thank you</span>
+      <h4>Endings get a home</h4>
+      <p>The Thank You card renders the ending inline and its panel finally gives redirect,
+      share, and branding toggles a natural place — built as a list so conditional multiple
+      endings can land without another redesign.</p></div>
+    <div class="note"><span class="k">Everywhere</span>
+      <h4>One unified AI</h4>
+      <p>The same ✨ pill sits on Content, Logic, and Automations. It knows your active tab and
+      selection, and one conversation can add fields, draft pending logic rules, and scaffold
+      automations together.</p></div>
+  </section>
+</div>
+
+<script>
+var sel = 'intro';
+var FIELDS = { f1:'Full name', f2:'Work email', f3:'Phone number' };
+
+function setTab(t){
+  ['content','logic','automations'].forEach(function(k){
+    document.getElementById('view-'+k).classList.toggle('active', k===t);
+    document.getElementById('tab-'+k).setAttribute('aria-selected', k===t ? 'true' : 'false');
+  });
+  closeDrawers();
+  updateAiCtx(t);
+}
+function select(s){
+  sel = s;
+  // rail highlight
+  document.getElementById('rail-intro').classList.toggle('sel', s==='intro');
+  document.getElementById('rail-ty').classList.toggle('sel', s==='ty');
+  document.getElementById('rail-p1').classList.toggle('sel', s==='p1' || s.charAt(0)==='f');
+  document.getElementById('rail-p2').classList.toggle('sel', s==='p2');
+  ['f1','f2','f3'].forEach(function(f){
+    document.getElementById('rail-'+f).classList.toggle('sel', s===f);
+    var fc = document.getElementById('fc-'+f);
+    if (fc) fc.classList.toggle('sel', s===f);
+  });
+  // canvas screen
+  var scr = (s==='intro') ? 'intro' : (s==='ty') ? 'ty' : 'page';
+  ['intro','page','ty'].forEach(function(k){
+    document.getElementById('scr-'+k).classList.toggle('active', k===scr);
+  });
+  document.getElementById('pagelabel').textContent = (s==='p2') ? 'Page 2 · Your request' : 'Page 1 · About you';
+  document.getElementById('pagefields').style.display = (s==='p2') ? 'none' : '';
+  // right pane
+  var pane = (s==='intro') ? 'intro' : (s==='ty') ? 'ty' : (s.charAt(0)==='f') ? 'field' : 'page';
+  ['intro','page','field','ty'].forEach(function(k){
+    document.getElementById('pane-'+k).classList.toggle('active', k===pane);
+  });
+  if (pane==='field'){
+    document.getElementById('fieldpanetitle').textContent = 'Field · ' + FIELDS[s];
+    document.getElementById('fieldlabelinput').value = 'What is your ' + FIELDS[s].toLowerCase() + '?';
+  }
+  if (pane==='page'){
+    document.getElementById('pagetitleinput').value = (s==='p2') ? 'Your request' : 'About you';
+  }
+  updateAiCtx('content');
+}
+function updateAiCtx(tab){
+  var where = { content:'Content', logic:'Logic', automations:'Automations' }[tab] || 'Content';
+  var what = '';
+  if (tab==='content'){
+    what = (sel==='intro') ? ' · Welcome screen selected'
+         : (sel==='ty') ? ' · Ending selected'
+         : (sel.charAt(0)==='f') ? ' · Field “'+FIELDS[sel]+'” selected'
+         : ' · ' + ((sel==='p2') ? 'Page 2' : 'Page 1') + ' selected';
+  }
+  document.getElementById('aictx').innerHTML = 'Context: <b>'+where+'</b>'+what;
+}
+function toggleDrawer(which){
+  var d = document.getElementById('drawer-'+which);
+  var other = document.getElementById('drawer-'+(which==='ai'?'design':'ai'));
+  other.classList.remove('open');
+  d.classList.toggle('open');
+  document.getElementById('designbtn').classList.toggle('active', document.getElementById('drawer-design').classList.contains('open'));
+}
+function closeDrawers(){
+  document.getElementById('drawer-ai').classList.remove('open');
+  document.getElementById('drawer-design').classList.remove('open');
+  document.getElementById('designbtn').classList.remove('active');
+}
+function openPreview(){ document.getElementById('preview').classList.add('open'); }
+function closePreview(){ document.getElementById('preview').classList.remove('open'); }
+
+/* field library: popover ↔ pinned dock */
+var libPinned = false;
+function toggleLib(){
+  var lib = document.getElementById('fieldlib');
+  if (libPinned) { togglePin(); return; }               // unpin via the rail button too
+  lib.classList.toggle('pop');
+}
+function togglePin(){
+  var lib = document.getElementById('fieldlib');
+  libPinned = !libPinned;
+  lib.classList.toggle('docked', libPinned);
+  lib.classList.remove('pop');
+  if (libPinned) lib.classList.add('docked');
+  document.getElementById('pinbtn').classList.toggle('on', libPinned);
+  document.getElementById('pinbtn').textContent = libPinned ? '📌 Unpin' : '📌 Pin';
+  document.getElementById('libclose').style.display = libPinned ? 'none' : '';
+}
+function filterLib(q){
+  q = q.trim().toLowerCase();
+  var tiles = document.querySelectorAll('#fieldlib .tile');
+  for (var i=0;i<tiles.length;i++){
+    tiles[i].style.display = tiles[i].textContent.toLowerCase().indexOf(q) !== -1 ? '' : 'none';
+  }
+}
+document.addEventListener('keydown', function(e){
+  if (e.key==='Escape'){
+    closePreview(); closeDrawers();
+    if (!libPinned) document.getElementById('fieldlib').classList.remove('pop');
+  }
+});
+select('intro');
+</script>

--- a/docs/prototypes/form-builder-redesign-prototype.html
+++ b/docs/prototypes/form-builder-redesign-prototype.html
@@ -1,4 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Dculus Forms — Builder Redesign Prototype</title>
+</head>
+<body>
 <style>
 :root{
   --bg:#f7f5f8; --paper:#ffffff; --ink:#2e2733; --muted:#756c7c;
@@ -280,7 +287,7 @@ button:focus-visible,.railcard:focus-visible,.chip:focus-visible{outline:2px sol
   <div class="frame-scroll"><div class="frame">
     <div class="chrome">
       <span class="dot"></span><span class="dot"></span><span class="dot"></span>
-      <span class="urlbar">app.dculus.com/dashboard/form/f_84h2/builder/content?screen=intro</span>
+      <span class="urlbar" id="urlbar">app.dculus.com/dashboard/form/f_84h2/builder/content?screen=intro</span>
     </div>
     <div class="app" id="app">
 
@@ -295,7 +302,7 @@ button:focus-visible,.railcard:focus-visible,.chip:focus-visible{outline:2px sol
         <div class="appbar-right">
           <button class="btn">Share</button>
           <button class="btn primary">Publish</button>
-          <button class="btn icon" title="Form settings — opens settings overlay">⚙</button>
+          <button class="btn icon" title="Form settings — opens settings overlay" onclick="openSettings()">⚙</button>
         </div>
       </div>
 
@@ -323,8 +330,8 @@ button:focus-visible,.railcard:focus-visible,.chip:focus-visible{outline:2px sol
             <div class="pagegroup" id="rail-p2">
               <button class="pagehead" onclick="select('p2')"><span class="rc-ico">≡</span> Page 2 · Your request</button>
               <div class="chips">
-                <button class="chip"><span class="n">4</span> ▾ Request type</button>
-                <button class="chip"><span class="n">5</span> ¶ Details</button>
+                <button class="chip" onclick="select('p2')"><span class="n">4</span> ▾ Request type</button>
+                <button class="chip" onclick="select('p2')"><span class="n">5</span> ¶ Details</button>
               </div>
             </div>
 
@@ -371,8 +378,10 @@ button:focus-visible,.railcard:focus-visible,.chip:focus-visible{outline:2px sol
             <div class="libgrid">
               <button class="tile"><span class="ti">📎</span> File upload</button>
             </div>
-            <div class="libnote">Drag onto the canvas, or click to append to the selected page.
-            All 11 types visible in one shot — pin 📌 to keep it docked like the classic panel.</div>
+            <div class="libnote">In the real builder, tiles drag onto the canvas or click to append
+            to the selected page (interactions land in ticket #230 — not wired in this static
+            prototype). All 11 types visible in one shot — pin 📌 to keep it docked like the
+            classic panel.</div>
           </div>
 
           <div class="canvas">
@@ -605,6 +614,34 @@ button:focus-visible,.railcard:focus-visible,.chip:focus-visible{outline:2px sol
         <div class="aiinput"><input placeholder="One assistant — content, logic &amp; automations…"><button class="btn primary">➤</button></div>
       </div>
 
+      <!-- Settings overlay (deep link: ?settings=1) -->
+      <div class="overlay" id="settings">
+        <div class="ovbar">
+          <span class="t">⚙ Form settings</span>
+          <button class="btn" onclick="closeSettings()">✕ Close (Esc)</button>
+        </div>
+        <div class="ovstage">
+          <div style="max-width:560px;width:100%;display:flex;flex-direction:column;gap:12px">
+            <div class="rulecard">
+              <div class="rt">General</div>
+              <div class="rd">Title, description, short URL — existing SettingsTab, hosted unchanged in this overlay</div>
+            </div>
+            <div class="rulecard">
+              <div class="rt">Submission limits</div>
+              <div class="rd">Max responses, time window</div>
+            </div>
+            <div class="rulecard">
+              <div class="rt">Access control &amp; response copy</div>
+              <div class="rd">Who can submit · email a copy to respondents</div>
+            </div>
+            <div class="rulecard" style="opacity:.7">
+              <div class="rt">Developer</div>
+              <div class="rd">JSON schema view (dev-only) — moved here from the old right-panel JSON tab</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <!-- Preview overlay -->
       <div class="overlay" id="preview">
         <div class="ovbar">
@@ -661,6 +698,8 @@ function setTab(t){
   });
   closeDrawers();
   updateAiCtx(t);
+  curTab = t;
+  setUrl(t);
 }
 function select(s){
   sel = s;
@@ -694,6 +733,7 @@ function select(s){
     document.getElementById('pagetitleinput').value = (s==='p2') ? 'Your request' : 'About you';
   }
   updateAiCtx('content');
+  setUrl('content');
 }
 function updateAiCtx(tab){
   var where = { content:'Content', logic:'Logic', automations:'Automations' }[tab] || 'Content';
@@ -718,8 +758,25 @@ function closeDrawers(){
   document.getElementById('drawer-design').classList.remove('open');
   document.getElementById('designbtn').classList.remove('active');
 }
-function openPreview(){ document.getElementById('preview').classList.add('open'); }
-function closePreview(){ document.getElementById('preview').classList.remove('open'); }
+function openPreview(){ document.getElementById('preview').classList.add('open'); setUrl('content', '?preview=1'); }
+function closePreview(){ document.getElementById('preview').classList.remove('open'); setUrl(curTab); }
+function openSettings(){ document.getElementById('settings').classList.add('open'); setUrl('content', '?settings=1'); }
+function closeSettings(){ document.getElementById('settings').classList.remove('open'); setUrl(curTab); }
+
+/* fake URL bar — demonstrates the deep-link contract (?screen/?field/?preview/?settings) */
+var curTab = 'content';
+function setUrl(tab, extra){
+  var q = extra || '';
+  if (tab === 'content' && !extra){
+    q = (sel==='intro') ? '?screen=intro'
+      : (sel==='ty') ? '?screen=thankyou'
+      : (sel==='p2') ? '?screen=page:pg_2'
+      : (sel.charAt(0)==='f') ? '?screen=page:pg_1&field=' + sel
+      : '?screen=page:pg_1';
+  }
+  document.getElementById('urlbar').textContent =
+    'app.dculus.com/dashboard/form/f_84h2/builder/' + tab + q;
+}
 
 /* field library: popover ↔ pinned dock */
 var libPinned = false;
@@ -747,9 +804,11 @@ function filterLib(q){
 }
 document.addEventListener('keydown', function(e){
   if (e.key==='Escape'){
-    closePreview(); closeDrawers();
+    closePreview(); closeSettings(); closeDrawers();
     if (!libPinned) document.getElementById('fieldlib').classList.remove('pop');
   }
 });
 select('intro');
 </script>
+</body>
+</html>

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -52,6 +52,29 @@ for app in backend form-app form-viewer admin-app; do
 done
 echo
 
+echo "==> Copying other gitignored local files from the main checkout"
+# root .env / test .env (test tooling), .claude/settings.local.json (approved
+# tool permissions — without it, agent sessions in the worktree re-prompt for
+# everything the main checkout already allows).
+for rel in .env test/.env .claude/settings.local.json; do
+  src="$MAIN_ROOT/$rel"
+  dest="$WORKTREE_ROOT/$rel"
+
+  if [ ! -f "$src" ]; then
+    continue
+  fi
+
+  if [ -f "$dest" ] && [ "$FORCE" != "true" ]; then
+    echo "  skip $rel: already exists (use --force to overwrite)"
+    continue
+  fi
+
+  mkdir -p "$(dirname "$dest")"
+  cp "$src" "$dest"
+  echo "  copied $rel"
+done
+echo
+
 if [ ! -d "$WORKTREE_ROOT/node_modules" ]; then
   echo "==> Installing dependencies (node_modules missing)"
   pnpm install

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -64,12 +64,24 @@ for rel in .env test/.env .claude/settings.local.json; do
     continue
   fi
 
+  # Never write through a symlink or onto a non-regular destination — with
+  # --force that could leak .env/settings content outside the worktree.
+  if [ -L "$dest" ] || { [ -e "$dest" ] && [ ! -f "$dest" ]; }; then
+    echo "  skip $rel: destination is not a regular file — refusing to write"
+    continue
+  fi
+  destdir="$(dirname "$dest")"
+  if [ -L "$destdir" ]; then
+    echo "  skip $rel: parent directory is a symlink — refusing to write"
+    continue
+  fi
+
   if [ -f "$dest" ] && [ "$FORCE" != "true" ]; then
     echo "  skip $rel: already exists (use --force to overwrite)"
     continue
   fi
 
-  mkdir -p "$(dirname "$dest")"
+  mkdir -p "$destdir"
   cp "$src" "$dest"
   echo "  copied $rel"
 done


### PR DESCRIPTION
Design spec for epic #226 — Unified Content Workspace.

- `docs/form-builder-redesign.md` — UX proposal, wireframes, unified-AI design
- `docs/form-builder-redesign-implementation.md` — routes, component map, phases
- `docs/form-builder-redesign-agent-prompts.md` — copy-paste prompt per ticket #227–#234
- `docs/prototypes/form-builder-redesign-prototype.html` — clickable prototype (open in a browser)

Merge this **before** starting #227 — every child ticket reads these paths from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Form Builder Redesign proposal and a multi-phase implementation plan.
  * Added an execution-order prompt pack for the redesign epic, including rollout and verification guidance.
  * Updated repository usage docs for E2E login guidance and worktree setup.
* **Prototype**
  * Added an interactive standalone HTML prototype of the redesigned Content, Logic, and Automations workspace.
* **Chores**
  * Prevented committing local Claude Code settings and improved worktree setup to copy needed local config files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->