### PR TITLE
Add per-page show/hide page name toggle; fix AI-generated page titles

### DIFF
--- a/apps/backend/src/graphql/schema.ts
+++ b/apps/backend/src/graphql/schema.ts
@@ -1605,6 +1605,7 @@ export const typeDefs = gql`
     placeholder: String
     required: Boolean!
     options: [AIFieldOption!]
+    section: String!
   }
 
   type AIGeneratedLayout {

--- a/apps/backend/src/services/aiService.ts
+++ b/apps/backend/src/services/aiService.ts
@@ -31,6 +31,11 @@ const AIFieldSchema = z.object({
     .array(AIFieldOptionSchema)
     .nullable()
     .describe('Option list for select/radio/checkbox types, or null for others'),
+  section: z
+    .string()
+    .describe(
+      'Short name (2-4 words) of the logical section/page this field belongs to, e.g. "Personal Information", "Contact Details". Fields with the same section name, listed consecutively, are grouped onto the same page.'
+    ),
 });
 
 const AILayoutSchema = z.object({
@@ -70,7 +75,8 @@ You MUST respond with valid JSON matching EXACTLY this structure — no extra ke
       "label": "Field label",
       "placeholder": "Hint text or null",
       "required": true,
-      "options": null
+      "options": null,
+      "section": "Personal Information"
     }
   ],
   "layout": {
@@ -81,10 +87,11 @@ You MUST respond with valid JSON matching EXACTLY this structure — no extra ke
 
 Strict rules:
 - "suggestedTitle" MUST be a short descriptive title string.
-- Each field MUST have: type, label, placeholder (string or null), required (boolean), options (array or null).
+- Each field MUST have: type, label, placeholder (string or null), required (boolean), options (array or null), section (string).
 - "required" MUST be true or false — never omit it.
 - "placeholder" MUST be a string or null — never omit it.
 - "options" MUST be an array of {"value": "...", "label": "..."} objects for select/radio/checkbox fields; null for all other field types.
+- "section" MUST be a short (2-4 word) name for the logical group/page this field belongs to. List fields belonging to the same section consecutively — they will become one page together.
 - "layout.content" MUST use only <h1> and <p> tags — no other HTML.
 - "layout.customCTAButtonName" MUST be a short action-oriented label (max 4 words).`;
 
@@ -94,6 +101,7 @@ Focus only on the most essential information — nothing extra.
 Use simple field types (text, email, number, textarea).
 Keep labels short and direct. Set placeholder to null unless it genuinely helps.
 Set options to null for non-choice fields.
+Assign every field the same "section" name (e.g. "Details") since a quick form is a single short page.
 ${JSON_SCHEMA_RULES}`,
 
   standard: `You are a form builder assistant. Create well-balanced forms with 6–10 fields.
@@ -102,6 +110,8 @@ Mix field types naturally — use radio or select for categorical choices, texta
 and phone for phone/contact-number questions instead of a plain text field.
 Keep labels concise and user-friendly. Set placeholder to null if not needed.
 Set options to null for non-choice fields.
+Organize fields into 2-3 logical sections with short, descriptive names (e.g. "Personal Information", "Preferences") —
+list fields belonging to the same section consecutively so each section becomes its own page.
 ${JSON_SCHEMA_RULES}`,
 
   professional: `You are a form builder assistant. Create comprehensive, professional forms with 10–20 fields.
@@ -110,6 +120,9 @@ Group related fields logically. Use radio/select for categorical choices, checkb
 textarea for open-ended answers, and specialized types (date, file, number, phone) where natural —
 use phone specifically for phone/contact-number questions instead of a plain text field.
 Set options to null for non-choice fields. Set placeholder to null only if truly unnecessary.
