### PR TITLE
Story 07: Plugins — pluginRepository + pluginService

### DIFF
--- a/apps/backend/src/graphql/resolvers/plugins.ts
+++ b/apps/backend/src/graphql/resolvers/plugins.ts
@@ -1,11 +1,10 @@
 import { createGraphQLError } from '#graphql-errors';
 import { GRAPHQL_ERROR_CODES } from '@dculus/types/graphql.js';
-import { prisma } from '../../lib/prisma.js';
 import { BetterAuthContext, requireAuth } from '../../middleware/better-auth-middleware.js';
 import { checkFormAccess, PermissionLevel } from './formSharing.js';
 import { emitPluginTest } from '../../plugins/core/events.js';
 import { startBackfill, cancelBackfill, getLatestBackfillJob } from '../../plugins/core/backfill.js';
-import { generateId } from '@dculus/utils';
+import * as pluginService from '../../services/pluginService.js';
 
 /**
  * GraphQL Resolvers for Plugin System
@@ -35,10 +34,7 @@ export const pluginsResolvers = {
       }
 
       // Fetch all plugins for this form
-      const plugins = await prisma.formPlugin.findMany({
-        where: { formId },
-        orderBy: { createdAt: 'desc' },
-      });
+      const plugins = await pluginService.listPluginsByForm(formId);
 
       return plugins;
     },
@@ -54,10 +50,7 @@ export const pluginsResolvers = {
       requireAuth(context.auth);
 
       // Fetch plugin and check access
-      const plugin = await prisma.formPlugin.findUnique({
-        where: { id },
-        include: { form: true },
-      });
+      const plugin = await pluginService.getPluginByIdWithForm(id);
 
       if (!plugin) {
         throw createGraphQLError('Plugin not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
@@ -87,9 +80,7 @@ export const pluginsResolvers = {
       requireAuth(context.auth);
 
       // Fetch plugin and check access
-      const plugin = await prisma.formPlugin.findUnique({
-        where: { id: pluginId },
-      });
+      const plugin = await pluginService.getPluginById(pluginId);
 
       if (!plugin) {
         throw createGraphQLError('Plugin not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
@@ -106,11 +97,7 @@ export const pluginsResolvers = {
       }
 
       // Fetch delivery history
-      const deliveries = await prisma.pluginDelivery.findMany({
-        where: { pluginId },
-        orderBy: { deliveredAt: 'desc' },
-        take: limit,
-      });
+      const deliveries = await pluginService.listPluginDeliveries(pluginId, limit);
 
       return deliveries;
     },
@@ -125,7 +112,7 @@ export const pluginsResolvers = {
     ) => {
       requireAuth(context.auth);
 
-      const plugin = await prisma.formPlugin.findUnique({ where: { id: pluginId } });
+      const plugin = await pluginService.getPluginById(pluginId);
       if (!plugin) {
         throw createGraphQLError('Plugin not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
       }
@@ -185,17 +172,7 @@ export const pluginsResolvers = {
       }
 
       // Create plugin
-      const plugin = await prisma.formPlugin.create({
-        data: {
-          id: generateId(),
-          formId: input.formId,
-          type: input.type,
-          name: input.name,
-          config: input.config,
-          events: input.events,
-          enabled: input.enabled ?? true,
-        },
-      });
+      const plugin = await pluginService.createPlugin(input);
 
       return plugin;
     },
@@ -222,9 +199,7 @@ export const pluginsResolvers = {
       requireAuth(context.auth);
 
       // Fetch plugin
-      const plugin = await prisma.formPlugin.findUnique({
-        where: { id },
-      });
+      const plugin = await pluginService.getPluginById(id);
 
       if (!plugin) {
         throw createGraphQLError('Plugin not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
@@ -252,13 +227,7 @@ export const pluginsResolvers = {
       }
 
       // Update plugin
-      const updatedPlugin = await prisma.formPlugin.update({
-        where: { id },
-        data: {
-          ...input,
-          updatedAt: new Date(),
-        },
-      });
+      const updatedPlugin = await pluginService.updatePlugin(id, input);
 
       return updatedPlugin;
     },
@@ -274,9 +243,7 @@ export const pluginsResolvers = {
       requireAuth(context.auth);
 
       // Fetch plugin
-      const plugin = await prisma.formPlugin.findUnique({
-        where: { id },
-      });
+      const plugin = await pluginService.getPluginById(id);
 
       if (!plugin) {
         throw createGraphQLError('Plugin not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
@@ -293,9 +260,7 @@ export const pluginsResolvers = {
       }
 
       // Delete plugin (deliveries will cascade delete)
-      await prisma.formPlugin.delete({
-        where: { id },
-      });
+      await pluginService.deletePlugin(id);
 
       return { success: true, message: 'Plugin deleted successfully' };
     },
@@ -311,10 +276,7 @@ export const pluginsResolvers = {
       requireAuth(context.auth);
 
       // Fetch plugin
-      const plugin = await prisma.formPlugin.findUnique({
-        where: { id },
-        include: { form: true },
-      });
+      const plugin = await pluginService.getPluginByIdWithForm(id);
 
       if (!plugin) {
         throw createGraphQLError('Plugin not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
@@ -353,7 +315,7 @@ export const pluginsResolvers = {
     ) => {
       requireAuth(context.auth);
 
-      const plugin = await prisma.formPlugin.findUnique({ where: { id: pluginId } });
+      const plugin = await pluginService.getPluginById(pluginId);
       if (!plugin) {
         throw createGraphQLError('Plugin not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
       }
@@ -380,12 +342,12 @@ export const pluginsResolvers = {
     ) => {
       requireAuth(context.auth);
 
-      const job = await prisma.pluginBackfillJob.findUnique({ where: { id: jobId } });
+      const job = await pluginService.getBackfillJobById(jobId);
       if (!job) {
         throw createGraphQLError('Backfill job not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
       }
 
-      const plugin = await prisma.formPlugin.findUnique({ where: { id: job.pluginId } });
+      const plugin = await pluginService.getPluginById(job.pluginId);
       if (!plugin) {
         throw createGraphQLError('Plugin not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
       }

--- a/apps/backend/src/graphql/resolvers/unifiedExport.ts
+++ b/apps/backend/src/graphql/resolvers/unifiedExport.ts
@@ -10,7 +10,7 @@ import { deserializeFormSchema } from '@dculus/types';
 import { ResponseFilter, applyResponseFilters } from '../../services/responseFilterService.js';
 import { checkFormAccess, PermissionLevel } from './formSharing.js';
 import { logger } from '../../lib/logger.js';
-import { prisma } from '../../lib/prisma.js';
+import * as pluginService from '../../services/pluginService.js';
 
 
 export const unifiedExportResolvers = {
@@ -104,10 +104,7 @@ export const unifiedExportResolvers = {
         // per-plugin settings (e.g. the quiz plugin's configurable columnName).
         // Key by 'type:id' so multiple instances of the same plugin type each
         // get their own config entry, matching the metadata key written by the handler.
-        const formPlugins = await prisma.formPlugin.findMany({
-          where: { formId, enabled: true },
-          select: { id: true, type: true, config: true },
-        });
+        const formPlugins = await pluginService.listEnabledPluginConfigsByForm(formId);
         const pluginConfigs: Record<string, Record<string, any>> = {};
         for (const fp of formPlugins) {
           if (fp.config && typeof fp.config === 'object') {

--- a/apps/backend/src/repositories/__tests__/pluginRepository.test.ts
+++ b/apps/backend/src/repositories/__tests__/pluginRepository.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createPluginRepository } from '../pluginRepository.js';
+
+const prismaMock = vi.hoisted(() => ({
+  formPlugin: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    count: vi.fn().mockResolvedValue(0),
+  },
+  pluginDelivery: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+  },
+  pluginBackfillJob: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('../baseRepository.js', () => ({
+  resolvePrisma: () => prismaMock,
+}));
+
+describe('pluginRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.formPlugin.findMany.mockResolvedValue([]);
+    prismaMock.formPlugin.findUnique.mockResolvedValue(null);
+    prismaMock.formPlugin.create.mockResolvedValue({});
+    prismaMock.formPlugin.update.mockResolvedValue({});
+    prismaMock.formPlugin.delete.mockResolvedValue({});
+    prismaMock.formPlugin.count.mockResolvedValue(0);
+    prismaMock.pluginDelivery.findMany.mockResolvedValue([]);
+    prismaMock.pluginDelivery.findUnique.mockResolvedValue(null);
+    prismaMock.pluginDelivery.create.mockResolvedValue({});
+    prismaMock.pluginBackfillJob.findMany.mockResolvedValue([]);
+    prismaMock.pluginBackfillJob.findUnique.mockResolvedValue(null);
+    prismaMock.pluginBackfillJob.create.mockResolvedValue({});
+    prismaMock.pluginBackfillJob.update.mockResolvedValue({});
+  });
+
+  it('should proxy generic FormPlugin delegate methods', async () => {
+    const repo = createPluginRepository();
+    const args = { where: { id: 'plugin-1' } };
+
+    await repo.findMany(args);
+    await repo.findUnique(args as any);
+    await repo.create({ data: { id: 'plugin-1' } } as any);
+    await repo.update({ where: { id: 'plugin-1' }, data: { name: 'New' } } as any);
+    await repo.delete({ where: { id: 'plugin-1' } } as any);
+    await repo.count(args as any);
+
+    expect(prismaMock.formPlugin.findMany).toHaveBeenCalledWith(args);
+    expect(prismaMock.formPlugin.findUnique).toHaveBeenCalledWith(args);
+    expect(prismaMock.formPlugin.create).toHaveBeenCalled();
+    expect(prismaMock.formPlugin.update).toHaveBeenCalled();
+    expect(prismaMock.formPlugin.delete).toHaveBeenCalled();
+    expect(prismaMock.formPlugin.count).toHaveBeenCalledWith(args);
+  });
+
+  it('should expose FormPlugin domain helpers', async () => {
+    const repo = createPluginRepository();
+
+    await repo.listByForm('form-1');
+    expect(prismaMock.formPlugin.findMany).toHaveBeenCalledWith({
+      where: { formId: 'form-1' },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    await repo.listEnabledByForm('form-1');
+    expect(prismaMock.formPlugin.findMany).toHaveBeenCalledWith({
+      where: { formId: 'form-1', enabled: true },
+      select: { id: true, type: true, config: true },
+    });
+
+    await repo.findById('plugin-1');
+    expect(prismaMock.formPlugin.findUnique).toHaveBeenCalledWith({ where: { id: 'plugin-1' } });
+
+    await repo.findByIdWithForm('plugin-1');
+    expect(prismaMock.formPlugin.findUnique).toHaveBeenCalledWith({
+      where: { id: 'plugin-1' },
+      include: { form: true },
+    });
+  });
+
+  it('should proxy PluginDelivery methods and domain helper', async () => {
+    const repo = createPluginRepository();
+
+    await repo.findManyDeliveries({ where: { pluginId: 'plugin-1' } } as any);
+    expect(prismaMock.pluginDelivery.findMany).toHaveBeenCalledWith({ where: { pluginId: 'plugin-1' } });
+
+    await repo.findUniqueDelivery({ where: { id: 'delivery-1' } } as any);
+    expect(prismaMock.pluginDelivery.findUnique).toHaveBeenCalledWith({ where: { id: 'delivery-1' } });
+
+    await repo.createDelivery({ data: { id: 'delivery-1' } } as any);
+    expect(prismaMock.pluginDelivery.create).toHaveBeenCalledWith({ data: { id: 'delivery-1' } });
+
+    await repo.listDeliveriesByPlugin('plugin-1', 25);
+    expect(prismaMock.pluginDelivery.findMany).toHaveBeenCalledWith({
+      where: { pluginId: 'plugin-1' },
+      orderBy: { deliveredAt: 'desc' },
+      take: 25,
+    });
+
+    await repo.listDeliveriesByPlugin('plugin-1');
+    expect(prismaMock.pluginDelivery.findMany).toHaveBeenCalledWith({
+      where: { pluginId: 'plugin-1' },
+      orderBy: { deliveredAt: 'desc' },
+      take: 50,
+    });
+  });
+
+  it('should proxy PluginBackfillJob methods and domain helper', async () => {
+    const repo = createPluginRepository();
+
+    await repo.findManyBackfillJobs({ where: { pluginId: 'plugin-1' } } as any);
+    expect(prismaMock.pluginBackfillJob.findMany).toHaveBeenCalledWith({ where: { pluginId: 'plugin-1' } });
+
+    await repo.findUniqueBackfillJob({ where: { id: 'job-1' } } as any);
+    expect(prismaMock.pluginBackfillJob.findUnique).toHaveBeenCalledWith({ where: { id: 'job-1' } });
+
+    await repo.createBackfillJob({ data: { id: 'job-1' } } as any);
+    expect(prismaMock.pluginBackfillJob.create).toHaveBeenCalledWith({ data: { id: 'job-1' } });
+
+    await repo.updateBackfillJob({ where: { id: 'job-1' }, data: { status: 'completed' } } as any);
+    expect(prismaMock.pluginBackfillJob.update).toHaveBeenCalledWith({
+      where: { id: 'job-1' },
+      data: { status: 'completed' },
+    });
+
+    await repo.findBackfillJobById('job-1');
+    expect(prismaMock.pluginBackfillJob.findUnique).toHaveBeenCalledWith({ where: { id: 'job-1' } });
+  });
+});

--- a/apps/backend/src/repositories/index.ts
+++ b/apps/backend/src/repositories/index.ts
@@ -7,3 +7,4 @@ export * from './formMetadataRepository.js';
 export * from './collaborativeDocumentRepository.js';
 export * from './formViewAnalyticsRepository.js';
 export * from './formSubmissionAnalyticsRepository.js';
+export * from './pluginRepository.js';

--- a/apps/backend/src/repositories/pluginRepository.ts
+++ b/apps/backend/src/repositories/pluginRepository.ts
@@ -1,0 +1,131 @@
+import type { Prisma } from '#prisma-client';
+import { resolvePrisma, type RepositoryContext } from './baseRepository.js';
+
+/**
+ * Factory for all plugin related data access (FormPlugin, PluginDelivery,
+ * PluginBackfillJob). Covers the plugin *CRUD* surface only — the plugin
+ * *execution* system (registry, executor, event emitter, per-type handlers)
+ * lives under `plugins/` and is out of scope here.
+ */
+export const createPluginRepository = (context?: RepositoryContext) => {
+  const prisma = resolvePrisma(context);
+
+  /** --- FormPlugin: generic delegate passthroughs --- */
+  const findMany = <T extends Prisma.FormPluginFindManyArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.FormPluginFindManyArgs>
+  ) => prisma.formPlugin.findMany(args);
+
+  const findUnique = <T extends Prisma.FormPluginFindUniqueArgs>(
+    args: Prisma.SelectSubset<T, Prisma.FormPluginFindUniqueArgs>
+  ) => prisma.formPlugin.findUnique(args);
+
+  const create = <T extends Prisma.FormPluginCreateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.FormPluginCreateArgs>
+  ) => prisma.formPlugin.create(args);
+
+  const update = <T extends Prisma.FormPluginUpdateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.FormPluginUpdateArgs>
+  ) => prisma.formPlugin.update(args);
+
+  const remove = <T extends Prisma.FormPluginDeleteArgs>(
+    args: Prisma.SelectSubset<T, Prisma.FormPluginDeleteArgs>
+  ) => prisma.formPlugin.delete(args);
+
+  const count = <T extends Prisma.FormPluginCountArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.FormPluginCountArgs>
+  ) => prisma.formPlugin.count(args);
+
+  /** --- FormPlugin: domain-oriented helpers --- */
+  const listByForm = async (formId: string) =>
+    prisma.formPlugin.findMany({
+      where: { formId },
+      orderBy: { createdAt: 'desc' },
+    });
+
+  const listEnabledByForm = async (formId: string) =>
+    prisma.formPlugin.findMany({
+      where: { formId, enabled: true },
+      select: { id: true, type: true, config: true },
+    });
+
+  const findById = async (id: string) =>
+    prisma.formPlugin.findUnique({ where: { id } });
+
+  const findByIdWithForm = async (id: string) =>
+    prisma.formPlugin.findUnique({ where: { id }, include: { form: true } });
+
+  /** --- PluginDelivery: generic delegate passthroughs --- */
+  const findManyDeliveries = <T extends Prisma.PluginDeliveryFindManyArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.PluginDeliveryFindManyArgs>
+  ) => prisma.pluginDelivery.findMany(args);
+
+  const findUniqueDelivery = <T extends Prisma.PluginDeliveryFindUniqueArgs>(
+    args: Prisma.SelectSubset<T, Prisma.PluginDeliveryFindUniqueArgs>
+  ) => prisma.pluginDelivery.findUnique(args);
+
+  const createDelivery = <T extends Prisma.PluginDeliveryCreateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.PluginDeliveryCreateArgs>
+  ) => prisma.pluginDelivery.create(args);
+
+  /** --- PluginDelivery: domain-oriented helpers --- */
+  const listDeliveriesByPlugin = async (pluginId: string, limit = 50) =>
+    prisma.pluginDelivery.findMany({
+      where: { pluginId },
+      orderBy: { deliveredAt: 'desc' },
+      take: limit,
+    });
+
+  /** --- PluginBackfillJob: generic delegate passthroughs --- */
+  const findManyBackfillJobs = <T extends Prisma.PluginBackfillJobFindManyArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.PluginBackfillJobFindManyArgs>
+  ) => prisma.pluginBackfillJob.findMany(args);
+
+  const findUniqueBackfillJob = <T extends Prisma.PluginBackfillJobFindUniqueArgs>(
+    args: Prisma.SelectSubset<T, Prisma.PluginBackfillJobFindUniqueArgs>
+  ) => prisma.pluginBackfillJob.findUnique(args);
+
+  const createBackfillJob = <T extends Prisma.PluginBackfillJobCreateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.PluginBackfillJobCreateArgs>
+  ) => prisma.pluginBackfillJob.create(args);
+
+  const updateBackfillJob = <T extends Prisma.PluginBackfillJobUpdateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.PluginBackfillJobUpdateArgs>
+  ) => prisma.pluginBackfillJob.update(args);
+
+  /** --- PluginBackfillJob: domain-oriented helpers --- */
+  const findBackfillJobById = async (id: string) =>
+    prisma.pluginBackfillJob.findUnique({ where: { id } });
+
+  return {
+    // FormPlugin: generic operations
+    findMany,
+    findUnique,
+    create,
+    update,
+    delete: remove,
+    count,
+
+    // FormPlugin: domain helpers
+    listByForm,
+    listEnabledByForm,
+    findById,
+    findByIdWithForm,
+
+    // PluginDelivery
+    findManyDeliveries,
+    findUniqueDelivery,
+    createDelivery,
+    listDeliveriesByPlugin,
+
+    // PluginBackfillJob
+    findManyBackfillJobs,
+    findUniqueBackfillJob,
+    createBackfillJob,
+    updateBackfillJob,
+    findBackfillJobById,
+  };
+};
+
+export type PluginRepository = ReturnType<typeof createPluginRepository>;
+
+export const pluginRepository = createPluginRepository();

