### PR TITLE
Story 08: Invitations — invitationRepository + invitationService

### DIFF
--- a/apps/backend/src/graphql/resolvers/__tests__/invitations.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/invitations.test.ts
@@ -1,27 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { invitationResolvers } from '../invitations.js';
 import { GraphQLError } from '#graphql-errors';
-import { prisma } from '../../../lib/prisma.js';
+import { getInvitationById } from '../../../services/invitationService.js';
 import * as dateHelpers from '../../../utils/dateHelpers.js';
 
 // Mock all dependencies
-vi.mock('../../../lib/prisma.js', () => ({
-  prisma: {
-    invitation: {
-      findUnique: vi.fn(),
-      findMany: vi.fn(),
-      create: vi.fn(),
-      update: vi.fn(),
-      delete: vi.fn(),
-    },
-    member: {
-      findFirst: vi.fn(),
-      create: vi.fn(),
-    },
-    organization: {
-      findUnique: vi.fn(),
-    },
-  },
+vi.mock('../../../services/invitationService.js', () => ({
+  getInvitationById: vi.fn(),
 }));
 
 vi.mock('../../../lib/logger.js', () => ({
@@ -112,7 +97,7 @@ describe('Invitation Resolvers', () => {
 
     describe('Invitation Not Found', () => {
       it('should throw error when invitation does not exist', async () => {
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(null);
+        vi.mocked(getInvitationById).mockResolvedValue(null);
 
         await expect(
           invitationResolvers.Query.getInvitationPublic({}, { id: 'nonexistent-id' })
@@ -123,32 +108,14 @@ describe('Invitation Resolvers', () => {
         ).rejects.toThrow('Invitation not found or has expired');
       });
 
-      it('should call prisma with correct parameters', async () => {
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(null);
+      it('should call the invitation service with correct parameters', async () => {
+        vi.mocked(getInvitationById).mockResolvedValue(null);
 
         await expect(
           invitationResolvers.Query.getInvitationPublic({}, { id: 'test-id-8x' })
         ).rejects.toThrow();
 
-        expect(prisma.invitation.findUnique).toHaveBeenCalledWith({
-          where: { id: 'test-id-8x' },
-          include: {
-            organization: {
-              select: {
-                id: true,
-                name: true,
-                slug: true,
-              },
-            },
-            inviter: {
-              select: {
-                id: true,
-                name: true,
-                email: true,
-              },
-            },
-          },
-        });
+        expect(getInvitationById).toHaveBeenCalledWith('test-id-8x');
       });
     });
 
@@ -158,7 +125,7 @@ describe('Invitation Resolvers', () => {
           ...mockInvitation,
           status: 'accepted',
         };
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(acceptedInvitation as any);
+        vi.mocked(getInvitationById).mockResolvedValue(acceptedInvitation as any);
 
         await expect(
           invitationResolvers.Query.getInvitationPublic({}, { id: 'invitation-123' })
@@ -174,7 +141,7 @@ describe('Invitation Resolvers', () => {
           ...mockInvitation,
           status: 'cancelled',
         };
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(cancelledInvitation as any);
+        vi.mocked(getInvitationById).mockResolvedValue(cancelledInvitation as any);
 
         await expect(
           invitationResolvers.Query.getInvitationPublic({}, { id: 'invitation-123' })
@@ -190,7 +157,7 @@ describe('Invitation Resolvers', () => {
           ...mockInvitation,
           status: 'rejected',
         };
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(rejectedInvitation as any);
+        vi.mocked(getInvitationById).mockResolvedValue(rejectedInvitation as any);
 
         await expect(
           invitationResolvers.Query.getInvitationPublic({}, { id: 'invitation-123' })
@@ -206,7 +173,7 @@ describe('Invitation Resolvers', () => {
           ...mockInvitation,
           status: 'accepted',
         };
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(acceptedInvitation as any);
+        vi.mocked(getInvitationById).mockResolvedValue(acceptedInvitation as any);
         vi.mocked(dateHelpers.isDateExpired).mockReturnValue(true);
 
         // Should throw "no longer valid" error, not "expired" error
@@ -218,7 +185,7 @@ describe('Invitation Resolvers', () => {
 
     describe('Invitation Expiry Validation', () => {
       it('should throw error when invitation is expired', async () => {
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(mockInvitation as any);
+        vi.mocked(getInvitationById).mockResolvedValue(mockInvitation as any);
         vi.mocked(dateHelpers.isDateExpired).mockReturnValue(true);
 
         await expect(
@@ -231,7 +198,7 @@ describe('Invitation Resolvers', () => {
       });
 
       it('should call isDateExpired with correct date string', async () => {
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(mockInvitation as any);
+        vi.mocked(getInvitationById).mockResolvedValue(mockInvitation as any);
         vi.mocked(dateHelpers.isDateExpired).mockReturnValue(true);
 
         await expect(
@@ -249,7 +216,7 @@ describe('Invitation Resolvers', () => {
           ...mockInvitation,
           expiresAt: futureDate,
         };
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(validInvitation as any);
+        vi.mocked(getInvitationById).mockResolvedValue(validInvitation as any);
         vi.mocked(dateHelpers.isDateExpired).mockReturnValue(false);
 
         const result = await invitationResolvers.Query.getInvitationPublic(
@@ -264,7 +231,7 @@ describe('Invitation Resolvers', () => {
 
     describe('Successful Invitation Retrieval', () => {
       it('should return invitation with all public fields', async () => {
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(mockInvitation as any);
+        vi.mocked(getInvitationById).mockResolvedValue(mockInvitation as any);
 
         const result = await invitationResolvers.Query.getInvitationPublic(
           {},
@@ -296,7 +263,7 @@ describe('Invitation Resolvers', () => {
           ...mockInvitation,
           organization: null,
         };
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(invitationWithoutOrg as any);
+        vi.mocked(getInvitationById).mockResolvedValue(invitationWithoutOrg as any);
 
         const result = await invitationResolvers.Query.getInvitationPublic(
           {},
@@ -311,7 +278,7 @@ describe('Invitation Resolvers', () => {
           ...mockInvitation,
           inviter: null,
         };
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(invitationWithoutInviter as any);
+        vi.mocked(getInvitationById).mockResolvedValue(invitationWithoutInviter as any);
 
         const result = await invitationResolvers.Query.getInvitationPublic(
           {},
@@ -322,7 +289,7 @@ describe('Invitation Resolvers', () => {
       });
 
       it('should convert dates to ISO strings', async () => {
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(mockInvitation as any);
+        vi.mocked(getInvitationById).mockResolvedValue(mockInvitation as any);
 
         const result = await invitationResolvers.Query.getInvitationPublic(
           {},
@@ -340,7 +307,7 @@ describe('Invitation Resolvers', () => {
           ...mockInvitation,
           role: 'owner',
         };
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(ownerInvitation as any);
+        vi.mocked(getInvitationById).mockResolvedValue(ownerInvitation as any);
 
         const result = await invitationResolvers.Query.getInvitationPublic(
           {},
@@ -356,7 +323,7 @@ describe('Invitation Resolvers', () => {
           internalNote: 'This should not be exposed',
           secretToken: 'secret-123',
         };
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(invitationWithExtraFields as any);
+        vi.mocked(getInvitationById).mockResolvedValue(invitationWithExtraFields as any);
 
         const result = await invitationResolvers.Query.getInvitationPublic(
           {},
@@ -374,7 +341,7 @@ describe('Invitation Resolvers', () => {
     describe('Error Handling', () => {
       it('should re-throw GraphQLError instances', async () => {
         const customError = new GraphQLError('Custom error message');
-        vi.mocked(prisma.invitation.findUnique).mockRejectedValue(customError);
+        vi.mocked(getInvitationById).mockRejectedValue(customError);
 
         await expect(
           invitationResolvers.Query.getInvitationPublic({}, { id: 'invitation-123' })
@@ -387,7 +354,7 @@ describe('Invitation Resolvers', () => {
 
       it('should convert non-GraphQLError to GraphQLError', async () => {
         const databaseError = new Error('Database connection failed');
-        vi.mocked(prisma.invitation.findUnique).mockRejectedValue(databaseError);
+        vi.mocked(getInvitationById).mockRejectedValue(databaseError);
 
         await expect(
           invitationResolvers.Query.getInvitationPublic({}, { id: 'invitation-123' })
@@ -400,7 +367,7 @@ describe('Invitation Resolvers', () => {
 
       it('should handle prisma errors gracefully', async () => {
         const prismaError = new Error('P2021: Table does not exist');
-        vi.mocked(prisma.invitation.findUnique).mockRejectedValue(prismaError);
+        vi.mocked(getInvitationById).mockRejectedValue(prismaError);
 
         await expect(
           invitationResolvers.Query.getInvitationPublic({}, { id: 'invitation-123' })
@@ -409,7 +376,7 @@ describe('Invitation Resolvers', () => {
 
       it('should handle null pointer exceptions', async () => {
         const nullError = new TypeError("Cannot read property 'toISOString' of null");
-        vi.mocked(prisma.invitation.findUnique).mockRejectedValue(nullError);
+        vi.mocked(getInvitationById).mockRejectedValue(nullError);
 
         await expect(
           invitationResolvers.Query.getInvitationPublic({}, { id: 'invitation-123' })
@@ -431,7 +398,7 @@ describe('Invitation Resolvers', () => {
           organization: null,
           inviter: null,
         };
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(minimalInvitation as any);
+        vi.mocked(getInvitationById).mockResolvedValue(minimalInvitation as any);
 
         const result = await invitationResolvers.Query.getInvitationPublic(
           {},
@@ -448,7 +415,7 @@ describe('Invitation Resolvers', () => {
           ...mockInvitation,
           email: 'test+filter@example.co.uk',
         };
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(specialEmailInvitation as any);
+        vi.mocked(getInvitationById).mockResolvedValue(specialEmailInvitation as any);
 
         const result = await invitationResolvers.Query.getInvitationPublic(
           {},
@@ -466,7 +433,7 @@ describe('Invitation Resolvers', () => {
             name: 'Test & Co. (2024)',
           },
         };
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(specialOrgInvitation as any);
+        vi.mocked(getInvitationById).mockResolvedValue(specialOrgInvitation as any);
 
         const result = await invitationResolvers.Query.getInvitationPublic(
           {},
@@ -478,15 +445,13 @@ describe('Invitation Resolvers', () => {
 
       it('should handle invitation with very long IDs', async () => {
         const longId = 'a'.repeat(100);
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(null);
+        vi.mocked(getInvitationById).mockResolvedValue(null);
 
         await expect(
           invitationResolvers.Query.getInvitationPublic({}, { id: longId })
         ).rejects.toThrow('Invitation not found or has expired');
 
-        expect(prisma.invitation.findUnique).toHaveBeenCalledWith(
-          expect.objectContaining({ where: { id: longId } })
-        );
+        expect(getInvitationById).toHaveBeenCalledWith(longId);
       });
 
       it('should handle invitation exactly at expiry time', async () => {
@@ -495,7 +460,7 @@ describe('Invitation Resolvers', () => {
           ...mockInvitation,
           expiresAt: now,
         };
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(expiringInvitation as any);
+        vi.mocked(getInvitationById).mockResolvedValue(expiringInvitation as any);
 
         // Mock isDateExpired to return false (not yet expired)
         vi.mocked(dateHelpers.isDateExpired).mockReturnValue(false);
@@ -520,7 +485,7 @@ describe('Invitation Resolvers', () => {
             ...mockInvitation,
             status,
           };
-          vi.mocked(prisma.invitation.findUnique).mockResolvedValue(invitation as any);
+          vi.mocked(getInvitationById).mockResolvedValue(invitation as any);
 
           if (status === 'pending') {
             const result = await invitationResolvers.Query.getInvitationPublic(
@@ -545,7 +510,7 @@ describe('Invitation Resolvers', () => {
             ...mockInvitation,
             role,
           };
-          vi.mocked(prisma.invitation.findUnique).mockResolvedValue(invitation as any);
+          vi.mocked(getInvitationById).mockResolvedValue(invitation as any);
 
           const result = await invitationResolvers.Query.getInvitationPublic(
             {},
@@ -565,7 +530,7 @@ describe('Invitation Resolvers', () => {
           createdAt: specificDate,
           expiresAt: new Date('2024-12-31T23:59:59.999Z'),
         };
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(invitation as any);
+        vi.mocked(getInvitationById).mockResolvedValue(invitation as any);
 
         const result = await invitationResolvers.Query.getInvitationPublic(
           {},
@@ -582,7 +547,7 @@ describe('Invitation Resolvers', () => {
           ...mockInvitation,
           expiresAt: utcDate,
         };
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(invitation as any);
+        vi.mocked(getInvitationById).mockResolvedValue(invitation as any);
 
         const result = await invitationResolvers.Query.getInvitationPublic(
           {},
@@ -594,63 +559,14 @@ describe('Invitation Resolvers', () => {
       });
     });
 
-    describe('Database Query Optimization', () => {
-      it('should use efficient includes for related data', async () => {
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(mockInvitation as any);
+    describe('Service Delegation', () => {
+      it('should look up the invitation via invitationService by ID', async () => {
+        vi.mocked(getInvitationById).mockResolvedValue(mockInvitation as any);
 
         await invitationResolvers.Query.getInvitationPublic({}, { id: 'invitation-123' });
 
-        expect(prisma.invitation.findUnique).toHaveBeenCalledWith({
-          where: { id: 'invitation-123' },
-          include: {
-            organization: {
-              select: {
-                id: true,
-                name: true,
-                slug: true,
-              },
-            },
-            inviter: {
-              select: {
-                id: true,
-                name: true,
-                email: true,
-              },
-            },
-          },
-        });
-      });
-
-      it('should only select necessary organization fields', async () => {
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(mockInvitation as any);
-
-        await invitationResolvers.Query.getInvitationPublic({}, { id: 'invitation-123' });
-
-        const call = vi.mocked(prisma.invitation.findUnique).mock.calls[0][0];
-        const orgSelect = (call?.include?.organization as any)?.select;
-
-        expect(orgSelect).toBeDefined();
-        expect(orgSelect).toEqual({
-          id: true,
-          name: true,
-          slug: true,
-        });
-      });
-
-      it('should only select necessary inviter fields', async () => {
-        vi.mocked(prisma.invitation.findUnique).mockResolvedValue(mockInvitation as any);
-
-        await invitationResolvers.Query.getInvitationPublic({}, { id: 'invitation-123' });
-
-        const call = vi.mocked(prisma.invitation.findUnique).mock.calls[0][0];
-        const inviterSelect = (call?.include?.inviter as any)?.select;
-
-        expect(inviterSelect).toBeDefined();
-        expect(inviterSelect).toEqual({
-          id: true,
-          name: true,
-          email: true,
-        });
+        expect(getInvitationById).toHaveBeenCalledWith('invitation-123');
+        expect(getInvitationById).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/apps/backend/src/graphql/resolvers/invitations.ts
+++ b/apps/backend/src/graphql/resolvers/invitations.ts
@@ -1,6 +1,6 @@
 import { createGraphQLError, GraphQLError } from '#graphql-errors';
 import { GRAPHQL_ERROR_CODES } from '@dculus/types/graphql.js';
-import { prisma } from '../../lib/prisma.js';
+import { getInvitationById } from '../../services/invitationService.js';
 import { isDateExpired } from '../../utils/dateHelpers.js';
 import { logger } from '../../lib/logger.js';
 
@@ -15,13 +15,7 @@ export const invitationResolvers = {
           throw createGraphQLError('Invalid invitation ID', GRAPHQL_ERROR_CODES.BAD_USER_INPUT);
         }
 
-        const invitation = await prisma.invitation.findUnique({
-          where: { id },
-          include: {
-            organization: { select: { id: true, name: true, slug: true } },
-            inviter:      { select: { id: true, name: true, email: true } },
-          },
-        });
+        const invitation = await getInvitationById(id);
 
         if (!invitation) {
           throw createGraphQLError('Invitation not found or has expired', GRAPHQL_ERROR_CODES.NOT_FOUND);

--- a/apps/backend/src/repositories/__tests__/invitationRepository.test.ts
+++ b/apps/backend/src/repositories/__tests__/invitationRepository.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createInvitationRepository } from '../invitationRepository.js';
+
+describe('Invitation Repository', () => {
+  const mockPrisma = {
+    invitation: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+  };
+
+  const mockContext = { prisma: mockPrisma as any };
+  let repository: ReturnType<typeof createInvitationRepository>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repository = createInvitationRepository(mockContext);
+  });
+
+  describe('findMany', () => {
+    it('delegates to prisma.invitation.findMany', async () => {
+      const mockInvitations = [{ id: 'invitation-1' }];
+      mockPrisma.invitation.findMany.mockResolvedValue(mockInvitations as any);
+
+      const result = await repository.findMany({ where: { status: 'pending' } });
+
+      expect(result).toEqual(mockInvitations);
+      expect(mockPrisma.invitation.findMany).toHaveBeenCalledWith({
+        where: { status: 'pending' },
+      });
+    });
+  });
+
+  describe('findUnique', () => {
+    it('delegates to prisma.invitation.findUnique', async () => {
+      const mockInvitation = { id: 'invitation-1' };
+      mockPrisma.invitation.findUnique.mockResolvedValue(mockInvitation as any);
+
+      const result = await repository.findUnique({ where: { id: 'invitation-1' } });
+
+      expect(result).toEqual(mockInvitation);
+      expect(mockPrisma.invitation.findUnique).toHaveBeenCalledWith({
+        where: { id: 'invitation-1' },
+      });
+    });
+  });
+
+  describe('create', () => {
+    it('delegates to prisma.invitation.create', async () => {
+      const data = {
+        email: 'invitee@example.com',
+        role: 'member',
+        organizationId: 'org-1',
+        inviterId: 'user-1',
+        expiresAt: new Date('2024-12-31'),
+      };
+      const created = { id: 'invitation-1', ...data };
+      mockPrisma.invitation.create.mockResolvedValue(created as any);
+
+      const result = await repository.create({ data });
+
+      expect(result).toEqual(created);
+      expect(mockPrisma.invitation.create).toHaveBeenCalledWith({ data });
+    });
+  });
+
+  describe('update', () => {
+    it('delegates to prisma.invitation.update', async () => {
+      const updated = { id: 'invitation-1', status: 'accepted' };
+      mockPrisma.invitation.update.mockResolvedValue(updated as any);
+
+      const result = await repository.update({
+        where: { id: 'invitation-1' },
+        data: { status: 'accepted' },
+      });
+
+      expect(result).toEqual(updated);
+      expect(mockPrisma.invitation.update).toHaveBeenCalledWith({
+        where: { id: 'invitation-1' },
+        data: { status: 'accepted' },
+      });
+    });
+  });
+
+  describe('delete', () => {
+    it('delegates to prisma.invitation.delete', async () => {
+      const deleted = { id: 'invitation-1' };
+      mockPrisma.invitation.delete.mockResolvedValue(deleted as any);
+
+      const result = await repository.delete({ where: { id: 'invitation-1' } });
+
+      expect(result).toEqual(deleted);
+      expect(mockPrisma.invitation.delete).toHaveBeenCalledWith({
+        where: { id: 'invitation-1' },
+      });
+    });
+  });
+
+  describe('count', () => {
+    it('delegates to prisma.invitation.count', async () => {
+      mockPrisma.invitation.count.mockResolvedValue(3);
+
+      const result = await repository.count({ where: { status: 'pending' } });
+
+      expect(result).toBe(3);
+      expect(mockPrisma.invitation.count).toHaveBeenCalledWith({
+        where: { status: 'pending' },
+      });
+    });
+  });
+
+  describe('findById', () => {
+    it('fetches an invitation with organization and inviter included', async () => {
+      const mockInvitation = {
+        id: 'invitation-1',
+        organization: { id: 'org-1', name: 'Acme', slug: 'acme' },
+        inviter: { id: 'user-1', name: 'John Doe', email: 'john@example.com' },
+      };
+      mockPrisma.invitation.findUnique.mockResolvedValue(mockInvitation as any);
+
+      const result = await repository.findById('invitation-1');
+
+      expect(result).toEqual(mockInvitation);
+      expect(mockPrisma.invitation.findUnique).toHaveBeenCalledWith({
+        where: { id: 'invitation-1' },
+        include: {
+          organization: { select: { id: true, name: true, slug: true } },
+          inviter: { select: { id: true, name: true, email: true } },
+        },
+      });
+    });
+
+    it('returns null when no invitation is found', async () => {
+      mockPrisma.invitation.findUnique.mockResolvedValue(null);
+
+      const result = await repository.findById('nonexistent-id');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/backend/src/repositories/index.ts
+++ b/apps/backend/src/repositories/index.ts
@@ -8,3 +8,4 @@ export * from './collaborativeDocumentRepository.js';
 export * from './formViewAnalyticsRepository.js';
 export * from './formSubmissionAnalyticsRepository.js';
 export * from './pluginRepository.js';
+export * from './invitationRepository.js';

--- a/apps/backend/src/repositories/invitationRepository.ts
+++ b/apps/backend/src/repositories/invitationRepository.ts
@@ -1,0 +1,74 @@
+import type { Prisma } from '#prisma-client';
+import { resolvePrisma, type RepositoryContext } from './baseRepository.js';
+
+const defaultInvitationInclude = {
+  organization: { select: { id: true, name: true, slug: true } },
+  inviter:      { select: { id: true, name: true, email: true } },
+} satisfies Prisma.InvitationInclude;
+
+/**
+ * Factory for all invitation related data access.
+ * Provides both low-level Prisma passthroughs and higher-level helpers
+ * so services can choose the right abstraction for their use-case.
+ */
+export const createInvitationRepository = (context?: RepositoryContext) => {
+  const prisma = resolvePrisma(context);
+
+  /** --- Generic delegate passthroughs (keep API flexibility) --- */
+  const findMany = <T extends Prisma.InvitationFindManyArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.InvitationFindManyArgs>
+  ) => prisma.invitation.findMany(args);
+
+  const findUnique = <T extends Prisma.InvitationFindUniqueArgs>(
+    args: Prisma.SelectSubset<T, Prisma.InvitationFindUniqueArgs>
+  ) => prisma.invitation.findUnique(args);
+
+  const create = <T extends Prisma.InvitationCreateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.InvitationCreateArgs>
+  ) => prisma.invitation.create(args);
+
+  const update = <T extends Prisma.InvitationUpdateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.InvitationUpdateArgs>
+  ) => prisma.invitation.update(args);
+
+  const remove = <T extends Prisma.InvitationDeleteArgs>(
+    args: Prisma.SelectSubset<T, Prisma.InvitationDeleteArgs>
+  ) => prisma.invitation.delete(args);
+
+  const count = <T extends Prisma.InvitationCountArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.InvitationCountArgs>
+  ) => prisma.invitation.count(args);
+
+  /** --- Domain-oriented helpers for common access patterns --- */
+  type InvitationWithRelations = Prisma.InvitationGetPayload<{
+    include: typeof defaultInvitationInclude;
+  }>;
+
+  /**
+   * Fetch an invitation by ID with organization + inviter metadata eagerly loaded.
+   */
+  const findById = async (
+    id: string
+  ): Promise<InvitationWithRelations | null> =>
+    prisma.invitation.findUnique({
+      where: { id },
+      include: defaultInvitationInclude,
+    });
+
+  return {
+    // Generic operations (used when custom queries are needed)
+    findMany,
+    findUnique,
+    create,
+    update,
+    delete: remove,
+    count,
+
+    // Domain helpers (preferred for service layer)
+    findById,
+  };
+};
+
+export type InvitationRepository = ReturnType<typeof createInvitationRepository>;
+
+export const invitationRepository = createInvitationRepository();

--- a/apps/backend/src/services/invitationService.ts
+++ b/apps/backend/src/services/invitationService.ts
@@ -1,0 +1,8 @@
+import { invitationRepository } from '../repositories/index.js';
+
+/**
+ * Fetch an invitation by ID with organization + inviter metadata eagerly loaded.
+ * Returns null when no invitation exists for the given ID.
+ */
+export const getInvitationById = async (id: string) =>
+  invitationRepository.findById(id);


### PR DESCRIPTION
## Summary
- Part of Epic #245 (Backend — Repository Pattern Rollout). Closes #254.
- Adds `invitationRepository` (Prisma passthroughs + `findById` domain helper) following `formRepository.ts`'s shape, registered in `repositories/index.ts`.
- Adds a thin `invitationService.getInvitationById` wrapping the repository.
- `graphql/resolvers/invitations.ts` now calls `invitationService.getInvitationById` instead of `prisma.invitation.findUnique` directly — no behavior change.

## Investigation note (per ticket's ask to search for other direct `prisma.invitation.*` usage)
- Searched the codebase for other `invitation`-related mutations. Better-auth's `organization` plugin handles invitation creation/acceptance internally (see `lib/better-auth.ts`'s `sendInvitationEmail` hook) — out of scope per the epic.
- Found one other direct usage: `apps/backend/src/scripts/migrate-organization-roles.ts` (a historical, already-executed one-off data migration script). Left untouched/out of scope: it's not part of the resolver/service runtime layer this epic targets, and it also mixes in direct `prisma.member.*` calls that belong to a different story (#258) — migrating only its invitation calls would be inconsistent without also touching member access there.

## Test plan
- [x] `apps/backend/src/repositories/__tests__/invitationRepository.test.ts` added (mocked Prisma via injected context, no real DB)
- [x] `apps/backend/src/graphql/resolvers/__tests__/invitations.test.ts` updated to mock `invitationService` instead of `prisma` directly (all 53 invitation-related tests pass)
- [x] `grep -rn "prisma\.invitation\." apps/backend/src` shows zero results outside the new repository file (excluding generated Prisma client and the out-of-scope migration script noted above)
- [x] `pnpm --filter backend exec tsc --noEmit` passes
- [x] `pnpm test:unit` passes (102 test files, 2895 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved invitation retrieval through a dedicated service and repository layer.
  * Preserved existing invitation response formatting, authorization checks, and missing-data handling.

* **Tests**
  * Added comprehensive coverage for invitation repository operations.
  * Expanded resolver tests to verify service delegation and invitation response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->