### PR TITLE
Story 03: AI Chat — new aiChatRepository, wire aiChatService

### DIFF
--- a/apps/backend/src/repositories/__tests__/aiChatRepository.test.ts
+++ b/apps/backend/src/repositories/__tests__/aiChatRepository.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createAiChatRepository } from '../aiChatRepository.js';
+
+const prismaMock = vi.hoisted(() => ({
+  aIChatConversation: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    findFirst: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    count: vi.fn().mockResolvedValue(0),
+  },
+  aIChatMessage: {
+    findMany: vi.fn().mockResolvedValue([]),
+    create: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('../baseRepository.js', () => ({
+  resolvePrisma: () => prismaMock,
+}));
+
+describe('aiChatRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.aIChatConversation.findMany.mockResolvedValue([]);
+    prismaMock.aIChatConversation.findUnique.mockResolvedValue(null);
+    prismaMock.aIChatConversation.findFirst.mockResolvedValue(null);
+    prismaMock.aIChatConversation.create.mockResolvedValue({});
+    prismaMock.aIChatConversation.update.mockResolvedValue({});
+    prismaMock.aIChatConversation.delete.mockResolvedValue({});
+    prismaMock.aIChatConversation.count.mockResolvedValue(0);
+    prismaMock.aIChatMessage.findMany.mockResolvedValue([]);
+    prismaMock.aIChatMessage.create.mockResolvedValue({});
+  });
+
+  it('should proxy basic prisma delegate methods', async () => {
+    const repo = createAiChatRepository();
+    const args = { where: { id: 'conv-1' } };
+    await repo.findMany(args);
+    await repo.findUnique(args as any);
+    await repo.create({ data: { id: 'conv-1' } } as any);
+    await repo.update({ where: { id: 'conv-1' }, data: { title: 'New' } } as any);
+    await repo.delete({ where: { id: 'conv-1' } } as any);
+    await repo.count(args as any);
+    await repo.findManyMessages({ where: { conversationId: 'conv-1' } } as any);
+    await repo.createMessage({ data: { conversationId: 'conv-1' } } as any);
+
+    expect(prismaMock.aIChatConversation.findMany).toHaveBeenCalledWith(args);
+    expect(prismaMock.aIChatConversation.findUnique).toHaveBeenCalledWith(args);
+    expect(prismaMock.aIChatConversation.create).toHaveBeenCalled();
+    expect(prismaMock.aIChatConversation.update).toHaveBeenCalled();
+    expect(prismaMock.aIChatConversation.delete).toHaveBeenCalled();
+    expect(prismaMock.aIChatConversation.count).toHaveBeenCalledWith(args);
+    expect(prismaMock.aIChatMessage.findMany).toHaveBeenCalled();
+    expect(prismaMock.aIChatMessage.create).toHaveBeenCalled();
+  });
+
+  it('should expose domain helpers for conversations', async () => {
+    const repo = createAiChatRepository();
+
+    await repo.createConversation({ formId: 'f1', organizationId: 'o1', userId: 'u1', title: 'New conversation' } as any);
+    expect(prismaMock.aIChatConversation.create).toHaveBeenCalledWith({
+      data: { formId: 'f1', organizationId: 'o1', userId: 'u1', title: 'New conversation' },
+    });
+
+    await repo.listConversationsByForm('f1', 'o1', 'u1');
+    expect(prismaMock.aIChatConversation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { formId: 'f1', organizationId: 'o1', userId: 'u1' },
+        orderBy: { updatedAt: 'desc' },
+        include: { _count: { select: { messages: true } } },
+      })
+    );
+
+    await repo.findConversationById('conv-1', 'u1');
+    expect(prismaMock.aIChatConversation.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'conv-1', userId: 'u1' },
+        include: expect.objectContaining({
+          messages: { orderBy: { createdAt: 'asc' } },
+          _count: { select: { messages: true } },
+        }),
+      })
+    );
+
+    await repo.findConversationByUser('conv-1', 'u1');
+    expect(prismaMock.aIChatConversation.findFirst).toHaveBeenCalledWith({
+      where: { id: 'conv-1', userId: 'u1' },
+    });
+
+    await repo.deleteConversation('conv-1');
+    expect(prismaMock.aIChatConversation.delete).toHaveBeenCalledWith({ where: { id: 'conv-1' } });
+
+    await repo.updateConversation('conv-1', { title: 'Renamed' });
+    expect(prismaMock.aIChatConversation.update).toHaveBeenCalledWith({
+      where: { id: 'conv-1' },
+      data: { title: 'Renamed' },
+    });
+
+    await repo.touchConversation('conv-1');
+    expect(prismaMock.aIChatConversation.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'conv-1' }, data: expect.objectContaining({ updatedAt: expect.any(Date) }) })
+    );
+  });
+
+  it('should expose domain helpers for messages', async () => {
+    const repo = createAiChatRepository();
+
+    await repo.listRecentMessages('conv-1', 6);
+    expect(prismaMock.aIChatMessage.findMany).toHaveBeenCalledWith({
+      where: { conversationId: 'conv-1' },
+      orderBy: { createdAt: 'desc' },
+      take: 6,
+      select: { data: true },
+    });
+
+    await repo.createConversationMessage({ conversationId: 'conv-1', role: 'user', content: 'hi', data: {} } as any);
+    expect(prismaMock.aIChatMessage.create).toHaveBeenCalledWith({
+      data: { conversationId: 'conv-1', role: 'user', content: 'hi', data: {} },
+    });
+  });
+});