+Organize fields into 3-6 logical sections with short, descriptive names (e.g. "Personal Information",
+"Employment History", "Emergency Contact") — list fields belonging to the same section consecutively,
+keeping each section to roughly 2-6 fields, so each section becomes its own page.
 ${JSON_SCHEMA_RULES}`,
 };
 

--- a/apps/backend/src/services/hocuspocus.ts
+++ b/apps/backend/src/services/hocuspocus.ts
@@ -416,6 +416,7 @@ export const getFormSchemaFromHocuspocus = async (
               id: pageMap.get('id'),
               title: pageMap.get('title'),
               order: pageMap.get('order'),
+              showPageName: pageMap.get('showPageName') ?? true,
               fields: [] as any[],
             };
 
@@ -634,6 +635,7 @@ export const initializeHocuspocusDocument = async (
         pageMap.set('id', page.id);
         pageMap.set('title', page.title);
         pageMap.set('order', page.order);
+        pageMap.set('showPageName', page.showPageName ?? true);
 
         const fieldsArray = new Y.Array();
         if (page.fields && page.fields.length > 0) {
@@ -762,6 +764,7 @@ export const initializeHocuspocusDocument = async (
       defaultPageMap.set('id', `page-${Date.now()}`);
       defaultPageMap.set('title', 'Page 1');
       defaultPageMap.set('order', 0);
+      defaultPageMap.set('showPageName', true);
       defaultPageMap.set('fields', new Y.Array());
       pagesArray.push([defaultPageMap]);
     }

--- a/apps/form-app/src/components/form-builder/panels/PageSettingsPanel.tsx
+++ b/apps/form-app/src/components/form-builder/panels/PageSettingsPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Copy, Trash2 } from 'lucide-react';
 import { FormPage } from '@dculus/types';
-import { Button, Input, Label, ScrollArea } from '@dculus/ui';
+import { Button, Input, Label, ScrollArea, Switch } from '@dculus/ui';
 import { useFormBuilderStore } from '../../../store/useFormBuilderStore';
 import { useFormPermissions } from '../../../hooks/useFormPermissions';
 import { useTranslation } from '../../../hooks/useTranslation';
@@ -24,6 +24,7 @@ export const PageSettingsPanel: React.FC<PageSettingsPanelProps> = ({ page, isCo
   const permissions = useFormPermissions();
 
   const updatePageTitle = useFormBuilderStore((state) => state.updatePageTitle);
+  const updatePageShowName = useFormBuilderStore((state) => state.updatePageShowName);
   const duplicatePage = useFormBuilderStore((state) => state.duplicatePage);
   const removePage = useFormBuilderStore((state) => state.removePage);
 
@@ -50,6 +51,22 @@ export const PageSettingsPanel: React.FC<PageSettingsPanelProps> = ({ page, isCo
               placeholder={t('pagePane.titlePlaceholder')}
               disabled={!canEditTitle}
               data-testid="page-settings-title-input"
+            />
+          </div>
+
+          <div className="flex items-center justify-between gap-2 mt-4">
+            <Label
+              htmlFor="page-settings-show-name"
+              className="text-sm font-medium text-foreground dark:text-gray-300 cursor-pointer"
+            >
+              {t('pagePane.showPageNameLabel')}
+            </Label>
+            <Switch
+              id="page-settings-show-name"
+              checked={page.showPageName !== false}
+              disabled={!canEditTitle}
+              onCheckedChange={(checked) => updatePageShowName(page.id, checked)}
+              data-testid="page-settings-show-name-toggle"
             />
           </div>
         </div>

--- a/apps/form-app/src/graphql/mutations.ts
+++ b/apps/form-app/src/graphql/mutations.ts
@@ -210,6 +210,7 @@ export const GENERATE_FORM_WITH_AI : TypedDocumentNode<any, any> = gql`
           value
           label
         }
+        section
       }
       layout {
         content

--- a/apps/form-app/src/locales/en/pageBuilderTab.json
+++ b/apps/form-app/src/locales/en/pageBuilderTab.json
@@ -41,6 +41,7 @@
     "title": "Page settings",
     "titleLabel": "Page title",
     "titlePlaceholder": "Untitled Page",
+    "showPageNameLabel": "Show page name to respondents",
     "duplicateButton": "Duplicate page",
     "deleteButton": "Delete page"
   },

--- a/apps/form-app/src/locales/ta/pageBuilderTab.json
+++ b/apps/form-app/src/locales/ta/pageBuilderTab.json
@@ -41,6 +41,7 @@
     "title": "பக்க அமைப்புகள்",
     "titleLabel": "பக்கத் தலைப்பு",
     "titlePlaceholder": "தலைப்பிடப்படாத பக்கம்",
+    "showPageNameLabel": "பதிலளிப்பவர்களுக்கு பக்கத் தலைப்பைக் காட்டு",
     "duplicateButton": "பக்கத்தை நகலெடு",
     "deleteButton": "பக்கத்தை நீக்கு"
   },

