### PR TITLE
Story 12: Form access reconnect — fieldAnalytics.ts + shared form-access helper

### DIFF
--- a/apps/backend/src/graphql/resolvers/__tests__/fieldAnalytics.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/fieldAnalytics.test.ts
@@ -5,20 +5,13 @@ import { FieldType } from '@dculus/types';
 import * as fieldAnalyticsService from '../../../services/fieldAnalytics/index.js';
 import * as hocuspocusService from '../../../services/hocuspocus.js';
 import * as formSharingModule from '../formSharing.js';
-import { prisma } from '../../../lib/prisma.js';
+import * as formServiceModule from '../../../services/formService.js';
 
 // Mock all dependencies
 vi.mock('../../../services/fieldAnalytics/index.js');
 vi.mock('../../../services/hocuspocus.js');
 vi.mock('../formSharing.js');
-vi.mock('../../../lib/prisma.js', () => ({
-  prisma: {
-    form: {
-      findFirst: vi.fn(),
-      findUnique: vi.fn(),
-    },
-  },
-}));
+vi.mock('../../../services/formService.js');
 vi.mock('../../../lib/logger.js', () => ({
   logger: {
     info: vi.fn(),
@@ -552,7 +545,7 @@ describe('Field Analytics Resolvers', () => {
     it('should throw error when fallback schema is null', async () => {
       vi.mocked(formSharingModule.checkFormAccess).mockResolvedValue({ hasAccess: true, permission: 'VIEWER' as any, form: mockForm as any });
       vi.mocked(hocuspocusService.getFormSchemaFromHocuspocus).mockResolvedValue(null);
-      vi.mocked(prisma.form.findUnique as any).mockResolvedValue({ formSchema: null });
+      vi.mocked(formServiceModule.getFormById).mockResolvedValue({ formSchema: null } as any);
 
       await expect(
         fieldAnalyticsResolvers.Query.fieldAnalytics(
@@ -566,7 +559,7 @@ describe('Field Analytics Resolvers', () => {
     it('should throw error when field not found in fallback schema', async () => {
       vi.mocked(formSharingModule.checkFormAccess).mockResolvedValue({ hasAccess: true, permission: 'VIEWER' as any, form: mockForm as any });
       vi.mocked(hocuspocusService.getFormSchemaFromHocuspocus).mockResolvedValue(null);
-      vi.mocked(prisma.form.findUnique as any).mockResolvedValue({ formSchema: mockFormWithSchema.formSchema });
+      vi.mocked(formServiceModule.getFormById).mockResolvedValue({ formSchema: mockFormWithSchema.formSchema } as any);
 
       await expect(
         fieldAnalyticsResolvers.Query.fieldAnalytics(

--- a/apps/backend/src/graphql/resolvers/fieldAnalytics.ts
+++ b/apps/backend/src/graphql/resolvers/fieldAnalytics.ts
@@ -7,7 +7,7 @@ import {
   type FieldAnalytics,
 } from '../../services/fieldAnalytics/index.js';
 import { requireAuth, type BetterAuthContext } from '../../middleware/better-auth-middleware.js';
-import { prisma } from '../../lib/prisma.js';
+import { getFormById } from '../../services/formService.js';
 import { getFormSchemaFromHocuspocus } from '../../services/hocuspocus.js';
 import { logger } from '../../lib/logger.js';
 import { checkFormAccess, PermissionLevel } from './formSharing.js';
@@ -204,10 +204,7 @@ export const fieldAnalyticsResolvers = {
 
         // Fallback to database schema if collaborative document doesn't exist
         // Access already verified above — only fetching schema here
-        const fallbackForm = await prisma.form.findUnique({
-          where: { id: formId },
-          select: { formSchema: true },
-        });
+        const fallbackForm = await getFormById(formId);
         const fallbackSchema = fallbackForm?.formSchema as any;
 
         logger.info('📋 Fallback DB schema structure:', {

--- a/apps/backend/src/repositories/__tests__/formRepository.test.ts
+++ b/apps/backend/src/repositories/__tests__/formRepository.test.ts
@@ -93,4 +93,34 @@ describe('formRepository', () => {
     expect(prismaMock.formPermission.create).toHaveBeenCalledWith({ data: { formId: 'form-1' } });
     expect(prismaMock.formFile.create).toHaveBeenCalledWith({ data: { formId: 'form-1', key: 'file' } });
   });
+
+  describe('listAccessibleByOrganization', () => {
+    it('queries with the created/permission/sharing-scope OR clause and id-only select', async () => {
+      const repo = createFormRepository();
+      prismaMock.form.findMany.mockResolvedValueOnce([{ id: 'form-1' }, { id: 'form-2' }]);
+
+      const result = await repo.listAccessibleByOrganization('org-1', 'user-1');
+
+      expect(prismaMock.form.findMany).toHaveBeenCalledWith({
+        where: {
+          organizationId: 'org-1',
+          OR: [
+            { createdById: 'user-1' },
+            { permissions: { some: { userId: 'user-1', permission: { not: 'NO_ACCESS' } } } },
+            { sharingScope: 'ALL_ORG_MEMBERS', defaultPermission: { not: 'NO_ACCESS' } },
+          ],
+        },
+        select: { id: true },
+      });
+      expect(result).toEqual([{ id: 'form-1' }, { id: 'form-2' }]);
+    });
+
+    it('does not filter by deletedAt (matches existing inline behavior)', async () => {
+      const repo = createFormRepository();
+      await repo.listAccessibleByOrganization('org-1', 'user-1');
+
+      const callArgs = prismaMock.form.findMany.mock.calls[0][0];
+      expect(callArgs.where).not.toHaveProperty('deletedAt');
+    });
+  });
 });

--- a/apps/backend/src/repositories/formRepository.ts
+++ b/apps/backend/src/repositories/formRepository.ts
@@ -78,6 +78,38 @@ export const createFormRepository = (context?: RepositoryContext) => {
     });
 
   /**
+   * Forms within an organization that a user can actually see: forms they
+   * created, forms with an explicit non-NO_ACCESS permission grant, or forms
+   * shared org-wide (ALL_ORG_MEMBERS) with a non-NO_ACCESS default permission.
+   * Mirrors the inline query in resolvers/responses.ts exactly (no `deletedAt`
+   * filter — matches existing behavior, do not add one here as a "fix").
+   * Only returns `id` — callers needing more should pass richer usage through
+   * a dedicated helper rather than widening this one.
+   */
+  const listAccessibleByOrganization = async (
+    organizationId: string,
+    userId: string
+  ): Promise<{ id: string }[]> =>
+    prisma.form.findMany({
+      where: {
+        organizationId,
+        OR: [
+          { createdById: userId },
+          {
+            permissions: {
+              some: { userId, permission: { not: 'NO_ACCESS' } },
+            },
+          },
+          {
+            sharingScope: 'ALL_ORG_MEMBERS',
+            defaultPermission: { not: 'NO_ACCESS' },
+          },
+        ],
+      },
+      select: { id: true },
+    });
+
+  /**
    * Create a form record with the default relation include baked in.
    * Use `create` above when a custom projection is required.
    */
@@ -141,6 +173,7 @@ export const createFormRepository = (context?: RepositoryContext) => {
     listByOrganization,
     findById,
     findByShortUrl,
+    listAccessibleByOrganization,
     createForm,
     updateForm,
     deleteForm,

--- a/apps/backend/src/services/__tests__/formService.test.ts
+++ b/apps/backend/src/services/__tests__/formService.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   getAllForms,
   getFormById,
+  getAccessibleFormIds,
   getFormByShortUrl,
   createForm,
   updateForm,
@@ -175,6 +176,28 @@ describe('Form Service', () => {
       const result = await getFormById('form-123');
 
       expect(result?.description).toBeUndefined();
+    });
+  });
+
+  describe('getAccessibleFormIds', () => {
+    it('should return ids of accessible forms for a user in an organization', async () => {
+      vi.mocked(formRepository.listAccessibleByOrganization).mockResolvedValue([
+        { id: 'form-1' },
+        { id: 'form-2' },
+      ] as any);
+
+      const result = await getAccessibleFormIds('org-123', 'user-123');
+
+      expect(formRepository.listAccessibleByOrganization).toHaveBeenCalledWith('org-123', 'user-123');
+      expect(result).toEqual(['form-1', 'form-2']);
+    });
+
+    it('should return an empty array when no forms are accessible', async () => {
+      vi.mocked(formRepository.listAccessibleByOrganization).mockResolvedValue([]);
+
+      const result = await getAccessibleFormIds('org-123', 'user-123');
+
+      expect(result).toEqual([]);
     });
   });
 

--- a/apps/backend/src/services/formService.ts
+++ b/apps/backend/src/services/formService.ts
@@ -65,6 +65,20 @@ export const getFormById = async (id: string): Promise<Form | null> => {
   }
 };
 
+/**
+ * Form IDs within an organization that a user can actually access (owner,
+ * explicit non-NO_ACCESS permission grant, or ALL_ORG_MEMBERS sharing with a
+ * non-NO_ACCESS default permission). Callers still need to separately verify
+ * organization membership — this only scopes forms, not org access.
+ */
+export const getAccessibleFormIds = async (
+  organizationId: string,
+  userId: string
+): Promise<string[]> => {
+  const forms = await formRepository.listAccessibleByOrganization(organizationId, userId);
+  return forms.map((form) => form.id);
+};
+
 export const getFormByShortUrl = async (shortUrl: string): Promise<Form | null> => {
   try {
     const form = await formRepository.findByShortUrl(shortUrl);


### PR DESCRIPTION
## Summary
- Routes `fieldAnalytics.ts`'s fallback schema lookup through `formService.getFormById()` instead of calling `prisma.form.findUnique(...)` directly, closing the last gap for this file in the repository-pattern rollout.
- Adds `formRepository.listAccessibleByOrganization(organizationId, userId)` — the exact access-scoping `OR` clause (`createdById` / non-`NO_ACCESS` explicit permission / `ALL_ORG_MEMBERS` with non-`NO_ACCESS` default permission) currently inlined in `responses.ts:77-87` — plus `formService.getAccessibleFormIds(organizationId, userId)` on top of it. Ticket #11 (Response & Analytics Reconnect) will consume this to swap out its own inline query; not touched here per the epic's shared-file ownership rule.
- Confirmed `formRepository.findById` / `formService.getFormById` already return `organizationId` as a plain scalar field, so no additional variant is needed for the other dependent tickets (#4 PDF templates, #6 automation, #10 form sharing).

Closes #246 (part of epic #245).

## Test plan
- [x] `grep -n "prisma\." apps/backend/src/graphql/resolvers/fieldAnalytics.ts` → no results
- [x] New test cases for `formRepository.listAccessibleByOrganization` in `repositories/__tests__/formRepository.test.ts`
- [x] New test cases for `formService.getAccessibleFormIds` in `services/__tests__/formService.test.ts`
- [x] Updated `fieldAnalytics.test.ts` to mock `formService.getFormById` instead of `prisma.form.findUnique` for the fallback-schema path
- [x] `pnpm --filter backend exec tsc --noEmit` passes
- [x] `pnpm test:unit` passes (2893/2893 tests, 101 files)
- [x] Pre-push hook (full build + test across backend/form-app/form-viewer/admin-app) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved field analytics reliability when collaborative form data is unavailable by using the available form schema as a fallback.
  * Improved handling of missing or unsupported fields and schemas during analytics requests.

* **Improvements**
  * Added more consistent retrieval of forms accessible to a user based on ownership, permissions, and organization-wide sharing settings.
  * Expanded automated coverage for analytics fallback behavior and access-based form retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->