--- a/apps/backend/src/repositories/aiChatRepository.ts
+++ b/apps/backend/src/repositories/aiChatRepository.ts
@@ -1,0 +1,128 @@
+import type { Prisma } from '#prisma-client';
+import { resolvePrisma, type RepositoryContext } from './baseRepository.js';
+
+/**
+ * Factory for AI chat data access, covering both `AIChatConversation` and
+ * `AIChatMessage` Prisma models.
+ */
+export const createAiChatRepository = (context?: RepositoryContext) => {
+  const prisma = resolvePrisma(context);
+
+  /** --- Generic delegate passthroughs (AIChatConversation) --- */
+  const findMany = <T extends Prisma.AIChatConversationFindManyArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.AIChatConversationFindManyArgs>
+  ) => prisma.aIChatConversation.findMany(args);
+
+  const findUnique = <T extends Prisma.AIChatConversationFindUniqueArgs>(
+    args: Prisma.SelectSubset<T, Prisma.AIChatConversationFindUniqueArgs>
+  ) => prisma.aIChatConversation.findUnique(args);
+
+  const create = <T extends Prisma.AIChatConversationCreateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.AIChatConversationCreateArgs>
+  ) => prisma.aIChatConversation.create(args);
+
+  const update = <T extends Prisma.AIChatConversationUpdateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.AIChatConversationUpdateArgs>
+  ) => prisma.aIChatConversation.update(args);
+
+  const remove = <T extends Prisma.AIChatConversationDeleteArgs>(
+    args: Prisma.SelectSubset<T, Prisma.AIChatConversationDeleteArgs>
+  ) => prisma.aIChatConversation.delete(args);
+
+  const count = <T extends Prisma.AIChatConversationCountArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.AIChatConversationCountArgs>
+  ) => prisma.aIChatConversation.count(args);
+
+  /** --- Domain-oriented helpers for AIChatConversation --- */
+
+  const createConversation = async (
+    data: Prisma.AIChatConversationCreateArgs['data']
+  ) => prisma.aIChatConversation.create({ data });
+
+  const listConversationsByForm = async (
+    formId: string,
+    organizationId: string,
+    userId: string
+  ) =>
+    prisma.aIChatConversation.findMany({
+      where: { formId, organizationId, userId },
+      orderBy: { updatedAt: 'desc' },
+      include: { _count: { select: { messages: true } } },
+    });
+
+  const findConversationById = async (id: string, userId: string) =>
+    prisma.aIChatConversation.findFirst({
+      where: { id, userId },
+      include: {
+        messages: { orderBy: { createdAt: 'asc' } },
+        _count: { select: { messages: true } },
+      },
+    });
+
+  const findConversationByUser = async (id: string, userId: string) =>
+    prisma.aIChatConversation.findFirst({ where: { id, userId } });
+
+  const deleteConversation = async (id: string) =>
+    prisma.aIChatConversation.delete({ where: { id } });
+
+  const updateConversation = async (
+    id: string,
+    data: Prisma.AIChatConversationUpdateInput
+  ) => prisma.aIChatConversation.update({ where: { id }, data });
+
+  const touchConversation = async (id: string) =>
+    prisma.aIChatConversation.update({
+      where: { id },
+      data: { updatedAt: new Date() },
+    });
+
+  /** --- Generic delegate passthroughs (AIChatMessage) --- */
+  const findManyMessages = <T extends Prisma.AIChatMessageFindManyArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.AIChatMessageFindManyArgs>
+  ) => prisma.aIChatMessage.findMany(args);
+
+  const createMessage = <T extends Prisma.AIChatMessageCreateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.AIChatMessageCreateArgs>
+  ) => prisma.aIChatMessage.create(args);
+
+  /** --- Domain-oriented helpers for AIChatMessage --- */
+
+  const listRecentMessages = async (conversationId: string, take: number) =>
+    prisma.aIChatMessage.findMany({
+      where: { conversationId },
+      orderBy: { createdAt: 'desc' },
+      take,
+      select: { data: true },
+    });
+
+  const createConversationMessage = async (
+    data: Prisma.AIChatMessageCreateArgs['data']
+  ) => prisma.aIChatMessage.create({ data });
+
+  return {
+    // Generic operations (used when custom queries are needed)
+    findMany,
+    findUnique,
+    create,
+    update,
+    delete: remove,
+    count,
+    findManyMessages,
+    createMessage,
+
+    // Domain helpers (preferred for service layer)
+    createConversation,
+    listConversationsByForm,
+    findConversationById,
+    findConversationByUser,
+    deleteConversation,
+    updateConversation,
+    touchConversation,
+    listRecentMessages,
+    createConversationMessage,
+  };
+};
+
+export type AiChatRepository = ReturnType<typeof createAiChatRepository>;
+
+export const aiChatRepository = createAiChatRepository();