--- a/apps/backend/src/services/pluginService.ts
+++ b/apps/backend/src/services/pluginService.ts
@@ -1,0 +1,68 @@
+import { generateId } from '@dculus/utils';
+import { pluginRepository } from '../repositories/index.js';
+
+/**
+ * CRUD-facing plugin service (FormPlugin, PluginDelivery, PluginBackfillJob).
+ * Distinct from `plugins/` (the plugin *execution* system — registry,
+ * executor, event emitter, per-type handlers), which this service does not
+ * touch or replace.
+ */
+
+export interface CreateFormPluginInput {
+  formId: string;
+  type: string;
+  name: string;
+  config: any;
+  events: string[];
+  enabled?: boolean;
+}
+
+export interface UpdateFormPluginInput {
+  name?: string;
+  config?: any;
+  events?: string[];
+  enabled?: boolean;
+}
+
+export const listPluginsByForm = async (formId: string) =>
+  pluginRepository.listByForm(formId);
+
+export const listEnabledPluginConfigsByForm = async (formId: string) =>
+  pluginRepository.listEnabledByForm(formId);
+
+export const getPluginById = async (id: string) =>
+  pluginRepository.findById(id);
+
+export const getPluginByIdWithForm = async (id: string) =>
+  pluginRepository.findByIdWithForm(id);
+
+export const createPlugin = async (input: CreateFormPluginInput) =>
+  pluginRepository.create({
+    data: {
+      id: generateId(),
+      formId: input.formId,
+      type: input.type,
+      name: input.name,
+      config: input.config,
+      events: input.events,
+      enabled: input.enabled ?? true,
+    },
+  });
+
+export const updatePlugin = async (id: string, input: UpdateFormPluginInput) =>
+  pluginRepository.update({
+    where: { id },
+    data: {
+      ...input,
+      updatedAt: new Date(),
+    },
+  });
+
+export const deletePlugin = async (id: string) =>
+  pluginRepository.delete({ where: { id } });
+
+export const listPluginDeliveries = async (pluginId: string, limit = 50) =>
+  pluginRepository.listDeliveriesByPlugin(pluginId, limit);
+
+export const getBackfillJobById = async (id: string) =>
+  pluginRepository.findBackfillJobById(id);


