### PR TITLE
Story 02: AI Usage — new aiUsageRepository, wire aiUsageService

### DIFF
--- a/apps/backend/src/repositories/__tests__/aiUsageRepository.test.ts
+++ b/apps/backend/src/repositories/__tests__/aiUsageRepository.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createAiUsageRepository } from '../aiUsageRepository.js';
+
+const prismaMock = vi.hoisted(() => ({
+  aIUsage: {
+    findFirst: vi.fn().mockResolvedValue(null),
+    upsert: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    aggregate: vi.fn().mockResolvedValue({ _sum: { tokensUsed: 0 } }),
+    updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+  },
+}));
+
+vi.mock('../baseRepository.js', () => ({
+  resolvePrisma: () => prismaMock,
+}));
+
+describe('aiUsageRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.aIUsage.findFirst.mockResolvedValue(null);
+    prismaMock.aIUsage.upsert.mockResolvedValue({});
+    prismaMock.aIUsage.delete.mockResolvedValue({});
+    prismaMock.aIUsage.aggregate.mockResolvedValue({ _sum: { tokensUsed: 0 } });
+    prismaMock.aIUsage.updateMany.mockResolvedValue({ count: 0 });
+  });
+
+  it('should proxy basic prisma delegate methods', async () => {
+    const repo = createAiUsageRepository();
+    const findArgs = { where: { organizationId: 'org-1' } };
+    const upsertArgs = {
+      where: { organizationId_periodStart: { organizationId: 'org-1', periodStart: new Date() } },
+      update: {},
+      create: { organizationId: 'org-1', periodStart: new Date(), periodEnd: new Date() },
+    };
+    const deleteArgs = { where: { id: 'usage-1' } };
+    const aggregateArgs = { where: { organizationId: 'org-1' }, _sum: { tokensUsed: true } };
+    const updateManyArgs = { where: { organizationId: 'org-1' }, data: { tokensUsed: 0 } };
+
+    await repo.findFirst(findArgs as any);
+    await repo.upsert(upsertArgs as any);
+    await repo.delete(deleteArgs as any);
+    await repo.aggregate(aggregateArgs as any);
+    await repo.updateMany(updateManyArgs as any);
+
+    expect(prismaMock.aIUsage.findFirst).toHaveBeenCalledWith(findArgs);
+    expect(prismaMock.aIUsage.upsert).toHaveBeenCalledWith(upsertArgs);
+    expect(prismaMock.aIUsage.delete).toHaveBeenCalledWith(deleteArgs);
+    expect(prismaMock.aIUsage.aggregate).toHaveBeenCalledWith(aggregateArgs);
+    expect(prismaMock.aIUsage.updateMany).toHaveBeenCalledWith(updateManyArgs);
+  });
+
+  it('should find usage for an organization and period', async () => {
+    const repo = createAiUsageRepository();
+    const periodStart = new Date('2026-07-01');
+    prismaMock.aIUsage.findFirst.mockResolvedValueOnce({ id: 'usage-1', tokensUsed: 10 } as any);
+
+    const result = await repo.findByOrganizationAndPeriod('org-1', periodStart);
+
+    expect(prismaMock.aIUsage.findFirst).toHaveBeenCalledWith({
+      where: { organizationId: 'org-1', periodStart },
+    });
+    expect(result).toEqual({ id: 'usage-1', tokensUsed: 10 });
+  });
+
+  it('should upsert period usage with increments', async () => {
+    const repo = createAiUsageRepository();
+    const periodStart = new Date('2026-07-01');
+    const periodEnd = new Date('2026-07-31');
+
+    await repo.upsertPeriodUsage('org-1', periodStart, periodEnd, 100, 50);
+
+    expect(prismaMock.aIUsage.upsert).toHaveBeenCalledWith({
+      where: { organizationId_periodStart: { organizationId: 'org-1', periodStart } },
+      update: {
+        tokensUsed: { increment: 100 },
+        creditsUsedMilli: { increment: 50 },
+      },
+      create: {
+        organizationId: 'org-1',
+        periodStart,
+        periodEnd,
+        tokensUsed: 100,
+        creditsUsedMilli: 50,
+      },
+    });
+  });
+
+  it('should migrate legacy period usage and delete the legacy row', async () => {
+    const repo = createAiUsageRepository();
+    const fromPeriodStart = new Date('2026-06-01');
+    const toPeriodStart = new Date('2026-06-15');
+    const toPeriodEnd = new Date('2026-07-14');
+
+    await repo.migratePeriodUsage(
+      'org-1',
+      fromPeriodStart,
+      toPeriodStart,
+      toPeriodEnd,
+      'legacy-usage-1',
+      20,
+      10
+    );
+
+    expect(prismaMock.aIUsage.upsert).toHaveBeenCalledWith({
+      where: { organizationId_periodStart: { organizationId: 'org-1', periodStart: toPeriodStart } },
+      update: {
+        tokensUsed: { increment: 20 },
+        creditsUsedMilli: { increment: 10 },
+      },
+      create: {
+        organizationId: 'org-1',
+        periodStart: toPeriodStart,
+        periodEnd: toPeriodEnd,
+        tokensUsed: 20,
+        creditsUsedMilli: 10,
+      },
+    });
+    expect(prismaMock.aIUsage.delete).toHaveBeenCalledWith({ where: { id: 'legacy-usage-1' } });
+  });
+
+  it('should sum tokensUsed across all periods for an organization', async () => {
+    const repo = createAiUsageRepository();
+    prismaMock.aIUsage.aggregate.mockResolvedValueOnce({ _sum: { tokensUsed: 250 } } as any);
+
+    const result = await repo.sumTokensUsedByOrganization('org-1');
+
+    expect(prismaMock.aIUsage.aggregate).toHaveBeenCalledWith({
+      where: { organizationId: 'org-1' },
+      _sum: { tokensUsed: true },
+    });
+    expect(result).toEqual({ _sum: { tokensUsed: 250 } });
+  });
+
+  it('should reset usage for an organization', async () => {
+    const repo = createAiUsageRepository();
+
+    await repo.resetUsageByOrganization('org-1');
+
+    expect(prismaMock.aIUsage.updateMany).toHaveBeenCalledWith({
+      where: { organizationId: 'org-1' },
+      data: { tokensUsed: 0, creditsUsedMilli: 0 },
+    });
+  });
+});