--- a/apps/form-app/src/pages/CreateFormWizard.tsx
+++ b/apps/form-app/src/pages/CreateFormWizard.tsx
@@ -52,6 +52,7 @@ interface AIField {
   placeholder: string | null;
   required: boolean;
   options: Array<{ value: string; label: string }> | null;
+  section: string;
 }
 
 interface SelectedImage {
@@ -121,20 +122,29 @@ function buildFormSchema(
 
   if (pageMode === 'single') {
     return {
-      pages: [{ id: `page-${Date.now()}`, title: 'Page 1', fields: fieldJsons, order: 1 }],
+      pages: [{ id: `page-${Date.now()}`, title: 'Page 1', fields: fieldJsons, order: 1, showPageName: true }],
       layout, isShuffleEnabled: false,
     };
   }
 
-  const PER_PAGE = 4;
+  // Group consecutive fields sharing the same AI-assigned section name onto one page,
+  // using that section name as the page title.
   const pages: any[] = [];
-  for (let i = 0; i < fieldJsons.length; i += PER_PAGE) {
+  let start = 0;
+  while (start < fields.length) {
+    const section = fields[start].section?.trim() || `Page ${pages.length + 1}`;
+    let end = start + 1;
+    while (end < fields.length && (fields[end].section?.trim() || '') === section) {
+      end++;
+    }
     pages.push({
-      id: `page-${Date.now()}-${i}`,
-      title: `Page ${pages.length + 1}`,
-      fields: fieldJsons.slice(i, i + PER_PAGE),
+      id: `page-${Date.now()}-${pages.length}`,
+      title: section,
+      fields: fieldJsons.slice(start, end),
       order: pages.length + 1,
+      showPageName: true,
     });
+    start = end;
   }
   return { pages, layout, isShuffleEnabled: false };
 }

--- a/apps/form-app/src/store/collaboration/CollaborationManager.ts
+++ b/apps/form-app/src/store/collaboration/CollaborationManager.ts
@@ -169,6 +169,7 @@ const deserializePagesFromYJS = (
       id: pageId,
       title: pageMap.get('title') || `Page ${index + 1}`,
       order: pageMap.get('order') ?? index,
+      showPageName: pageMap.get('showPageName') ?? true,
       fields,
     };
   });