### PR DESCRIPTION
## Summary
- Adds `pluginRepository` (`apps/backend/src/repositories/pluginRepository.ts`) covering `FormPlugin`, `PluginDelivery`, `PluginBackfillJob`, following the `formRepository.ts` conventions.
- Adds `pluginService` (`apps/backend/src/services/pluginService.ts`) — pure CRUD/light orchestration, distinct from the plugin *execution* system in `apps/backend/src/plugins/` (registry/executor/event emitter/handlers), which is untouched.
- Routes `apps/backend/src/graphql/resolvers/plugins.ts` (all 13 direct `prisma.*` call sites) and `unifiedExport.ts` (1 call site) through the new service. All existing `requireAuth`/`checkFormAccess` guards are preserved exactly as-is — no behavior change.

Closes #253 (part of epic #245).

## Test plan
- [x] `pnpm --filter backend exec tsc --noEmit` passes
- [x] `pnpm test:unit` passes (102 files / 2893 tests), including `plugins/**/__tests__/` unmodified
- [x] New `apps/backend/src/repositories/__tests__/pluginRepository.test.ts` added (mocked Prisma)
- [x] `grep -n "prisma\."` on `plugins.ts` and `unifiedExport.ts` returns zero results
- [x] Pre-push hooks (backend tests, form-viewer/admin-app/form-app builds) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Improved consistency across plugin management, delivery history, and backfill operations.
  - Unified exports continue to include enabled plugin configurations correctly.

- **Bug Fixes**
  - Preserved existing access checks and clear not-found handling for missing plugins and backfill jobs.
  - Improved consistency when creating, updating, deleting, testing, and cancelling plugin backfills.

- **Tests**
  - Added comprehensive coverage for plugin operations, delivery history, and backfill job handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->