--- a/apps/backend/src/repositories/aiUsageRepository.ts
+++ b/apps/backend/src/repositories/aiUsageRepository.ts
@@ -1,0 +1,137 @@
+import type { Prisma } from '#prisma-client';
+import { resolvePrisma, type RepositoryContext } from './baseRepository.js';
+
+/**
+ * Factory for all AIUsage data access.
+ * Note: the Prisma client accessor is `prisma.aIUsage` (capital I, from the
+ * `AIUsage` model name), not `prisma.aiUsage`.
+ */
+export const createAiUsageRepository = (context?: RepositoryContext) => {
+  const prisma = resolvePrisma(context);
+
+  /** --- Generic delegate passthroughs (keep API flexibility) --- */
+  const findFirst = <T extends Prisma.AIUsageFindFirstArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.AIUsageFindFirstArgs>
+  ) => prisma.aIUsage.findFirst(args);
+
+  const upsert = <T extends Prisma.AIUsageUpsertArgs>(
+    args: Prisma.SelectSubset<T, Prisma.AIUsageUpsertArgs>
+  ) => prisma.aIUsage.upsert(args);
+
+  const remove = <T extends Prisma.AIUsageDeleteArgs>(
+    args: Prisma.SelectSubset<T, Prisma.AIUsageDeleteArgs>
+  ) => prisma.aIUsage.delete(args);
+
+  const aggregate = <T extends Prisma.AIUsageAggregateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.AIUsageAggregateArgs>
+  ) => prisma.aIUsage.aggregate(args);
+
+  const updateMany = <T extends Prisma.AIUsageUpdateManyArgs>(
+    args: Prisma.SelectSubset<T, Prisma.AIUsageUpdateManyArgs>
+  ) => prisma.aIUsage.updateMany(args);
+
+  /** --- Domain-oriented helpers for common access patterns --- */
+
+  /**
+   * Find the usage row for an org's given billing/calendar period, if any.
+   */
+  const findByOrganizationAndPeriod = async (
+    organizationId: string,
+    periodStart: Date
+  ) => prisma.aIUsage.findFirst({ where: { organizationId, periodStart } });
+
+  /**
+   * Upsert the usage row for an org's current period, incrementing
+   * `tokensUsed`/`creditsUsedMilli` on an existing row or creating a fresh one.
+   */
+  const upsertPeriodUsage = async (
+    organizationId: string,
+    periodStart: Date,
+    periodEnd: Date,
+    tokensUsed: number,
+    creditsUsedMilli: number
+  ) =>
+    prisma.aIUsage.upsert({
+      where: { organizationId_periodStart: { organizationId, periodStart } },
+      update: {
+        tokensUsed: { increment: tokensUsed },
+        creditsUsedMilli: { increment: creditsUsedMilli },
+      },
+      create: {
+        organizationId,
+        periodStart,
+        periodEnd,
+        tokensUsed,
+        creditsUsedMilli,
+      },
+    });
+
+  /**
+   * Merge a legacy calendar-month-keyed row's totals onto the new billing-cycle
+   * key and delete the legacy row.
+   */
+  const migratePeriodUsage = async (
+    organizationId: string,
+    fromPeriodStart: Date,
+    toPeriodStart: Date,
+    toPeriodEnd: Date,
+    legacyUsageId: string,
+    tokensUsed: number,
+    creditsUsedMilli: number
+  ) => {
+    await prisma.aIUsage.upsert({
+      where: { organizationId_periodStart: { organizationId, periodStart: toPeriodStart } },
+      update: {
+        tokensUsed: { increment: tokensUsed },
+        creditsUsedMilli: { increment: creditsUsedMilli },
+      },
+      create: {
+        organizationId,
+        periodStart: toPeriodStart,
+        periodEnd: toPeriodEnd,
+        tokensUsed,
+        creditsUsedMilli,
+      },
+    });
+    await prisma.aIUsage.delete({ where: { id: legacyUsageId } });
+  };
+
+  /**
+   * Sum of `tokensUsed` across every period recorded for an org — used by the
+   * admin usage-reset flow to report what's about to be zeroed out.
+   */
+  const sumTokensUsedByOrganization = async (organizationId: string) =>
+    prisma.aIUsage.aggregate({
+      where: { organizationId },
+      _sum: { tokensUsed: true },
+    });
+
+  /**
+   * Zero out every usage row for an org — used by the admin usage-reset flow.
+   */
+  const resetUsageByOrganization = async (organizationId: string) =>
+    prisma.aIUsage.updateMany({
+      where: { organizationId },
+      data: { tokensUsed: 0, creditsUsedMilli: 0 },
+    });
+
+  return {
+    // Generic operations (used when custom queries are needed)
+    findFirst,
+    upsert,
+    delete: remove,
+    aggregate,
+    updateMany,
+
+    // Domain helpers (preferred for service layer)
+    findByOrganizationAndPeriod,
+    upsertPeriodUsage,
+    migratePeriodUsage,
+    sumTokensUsedByOrganization,
+    resetUsageByOrganization,
+  };
+};
+
+export type AiUsageRepository = ReturnType<typeof createAiUsageRepository>;
+
+export const aiUsageRepository = createAiUsageRepository();