--- a/apps/form-app/src/store/slices/pagesSlice.ts
+++ b/apps/form-app/src/store/slices/pagesSlice.ts
@@ -58,6 +58,7 @@ export const createPagesSlice: SliceCreator<PagesSlice> = (set, get) => {
       pageMap.set('id', newPageId);
       pageMap.set('title', `New Page ${pagesArray.length + 1}`);
       pageMap.set('order', pagesArray.length);
+      pageMap.set('showPageName', true);
       pageMap.set('fields', fieldsArray);
 
       pagesArray.push([pageMap]);
@@ -100,6 +101,7 @@ export const createPagesSlice: SliceCreator<PagesSlice> = (set, get) => {
         pageMap.set('title', title);
         pageMap.set('fields', fieldsArray);
         pageMap.set('description', '');
+        pageMap.set('showPageName', true);
         pageMap.set('order', 0); // corrected by the order rewrite loop below
 
         if (insertAfterPageId) {
@@ -194,6 +196,7 @@ export const createPagesSlice: SliceCreator<PagesSlice> = (set, get) => {
       duplicatePageMap.set('title', `${originalPageMap.get('title')} (Copy)`);
       duplicatePageMap.set('description', originalPageMap.get('description') || '');
       duplicatePageMap.set('order', pageIndex + 1);
+      duplicatePageMap.set('showPageName', originalPageMap.get('showPageName') ?? true);
 
       const originalFieldsArray = originalPageMap.get('fields') as Y.Array<Y.Map<any>>;
       const duplicateFieldsArray = new Y.Array();
@@ -240,6 +243,34 @@ export const createPagesSlice: SliceCreator<PagesSlice> = (set, get) => {
 
       const pageMap = pagesArray.get(pageIndex);
       pageMap.set('title', title);
+    },
+
+    /**
+     * Update whether the page name is shown to respondents
+     *
+     * Toggles visibility of this page's title in the form viewer.
+     */
+    updatePageShowName: (pageId: string, showPageName: boolean) => {
+      const { _getYDoc, _isYJSReady } = get() as any;
+      const ydoc = _getYDoc();
+      const isReady = _isYJSReady();
+
+      if (!ydoc || !isReady) {
+        console.warn('Cannot update page show name: YJS document not available or not connected');
+        return;
+      }
+
+      const formSchemaMap = ydoc.getMap('formSchema');
+      const pagesArray = getOrCreatePagesArray(formSchemaMap);
+
+      const pageIndex = pagesArray.toArray().findIndex((pageMap) => pageMap.get('id') === pageId);
+      if (pageIndex === -1) {
+        console.warn(`Page with id ${pageId} not found`);
+        return;
+      }
+
+      const pageMap = pagesArray.get(pageIndex);
+      pageMap.set('showPageName', showPageName);
     },
 
     /**
@@ -291,11 +322,13 @@ export const createPagesSlice: SliceCreator<PagesSlice> = (set, get) => {
           id: string;
           title: string;
           description: string;
+          showPageName: boolean;
           fields: FieldData[];
         } = {
           id: oldPageMap.get('id'),
           title: oldPageMap.get('title'),
           description: oldPageMap.get('description') || '',
+          showPageName: oldPageMap.get('showPageName') ?? true,
           fields: [],
         };
 
@@ -312,6 +345,7 @@ export const createPagesSlice: SliceCreator<PagesSlice> = (set, get) => {
         pageMap.set('id', pageData.id);
         pageMap.set('title', pageData.title);
         pageMap.set('description', pageData.description);
+        pageMap.set('showPageName', pageData.showPageName);
         pageMap.set('order', newIndex);
 
         const newFieldsArray = new Y.Array();

--- a/apps/form-app/src/store/types/store.types.ts
+++ b/apps/form-app/src/store/types/store.types.ts
@@ -53,6 +53,7 @@ export interface PagesSlice {
   removePage: (pageId: string) => void;
   duplicatePage: (pageId: string) => void;
   updatePageTitle: (pageId: string, title: string) => void;
+  updatePageShowName: (pageId: string, showPageName: boolean) => void;
   reorderPages: (oldIndex: number, newIndex: number) => void;
 
   // Internal helpers

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -116,6 +116,7 @@ export interface FormPage {
   title: string;
   fields: FormField[];
   order: number;
+  showPageName?: boolean; // Whether the page title is shown to respondents in the viewer (default: true)
 }
 
 export type LayoutCode =

--- a/packages/ui/src/renderers/PageRenderer.tsx
+++ b/packages/ui/src/renderers/PageRenderer.tsx
@@ -282,7 +282,7 @@ export const PageRenderer: React.FC<PageRendererProps> = ({
       )}
 
       {/* Page title */}
-      {showPageNavigation && currentPage?.title && (
+      {showPageNavigation && currentPage?.showPageName !== false && currentPage?.title && (
         <div className="mb-4 sm:mb-8">
           <h3
             className="text-3xl font-bold text-gray-900 dark:text-white tracking-tight"


### PR DESCRIPTION
## Summary
- Adds a per-page **show/hide page name** toggle (Page Settings panel in the builder), stored as `FormPage.showPageName` and threaded through Y.js real-time sync (frontend `CollaborationManager` + backend `hocuspocus.ts`).
- The form viewer's `PageRenderer` now respects the flag, hiding the page title (e.g. "Page 1", "Page 2") when disabled.
- Fixes AI form creation, which previously hardcoded every page title to `Page 1`/`Page 2`: the AI now assigns each generated field a short `section` label (e.g. "Personal Information"), and multi-page forms group consecutive same-section fields into a page titled after that section.

## Test plan
- [x] `pnpm --filter @dculus/types build` / `pnpm --filter @dculus/ui build` — clean
- [x] `apps/backend` type-check — clean
- [x] `apps/form-app` type-check — clean
- [x] `apps/form-viewer` type-check — clean
- [x] `apps/backend` full test suite — 2843 passed
- [x] `apps/form-app` full test suite — 174 passed
- [x] pre-commit / pre-push hooks (lint, build, tests) — passed
- [ ] Manual check in browser: toggle a page's "Show page name" off in the builder, confirm it's hidden in the form viewer, and confirm AI-generated multi-page forms get meaningful section-based page titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a page setting to show or hide page names for respondents.
  * AI-generated multi-page forms are now grouped into logical sections, with section names used as page titles.
  * Page-name visibility is preserved when creating, duplicating, reordering, and loading pages.

* **Localization**
  * Added English and Tamil translations for the page-name visibility setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->