### PR TITLE
Story 09: Form Files — new formFileRepository + formFileService

### DIFF
--- a/apps/backend/src/graphql/resolvers/formFiles.ts
+++ b/apps/backend/src/graphql/resolvers/formFiles.ts
@@ -1,6 +1,6 @@
 import { createGraphQLError, GraphQLError } from '#graphql-errors';
 import { GRAPHQL_ERROR_CODES } from '@dculus/types/graphql.js';
-import { prisma } from '../../lib/prisma.js';
+import { listFormFiles } from '../../services/formFileService.js';
 import { BetterAuthContext, requireAuth } from '../../middleware/better-auth-middleware.js';
 import { checkFormAccess, PermissionLevel } from './formSharing.js';
 import { logger } from '../../lib/logger.js';
@@ -34,18 +34,8 @@ export const formFileResolvers = {
           throw createGraphQLError(`Invalid file type filter: ${type}`, GRAPHQL_ERROR_CODES.BAD_USER_INPUT);
         }
 
-        const where: any = { formId };
-        if (type) {
-          where.type = type;
-        }
-
         // Fetch form files
-        const formFiles = await prisma.formFile.findMany({
-          where,
-          orderBy: {
-            createdAt: 'desc'
-          }
-        });
+        const formFiles = await listFormFiles(formId, type);
 
         return formFiles;
       } catch (error) {

--- a/apps/backend/src/graphql/resolvers/templates.ts
+++ b/apps/backend/src/graphql/resolvers/templates.ts
@@ -12,7 +12,7 @@ import {
 import { createForm } from '../../services/formService.js';
 import { randomUUID } from 'crypto';
 import { copyFileForForm } from '../../services/fileUploadService.js';
-import { prisma } from '../../lib/prisma.js';
+import { createFormFile } from '../../services/formFileService.js';
 import { requireSystemLevelRole, requireAuthentication, type AuthContext } from '../../utils/auth.js';
 import { requireOrganizationMembership, BetterAuthContext } from '../../middleware/better-auth-middleware.js';
 import { logger } from '../../lib/logger.js';
@@ -239,17 +239,15 @@ export const templatesResolvers = {
         // Now that the form row exists, persist FormFile records for any copied assets
         if (copiedImageAsset) {
           try {
-            await prisma.formFile.create({
-              data: {
-                id: randomUUID(),
-                key: copiedImageAsset.key,
-                type: 'FormBackground',
-                formId: newFormId,
-                originalName: copiedImageAsset.originalName,
-                url: copiedImageAsset.url,
-                size: copiedImageAsset.size,
-                mimeType: copiedImageAsset.mimeType,
-              }
+            await createFormFile({
+              id: randomUUID(),
+              key: copiedImageAsset.key,
+              type: 'FormBackground',
+              formId: newFormId,
+              originalName: copiedImageAsset.originalName,
+              url: copiedImageAsset.url,
+              size: copiedImageAsset.size,
+              mimeType: copiedImageAsset.mimeType,
             });
           } catch (error) {
             logger.error('Error creating FormFile record for copied background image:', error);
@@ -257,17 +255,15 @@ export const templatesResolvers = {
         }
         if (copiedVideoAsset) {
           try {
-            await prisma.formFile.create({
-              data: {
-                id: randomUUID(),
-                key: copiedVideoAsset.key,
-                type: 'FormBackground',
-                formId: newFormId,
-                originalName: copiedVideoAsset.originalName,
-                url: copiedVideoAsset.url,
-                size: copiedVideoAsset.size,
-                mimeType: copiedVideoAsset.mimeType,
-              }
+            await createFormFile({
+              id: randomUUID(),
+              key: copiedVideoAsset.key,
+              type: 'FormBackground',
+              formId: newFormId,
+              originalName: copiedVideoAsset.originalName,
+              url: copiedVideoAsset.url,
+              size: copiedVideoAsset.size,
+              mimeType: copiedVideoAsset.mimeType,
             });
           } catch (error) {
             logger.error('Error creating FormFile record for copied background video:', error);

--- a/apps/backend/src/repositories/__tests__/formFileRepository.test.ts
+++ b/apps/backend/src/repositories/__tests__/formFileRepository.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createFormFileRepository } from '../formFileRepository.js';
+
+const prismaMock = vi.hoisted(() => ({
+  formFile: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    count: vi.fn().mockResolvedValue(0),
+  },
+}));
+
+vi.mock('../baseRepository.js', () => ({
+  resolvePrisma: () => prismaMock,
+}));
+
+describe('formFileRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.formFile.findMany.mockResolvedValue([]);
+    prismaMock.formFile.findUnique.mockResolvedValue(null);
+    prismaMock.formFile.create.mockResolvedValue({});
+    prismaMock.formFile.update.mockResolvedValue({});
+    prismaMock.formFile.delete.mockResolvedValue({});
+    prismaMock.formFile.count.mockResolvedValue(0);
+  });
+
+  it('should proxy basic prisma delegate methods', async () => {
+    const repo = createFormFileRepository();
+    const args = { where: { id: 'file-1' } };
+
+    await repo.findMany(args);
+    await repo.findUnique(args as any);
+    await repo.create({ data: { id: 'file-1' } } as any);
+    await repo.update({ where: { id: 'file-1' }, data: { url: 'new-url' } } as any);
+    await repo.delete({ where: { id: 'file-1' } } as any);
+    await repo.count(args as any);
+
+    expect(prismaMock.formFile.findMany).toHaveBeenCalledWith(args);
+    expect(prismaMock.formFile.findUnique).toHaveBeenCalledWith(args);
+    expect(prismaMock.formFile.create).toHaveBeenCalled();
+    expect(prismaMock.formFile.update).toHaveBeenCalled();
+    expect(prismaMock.formFile.delete).toHaveBeenCalled();
+    expect(prismaMock.formFile.count).toHaveBeenCalledWith(args);
+  });
+
+  it('should list files for a form, most recent first', async () => {
+    const repo = createFormFileRepository();
+
+    await repo.listByFormId('form-1');
+    expect(prismaMock.formFile.findMany).toHaveBeenCalledWith({
+      where: { formId: 'form-1' },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    await repo.listByFormId('form-1', 'FormBackground');
+    expect(prismaMock.formFile.findMany).toHaveBeenCalledWith({
+      where: { formId: 'form-1', type: 'FormBackground' },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+
+  it('should find a file by id', async () => {
+    const repo = createFormFileRepository();
+
+    await repo.findById('file-1');
+    expect(prismaMock.formFile.findUnique).toHaveBeenCalledWith({
+      where: { id: 'file-1' },
+    });
+  });
+
+  it('should create a form file', async () => {
+    const repo = createFormFileRepository();
+
+    await repo.createFormFile({ formId: 'form-1', key: 'file' } as any);
+    expect(prismaMock.formFile.create).toHaveBeenCalledWith({
+      data: { formId: 'form-1', key: 'file' },
+    });
+  });
+});

--- a/apps/backend/src/repositories/formFileRepository.ts
+++ b/apps/backend/src/repositories/formFileRepository.ts
@@ -1,0 +1,78 @@
+import type { Prisma } from '#prisma-client';
+import { resolvePrisma, type RepositoryContext } from './baseRepository.js';
+
+/**
+ * Factory for all FormFile (form asset) related data access.
+ * Provides both low-level Prisma passthroughs and higher-level helpers
+ * so services can choose the right abstraction for their use-case.
+ */
+export const createFormFileRepository = (context?: RepositoryContext) => {
+  const prisma = resolvePrisma(context);
+
+  /** --- Generic delegate passthroughs (keep API flexibility) --- */
+  const findMany = <T extends Prisma.FormFileFindManyArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.FormFileFindManyArgs>
+  ) => prisma.formFile.findMany(args);
+
+  const findUnique = <T extends Prisma.FormFileFindUniqueArgs>(
+    args: Prisma.SelectSubset<T, Prisma.FormFileFindUniqueArgs>
+  ) => prisma.formFile.findUnique(args);
+
+  const create = <T extends Prisma.FormFileCreateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.FormFileCreateArgs>
+  ) => prisma.formFile.create(args);
+
+  const update = <T extends Prisma.FormFileUpdateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.FormFileUpdateArgs>
+  ) => prisma.formFile.update(args);
+
+  const remove = <T extends Prisma.FormFileDeleteArgs>(
+    args: Prisma.SelectSubset<T, Prisma.FormFileDeleteArgs>
+  ) => prisma.formFile.delete(args);
+
+  const count = <T extends Prisma.FormFileCountArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.FormFileCountArgs>
+  ) => prisma.formFile.count(args);
+
+  /** --- Domain-oriented helpers for common access patterns --- */
+
+  /**
+   * List a form's files, most recent first, optionally filtered by type
+   * (e.g. `FormBackground`, `FormResponse`).
+   */
+  const listByFormId = async (formId: string, type?: string) =>
+    prisma.formFile.findMany({
+      where: { formId, ...(type ? { type } : {}) },
+      orderBy: { createdAt: 'desc' },
+    });
+
+  const findById = async (id: string) =>
+    prisma.formFile.findUnique({ where: { id } });
+
+  /**
+   * Create a form asset record (e.g. a copied background image/video).
+   * Kept as its own helper so `formRepository.createFormAsset` can delegate
+   * here while still sharing a transaction-scoped Prisma client.
+   */
+  const createFormFile = async (data: Prisma.FormFileCreateArgs['data']) =>
+    prisma.formFile.create({ data });
+
+  return {
+    // Generic operations (used when custom queries are needed)
+    findMany,
+    findUnique,
+    create,
+    update,
+    delete: remove,
+    count,
+
+    // Domain helpers (preferred for service layer)
+    listByFormId,
+    findById,
+    createFormFile,
+  };
+};
+
+export type FormFileRepository = ReturnType<typeof createFormFileRepository>;
+
+export const formFileRepository = createFormFileRepository();

--- a/apps/backend/src/repositories/formRepository.ts
+++ b/apps/backend/src/repositories/formRepository.ts
@@ -1,5 +1,6 @@
 import type { Prisma } from '#prisma-client';
 import { resolvePrisma, type RepositoryContext } from './baseRepository.js';
+import { createFormFileRepository } from './formFileRepository.js';
 
 const defaultFormInclude = {
   organization: { select: { id: true, name: true, slug: true, logo: true } },
@@ -13,6 +14,9 @@ const defaultFormInclude = {
  */
 export const createFormRepository = (context?: RepositoryContext) => {
   const prisma = resolvePrisma(context);
+  // Share the same (possibly transaction-scoped) Prisma client so FormFile
+  // writes made through this repository stay atomic with the caller's transaction.
+  const formFileRepo = createFormFileRepository(context);
 
   /** --- Generic delegate passthroughs (keep API flexibility) --- */
   const findMany = <T extends Prisma.FormFindManyArgs>(
@@ -120,13 +124,12 @@ export const createFormRepository = (context?: RepositoryContext) => {
 
   /**
    * Attach form-level assets (e.g. background images) in a single call.
+   * `FormFile` is the single source of truth here — this delegates to
+   * `formFileRepository` rather than duplicating the write.
    */
   const createFormAsset = async (
     data: Prisma.FormFileCreateArgs['data']
-  ) =>
-    prisma.formFile.create({
-      data,
-    });
+  ) => formFileRepo.createFormFile(data);
 
   return {
     // Generic operations (used when custom queries are needed)

--- a/apps/backend/src/repositories/index.ts
+++ b/apps/backend/src/repositories/index.ts
@@ -1,5 +1,6 @@
 export * from './baseRepository.js';
 export * from './formRepository.js';
+export * from './formFileRepository.js';
 export * from './subscriptionRepository.js';
 export * from './responseRepository.js';
 export * from './formTemplateRepository.js';

--- a/apps/backend/src/services/formFileService.ts
+++ b/apps/backend/src/services/formFileService.ts
@@ -1,0 +1,17 @@
+import type { Prisma } from '#prisma-client';
+import { formFileRepository } from '../repositories/index.js';
+
+/**
+ * List a form's files, most recent first, optionally filtered by type
+ * (e.g. `FormBackground`, `FormResponse`). Caller is responsible for
+ * validating `type` against the allowed set before calling.
+ */
+export const listFormFiles = async (formId: string, type?: string) =>
+  formFileRepository.listByFormId(formId, type);
+
+export const findFormFileById = async (id: string) =>
+  formFileRepository.findById(id);
+
+export const createFormFile = async (
+  data: Prisma.FormFileCreateArgs['data']
+) => formFileRepository.createFormFile(data);


### PR DESCRIPTION
## Summary
- Adds `formFileRepository` (`apps/backend/src/repositories/formFileRepository.ts`) covering `prisma.formFile.*`, following the `formRepository.ts` pattern (generic passthroughs + domain helpers `listByFormId`, `findById`, `createFormFile`).
- Adds `formFileService` (`apps/backend/src/services/formFileService.ts`) with `listFormFiles`, `findFormFileById`, `createFormFile`.
- `formRepository.createFormAsset` now delegates to `formFileRepository.createFormFile` instead of duplicating the write, using the same (possibly transaction-scoped) Prisma client, so `formService.createForm`'s transaction atomicity is unaffected.
- `formFiles.ts`'s `getFormFiles` resolver now calls `formFileService.listFormFiles` instead of `prisma.formFile.findMany`.
- `templates.ts`'s `createFormFromTemplate` now calls `formFileService.createFormFile` for the two copied background image/video `FormFile` writes instead of `prisma.formFile.create`; the now-unused `prisma` import was removed.

No behavior change — this is a structural refactor per the repository-pattern rollout epic.

Closes #255 (part of epic #245).

## Test plan
- [x] `apps/backend/src/repositories/__tests__/formFileRepository.test.ts` added (mocked Prisma)
- [x] `grep -n "prisma\." apps/backend/src/graphql/resolvers/formFiles.ts` → zero results
- [x] `grep -n "prisma\.formFile" apps/backend/src/graphql/resolvers/templates.ts` → zero results
- [x] `pnpm --filter backend exec tsc --noEmit` passes
- [x] `pnpm test:unit` passes (2893/2893 tests, 102 files) — includes unmodified `formFiles.test.ts`, `templates.test.ts`, `formService.test.ts`, `formRepository.test.ts`
- [x] `pnpm test:unit`/build ran again automatically via the pre-push hook and passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)