--- a/apps/backend/src/repositories/index.ts
+++ b/apps/backend/src/repositories/index.ts
@@ -7,3 +7,4 @@ export * from './formMetadataRepository.js';
 export * from './collaborativeDocumentRepository.js';
 export * from './formViewAnalyticsRepository.js';
 export * from './formSubmissionAnalyticsRepository.js';
+export * from './aiUsageRepository.js';

--- a/apps/backend/src/services/aiUsageService.ts
+++ b/apps/backend/src/services/aiUsageService.ts
@@ -1,7 +1,8 @@
-import { prisma } from '../lib/prisma.js';
 import { AI_CREDIT_LIMITS_FALLBACK, tokensToMilliCredits, type AIModelTier } from '../lib/ai.js';
 import { logger } from '../lib/logger.js';
 import { emitUsageLimitReached, emitUsageLimitExceeded } from '../subscriptions/events.js';
+import { aiUsageRepository } from '../repositories/aiUsageRepository.js';
+import { subscriptionRepository } from '../repositories/subscriptionRepository.js';
 
 /**
  * Design decision (issue #83 — check-then-record race on AI credit budget):
@@ -128,26 +129,20 @@ async function migrateLegacyPeriodUsage(
 
   try {
     const [existingNew, legacy] = await Promise.all([
-      prisma.aIUsage.findFirst({ where: { organizationId, periodStart: newStart } }),
-      prisma.aIUsage.findFirst({ where: { organizationId, periodStart: legacyStart } }),
+      aiUsageRepository.findByOrganizationAndPeriod(organizationId, newStart),
+      aiUsageRepository.findByOrganizationAndPeriod(organizationId, legacyStart),
     ]);
     if (existingNew || !legacy) return;
 
-    await prisma.aIUsage.upsert({
-      where: { organizationId_periodStart: { organizationId, periodStart: newStart } },
-      update: {
-        tokensUsed: { increment: legacy.tokensUsed },
-        creditsUsedMilli: { increment: legacy.creditsUsedMilli },
-      },
-      create: {
-        organizationId,
-        periodStart: newStart,
-        periodEnd: newEnd,
-        tokensUsed: legacy.tokensUsed,
-        creditsUsedMilli: legacy.creditsUsedMilli,
-      },
-    });
-    await prisma.aIUsage.delete({ where: { id: legacy.id } });
+    await aiUsageRepository.migratePeriodUsage(
+      organizationId,
+      legacyStart,
+      newStart,
+      newEnd,
+      legacy.id,
+      legacy.tokensUsed,
+      legacy.creditsUsedMilli
+    );
   } catch {
     logger.warn(
       { organizationId },
@@ -225,13 +220,11 @@ export async function checkAITokenBudget(organizationId: string): Promise<{
 
   const generationAtStart = currentWriteGeneration(organizationId);
 
-  const subscription = await prisma.subscription.findUnique({ where: { organizationId } });
+  const subscription = await subscriptionRepository.findUnique({ where: { organizationId } });
   const { start, end } = currentPeriod(subscription);
   await migrateLegacyPeriodUsage(organizationId, start, end, subscription);
 
-  const usage = await prisma.aIUsage.findFirst({
-    where: { organizationId, periodStart: start },
-  });
+  const usage = await aiUsageRepository.findByOrganizationAndPeriod(organizationId, start);
 
   const limit = effectiveCreditLimit(subscription);
   const creditsUsedMilli = usage?.creditsUsedMilli ?? 0;
@@ -304,29 +297,22 @@ export async function recordAITokenUsage(
   budgetCache.delete(organizationId); // invalidate before the write starts
   // Fetched once (not select-limited): currentPeriod() needs currentPeriodStart/End,
   // and effectiveCreditLimit() below needs planId/aiCreditsLimit/status from the same row.
-  const subscription = await prisma.subscription.findUnique({ where: { organizationId } });
+  const subscription = await subscriptionRepository.findUnique({ where: { organizationId } });
   const { start, end } = currentPeriod(subscription);
   await migrateLegacyPeriodUsage(organizationId, start, end, subscription);
   const creditsUsedMilli = tokensToMilliCredits(tokensUsed, tier);
 
   try {
-    const existing = await prisma.aIUsage.findFirst({ where: { organizationId, periodStart: start } });
+    const existing = await aiUsageRepository.findByOrganizationAndPeriod(organizationId, start);
     const previousMilli = existing?.creditsUsedMilli ?? 0;
 
-    const updated = await prisma.aIUsage.upsert({
-      where: { organizationId_periodStart: { organizationId, periodStart: start } },
-      update: {
-        tokensUsed: { increment: tokensUsed },
-        creditsUsedMilli: { increment: creditsUsedMilli },
-      },
-      create: {
-        organizationId,
-        tokensUsed,
-        creditsUsedMilli,
-        periodStart: start,
-        periodEnd: end,
-      },
-    });
+    const updated = await aiUsageRepository.upsertPeriodUsage(
+      organizationId,
+      start,
+      end,
+      tokensUsed,
+      creditsUsedMilli
+    );
 
     const limitCredits = effectiveCreditLimit(subscription);
     checkAICreditLimits(organizationId, previousMilli, updated.creditsUsedMilli, limitCredits);
@@ -353,11 +339,11 @@ export async function getAITokenUsage(organizationId: string): Promise<{
   creditsUsed: number;
   creditsLimit: number;
 }> {
-  const subscription = await prisma.subscription.findUnique({ where: { organizationId } });
+  const subscription = await subscriptionRepository.findUnique({ where: { organizationId } });
   const { start, end } = currentPeriod(subscription);
   await migrateLegacyPeriodUsage(organizationId, start, end, subscription);
 
-  const usage = await prisma.aIUsage.findFirst({ where: { organizationId, periodStart: start } });
+  const usage = await aiUsageRepository.findByOrganizationAndPeriod(organizationId, start);
 
   const creditsLimit = effectiveCreditLimit(subscription);
   const creditsUsedMilli = usage?.creditsUsedMilli ?? 0;
@@ -371,4 +357,30 @@ export async function getAITokenUsage(organizationId: string): Promise<{
     creditsUsed: Math.round((creditsUsedMilli / 1000) * 10) / 10,
     creditsLimit,
   };
+}
+
+/**
+ * Sum of `tokensUsed` across every period recorded for an org.
+ *
+ * Used by the admin usage-reset flow (`admin.ts` `adminResetUsage`) to report what's
+ * about to be zeroed out — exported here so ticket #14 (Org/Member/User/AuditLog) can
+ * call it instead of touching `prisma.aIUsage` directly.
+ */
+export async function getOrganizationUsageTotals(
+  organizationId: string
+): Promise<{ totalTokensUsed: number }> {
+  const result = await aiUsageRepository.sumTokensUsedByOrganization(organizationId);
+  return { totalTokensUsed: result._sum.tokensUsed ?? 0 };
+}
+
+/**
+ * Zeroes out every usage row for an org and invalidates the in-memory budget cache.
+ *
+ * Used by the admin usage-reset flow (`admin.ts` `adminResetUsage`) — exported here so
+ * ticket #14 (Org/Member/User/AuditLog) can call it instead of touching `prisma.aIUsage`
+ * directly.
+ */
+export async function resetOrganizationUsage(organizationId: string): Promise<void> {
+  await aiUsageRepository.resetUsageByOrganization(organizationId);
+  invalidateAIBudgetCache(organizationId);
 }