--- a/apps/backend/src/repositories/index.ts
+++ b/apps/backend/src/repositories/index.ts
@@ -7,3 +7,4 @@ export * from './formMetadataRepository.js';
 export * from './collaborativeDocumentRepository.js';
 export * from './formViewAnalyticsRepository.js';
 export * from './formSubmissionAnalyticsRepository.js';
+export * from './aiChatRepository.js';

--- a/apps/backend/src/services/aiChatService.ts
+++ b/apps/backend/src/services/aiChatService.ts
@@ -1,6 +1,6 @@
 import { generateText } from 'ai';
 import type { UIMessage } from 'ai';
-import { prisma } from '../lib/prisma.js';
+import { aiChatRepository } from '../repositories/aiChatRepository.js';
 import { getFastModel } from '../lib/ai.js';
 import { logger } from '../lib/logger.js';
 
@@ -47,8 +47,8 @@ export async function createConversation(
   organizationId: string,
   userId: string
 ) {
-  return prisma.aIChatConversation.create({
-    data: { formId, organizationId, userId, title: 'New conversation' },
+  return aiChatRepository.createConversation({
+    formId, organizationId, userId, title: 'New conversation',
   });
 }
 
@@ -57,11 +57,9 @@ export async function listConversations(
   organizationId: string,
   userId: string
 ) {
-  const conversations = await prisma.aIChatConversation.findMany({
-    where: { formId, organizationId, userId },
-    orderBy: { updatedAt: 'desc' },
-    include: { _count: { select: { messages: true } } },
-  });
+  const conversations = await aiChatRepository.listConversationsByForm(
+    formId, organizationId, userId
+  );
 
   return conversations.map((c) => ({
     ...c,
@@ -71,38 +69,27 @@ export async function listConversations(
 }
 
 export async function getConversation(id: string, userId: string) {
-  const conv = await prisma.aIChatConversation.findFirst({
-    where: { id, userId },
-    include: {
-      messages: { orderBy: { createdAt: 'asc' } },
-      _count: { select: { messages: true } },
-    },
-  });
+  const conv = await aiChatRepository.findConversationById(id, userId);
   if (!conv) return null;
   return { ...conv, messageCount: conv._count.messages };
 }
 
 export async function deleteConversation(id: string, userId: string) {
-  const conv = await prisma.aIChatConversation.findFirst({ where: { id, userId } });
+  const conv = await aiChatRepository.findConversationByUser(id, userId);
   if (!conv) return false;
-  await prisma.aIChatConversation.delete({ where: { id } });
+  await aiChatRepository.deleteConversation(id);
   return true;
 }
 
 export async function renameConversation(id: string, userId: string, title: string) {
-  const conv = await prisma.aIChatConversation.findFirst({ where: { id, userId } });
+  const conv = await aiChatRepository.findConversationByUser(id, userId);
   if (!conv) return null;
   const safeTitle = title.trim().slice(0, 100) || 'Untitled conversation';
-  return prisma.aIChatConversation.update({ where: { id }, data: { title: safeTitle } });
+  return aiChatRepository.updateConversation(id, { title: safeTitle });
 }
 
 export async function loadConversationMessages(conversationId: string): Promise<UIMessage[]> {
-  const messages = await prisma.aIChatMessage.findMany({
-    where: { conversationId },
-    orderBy: { createdAt: 'desc' },
-    take: MAX_HISTORY_MESSAGES,
-    select: { data: true },
-  });
+  const messages = await aiChatRepository.listRecentMessages(conversationId, MAX_HISTORY_MESSAGES);
   return messages.reverse().map((m) => m.data as unknown as UIMessage);
 }
 
@@ -222,21 +209,16 @@ export async function saveConversationMessages(
     const isLast = i === messages.length - 1;
     const textPart = (msg.parts as any[])?.find((p: any) => p.type === 'text');
     const textContent = textPart?.text ?? (msg as any).content ?? '';
-    await prisma.aIChatMessage.create({
-      data: {
-        conversationId,
-        role: msg.role,
-        content: textContent,
-        data: msg as any,
-        tokensUsed: isLast && msg.role === 'assistant' ? tokensUsed : 0,
-        createdAt: new Date(base + i),
-      },
+    await aiChatRepository.createConversationMessage({
+      conversationId,
+      role: msg.role,
+      content: textContent,
+      data: msg as any,
+      tokensUsed: isLast && msg.role === 'assistant' ? tokensUsed : 0,
+      createdAt: new Date(base + i),
     });
   }
-  await prisma.aIChatConversation.update({
-    where: { id: conversationId },
-    data: { updatedAt: new Date() },
-  });
+  await aiChatRepository.touchConversation(conversationId);
 }
 
 // Fire-and-forget: generates a short title from the first user message
@@ -248,7 +230,7 @@ export function autoGenerateTitle(conversationId: string, firstMessage: string):
     .then(async ({ text }) => {
       try {
         const title = text.trim().slice(0, 60);
-        await prisma.aIChatConversation.update({ where: { id: conversationId }, data: { title } });
+        await aiChatRepository.updateConversation(conversationId, { title });
       } catch (err) {
         logger.warn({ err, conversationId }, 'Failed to save auto-generated title');
       }


### PR DESCRIPTION
## Summary
- Adds `aiChatRepository.ts` covering both `AIChatConversation` and `AIChatMessage` Prisma models, following the `formRepository.ts` shape (generic passthroughs + domain helpers).
- Routes all direct `prisma.aIChatConversation.*` / `prisma.aIChatMessage.*` calls in `aiChatService.ts` through the new repository.
- Registers the repository in `repositories/index.ts`.
- `aiChat.ts` resolver is untouched — it was already fully service-driven (out of scope per the ticket).

Part of Epic #245 (Backend — Repository Pattern Rollout). Closes #249.

## Test plan
- [x] `apps/backend/src/repositories/__tests__/aiChatRepository.test.ts` added, mocked Prisma, no real DB
- [x] `grep -n "prisma\." apps/backend/src/services/aiChatService.ts` → zero results
- [x] `pnpm --filter backend exec tsc --noEmit` passes
- [x] `pnpm test:unit` passes (102 files / 2892 tests, including existing AI-chat tests unmodified)