### PR DESCRIPTION
## Summary
- Adds `aiUsageRepository.ts` (generic passthroughs + domain helpers) following the `formRepository.ts` shape, and wires `aiUsageService.ts` through it instead of calling `prisma.aIUsage.*` directly.
- Switches `aiUsageService.ts`'s `prisma.subscription.findUnique` calls onto the existing `subscriptionRepository`.
- Adds `aiUsageService.getOrganizationUsageTotals()` / `resetOrganizationUsage()` (backed by new `sumTokensUsedByOrganization`/`resetUsageByOrganization` repository methods) for ticket #258 to consume when it migrates `admin.ts`'s usage-reset flow.
- Registers the new repository in `repositories/index.ts`.

Part of epic #245. Closes #248.

Out of scope (per the ticket): `admin.ts`'s 2 direct `prisma.aIUsage.*` call sites (lines 982, 989) are left untouched — owned by ticket #258. `ai.ts` resolver was already fully service-driven, no changes needed.

## Test plan
- [x] `apps/backend/src/repositories/__tests__/aiUsageRepository.test.ts` added, mocked Prisma, covers all passthroughs + domain helpers.
- [x] `grep -n "prisma\." apps/backend/src/services/aiUsageService.ts` → zero real call sites (only doc-comment mentions).
- [x] `pnpm --filter backend exec tsc --noEmit` passes.
- [x] `pnpm test:unit` — 102 test files / 2895 tests pass, no existing tests modified.
- [x] Pre-push hook (test-backend, test-form-viewer, builds) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)