### PR TITLE
Story 06: Automation repository pattern (automationRepository + automationService)

### DIFF
--- a/apps/backend/src/graphql/resolvers/__tests__/automations.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/automations.test.ts
@@ -3,50 +3,11 @@ import { automationsResolvers } from '../automations.js';
 import { GraphQLError } from '#graphql-errors';
 import * as betterAuthMiddleware from '../../../middleware/better-auth-middleware.js';
 import * as formSharingResolvers from '../formSharing.js';
-import * as pluginRegistry from '../../../plugins/core/registry.js';
-import * as graphValidator from '../../../services/automation/graphValidator.js';
-import * as engine from '../../../services/automation/engine.js';
-import * as triggerService from '../../../services/automation/triggerService.js';
-import { prisma } from '../../../lib/prisma.js';
+import * as automationService from '../../../services/automationService.js';
 
 vi.mock('../../../middleware/better-auth-middleware.js');
 vi.mock('../formSharing.js');
-vi.mock('../../../plugins/core/registry.js');
-vi.mock('../../../services/automation/graphValidator.js');
-vi.mock('../../../services/automation/engine.js');
-vi.mock('../../../services/automation/triggerService.js');
-vi.mock('../../../lib/prisma.js', () => ({
-  prisma: {
-    automation: {
-      findMany: vi.fn(),
-      findUnique: vi.fn(),
-      create: vi.fn(),
-      update: vi.fn(),
-      delete: vi.fn(),
-    },
-    automationRun: {
-      findMany: vi.fn(),
-      findUnique: vi.fn(),
-      create: vi.fn(),
-    },
-    automationStepRun: {
-      findMany: vi.fn(),
-    },
-    response: {
-      findFirst: vi.fn(),
-    },
-  },
-}));
-vi.mock('../../../lib/logger.js', () => ({
-  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
-}));
-vi.mock('@dculus/utils', async () => {
-  const actual = await vi.importActual<typeof import('@dculus/utils')>('@dculus/utils');
-  return {
-    ...actual,
-    generateId: vi.fn(() => 'generated-id'),
-  };
-});
+vi.mock('../../../services/automationService.js');
 
 describe('Automations Resolvers', () => {
   const mockContext = {
@@ -118,7 +79,7 @@ describe('Automations Resolvers', () => {
   describe('Permission matrix', () => {
     it('formAutomations: allows VIEWER access to read', async () => {
       grantAccess('VIEWER');
-      vi.mocked(prisma.automation.findMany).mockResolvedValue([mockAutomation] as any);
+      vi.mocked(automationService.listAutomationsByForm).mockResolvedValue([mockAutomation] as any);
 
       const result = await automationsResolvers.Query.formAutomations(
         {},
@@ -131,6 +92,7 @@ describe('Automations Resolvers', () => {
         'form-123',
         formSharingResolvers.PermissionLevel.VIEWER
       );
+      expect(automationService.listAutomationsByForm).toHaveBeenCalledWith('form-123');
       expect(result).toEqual([mockAutomation]);
     });
 
@@ -176,12 +138,12 @@ describe('Automations Resolvers', () => {
           mockContext
         )
       ).rejects.toThrow(/Access denied/);
-      expect(prisma.automation.create).not.toHaveBeenCalled();
+      expect(automationService.createAutomation).not.toHaveBeenCalled();
     });
 
     it('createAutomation: allows EDITOR access to write', async () => {
       grantAccess('EDITOR');
-      vi.mocked(prisma.automation.create).mockResolvedValue(mockAutomation as any);
+      vi.mocked(automationService.createAutomation).mockResolvedValue(mockAutomation as any);
 
       const result = await automationsResolvers.Mutation.createAutomation(
         {},
@@ -194,12 +156,19 @@ describe('Automations Resolvers', () => {
         'form-123',
         formSharingResolvers.PermissionLevel.EDITOR
       );
+      expect(automationService.createAutomation).toHaveBeenCalledWith({
+        formId: 'form-123',
+        organizationId: 'org-123',
+        name: 'Test',
+        triggerType: 'form.submitted',
+        createdBy: 'user-123',
+      });
       expect(result).toEqual(mockAutomation);
     });
 
     it('automation: allows OWNER access to read', async () => {
       grantAccess('OWNER');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(mockAutomation as any);
+      vi.mocked(automationService.getAutomationById).mockResolvedValue(mockAutomation as any);
 
       const result = await automationsResolvers.Query.automation(
         {},
@@ -211,14 +180,16 @@ describe('Automations Resolvers', () => {
     });
 
     it('automation: throws AUTOMATION_NOT_FOUND when the automation does not exist', async () => {
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(null);
+      vi.mocked(automationService.getAutomationById).mockRejectedValue(
+        new GraphQLError('Automation not found')
+      );
 
       await expect(
         automationsResolvers.Query.automation({}, { id: 'missing' }, mockContext)
       ).rejects.toThrow('Automation not found');
     });
 
-    it('automation: checks auth before looking up the automation in the DB', async () => {
+    it('automation: checks auth before looking up the automation', async () => {
       vi.mocked(betterAuthMiddleware.requireAuth).mockImplementation(() => {
         throw new GraphQLError('Authentication required');
       });
@@ -226,55 +197,51 @@ describe('Automations Resolvers', () => {
       await expect(
         automationsResolvers.Query.automation({}, { id: 'automation-123' }, mockContext)
       ).rejects.toThrow('Authentication required');
-      expect(prisma.automation.findUnique).not.toHaveBeenCalled();
+      expect(automationService.getAutomationById).not.toHaveBeenCalled();
     });
   });
 
-  describe('Activation gate (setAutomationStatus)', () => {
-    it('blocks activation and surfaces structured validation errors', async () => {
+  describe('updateAutomation / setAutomationStatus / deleteAutomation / testAutomation orchestration', () => {
+    it('updateAutomation: fetches the automation, checks EDITOR access, then delegates to the service', async () => {
       grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(mockAutomation as any);
-      vi.mocked(pluginRegistry.getAvailablePluginTypes).mockReturnValue(['webhook', 'email']);
-      const validationErrors = [
-        { nodeId: 'action-1', code: 'UNKNOWN_ACTION_TYPE', message: 'unregistered action type' },
-      ];
-      vi.mocked(graphValidator.validateAutomationGraph).mockReturnValue({
-        valid: false,
-        errors: validationErrors,
+      vi.mocked(automationService.getAutomationById).mockResolvedValue(mockAutomation as any);
+      const updated = { ...mockAutomation, name: 'Renamed' };
+      vi.mocked(automationService.updateAutomation).mockResolvedValue(updated as any);
+
+      const result = await automationsResolvers.Mutation.updateAutomation(
+        {},
+        { id: 'automation-123', name: 'Renamed' },
+        mockContext
+      );
+
+      expect(automationService.getAutomationById).toHaveBeenCalledWith('automation-123');
+      expect(automationService.updateAutomation).toHaveBeenCalledWith(mockAutomation, {
+        name: 'Renamed',
+        graph: undefined,
+        triggerConfig: undefined,
       });
-
-      await expect(
-        automationsResolvers.Mutation.setAutomationStatus(
-          {},
-          { id: 'automation-123', status: 'ACTIVE' },
-          mockContext
-        )
-      ).rejects.toThrow(GraphQLError);
-
-      try {
-        await automationsResolvers.Mutation.setAutomationStatus(
-          {},
-          { id: 'automation-123', status: 'ACTIVE' },
-          mockContext
-        );
-        expect.unreachable('should have thrown');
-      } catch (error: any) {
-        expect(error.extensions.code).toBe('AUTOMATION_INVALID_GRAPH');
-        expect(error.extensions.validationErrors).toEqual(validationErrors);
-      }
-
-      expect(prisma.automation.update).not.toHaveBeenCalled();
+      expect(result).toEqual(updated);
     });
 
-    it('activates when the graph is valid', async () => {
+    it('updateAutomation: denies without EDITOR+ access', async () => {
+      denyAccess();
+      vi.mocked(automationService.getAutomationById).mockResolvedValue(mockAutomation as any);
+
+      await expect(
+        automationsResolvers.Mutation.updateAutomation(
+          {},
+          { id: 'automation-123', name: 'x' },
+          mockContext
+        )
+      ).rejects.toThrow(/Access denied/);
+      expect(automationService.updateAutomation).not.toHaveBeenCalled();
+    });
+
+    it('setAutomationStatus: fetches the automation, checks EDITOR access, then delegates to the service', async () => {
       grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(mockAutomation as any);
-      vi.mocked(pluginRegistry.getAvailablePluginTypes).mockReturnValue(['webhook', 'email']);
-      vi.mocked(graphValidator.validateAutomationGraph).mockReturnValue({ valid: true, errors: [] });
-      vi.mocked(prisma.automation.update).mockResolvedValue({
-        ...mockAutomation,
-        status: 'ACTIVE',
-      } as any);
+      vi.mocked(automationService.getAutomationById).mockResolvedValue(mockAutomation as any);
+      const updated = { ...mockAutomation, status: 'ACTIVE' };
+      vi.mocked(automationService.setAutomationStatus).mockResolvedValue(updated as any);
 
       const result = await automationsResolvers.Mutation.setAutomationStatus(
         {},
@@ -282,91 +249,13 @@ describe('Automations Resolvers', () => {
         mockContext
       );
 
-      expect(prisma.automation.update).toHaveBeenCalledWith({
-        where: { id: 'automation-123' },
-        data: { status: 'ACTIVE', updatedAt: expect.any(Date) },
-      });
-      expect(result.status).toBe('ACTIVE');
+      expect(automationService.setAutomationStatus).toHaveBeenCalledWith(mockAutomation, 'ACTIVE');
+      expect(result).toEqual(updated);
     });
 
-    it('does not run graph validation when pausing', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue({
-        ...mockAutomation,
-        status: 'ACTIVE',
-      } as any);
-      vi.mocked(prisma.automation.update).mockResolvedValue({
-        ...mockAutomation,
-        status: 'PAUSED',
-      } as any);
-
-      await automationsResolvers.Mutation.setAutomationStatus(
-        {},
-        { id: 'automation-123', status: 'PAUSED' },
-        mockContext
-      );
-
-      expect(graphValidator.validateAutomationGraph).not.toHaveBeenCalled();
-    });
-
-    it('rejects unknown status values', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(mockAutomation as any);
-
-      await expect(
-        automationsResolvers.Mutation.setAutomationStatus(
-          {},
-          { id: 'automation-123', status: 'BOGUS' },
-          mockContext
-        )
-      ).rejects.toThrow(/Invalid status/);
-    });
-  });
-
-  describe('schedule lifecycle (setAutomationStatus)', () => {
-    const scheduleAutomation = {
-      ...mockAutomation,
-      triggerType: 'schedule',
-      triggerConfig: { cron: '0 9 * * *', timezone: 'America/Chicago' },
-    };
-
-    it('activating a valid schedule automation validates the graph, validates the cron, and schedules it', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(scheduleAutomation as any);
-      vi.mocked(pluginRegistry.getAvailablePluginTypes).mockReturnValue(['webhook', 'email']);
-      vi.mocked(graphValidator.validateAutomationGraph).mockReturnValue({ valid: true, errors: [] });
-      vi.mocked(prisma.automation.update).mockResolvedValue({
-        ...scheduleAutomation,
-        status: 'ACTIVE',
-      } as any);
-      vi.mocked(triggerService.scheduleAutomationCron).mockResolvedValue(undefined as any);
-
-      await automationsResolvers.Mutation.setAutomationStatus(
-        {},
-        { id: 'automation-123', status: 'ACTIVE' },
-        mockContext
-      );
-
-      expect(graphValidator.validateAutomationGraph).toHaveBeenCalledWith(
-        scheduleAutomation.graph,
-        expect.objectContaining({ triggerType: 'schedule' })
-      );
-      expect(triggerService.scheduleAutomationCron).toHaveBeenCalledWith(
-        'automation-123',
-        '0 9 * * *',
-        'America/Chicago'
-      );
-      expect(triggerService.unscheduleAutomationCron).not.toHaveBeenCalled();
-    });
-
-    it('rejects activating a schedule automation with an invalid cron before updating or scheduling', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue({
-        ...scheduleAutomation,
-        triggerConfig: { cron: 'not a cron' },
-      } as any);
-      vi.mocked(pluginRegistry.getAvailablePluginTypes).mockReturnValue(['webhook', 'email']);
-      vi.mocked(graphValidator.validateAutomationGraph).mockReturnValue({ valid: true, errors: [] });
+    it('setAutomationStatus: denies without EDITOR+ access', async () => {
+      denyAccess();
+      vi.mocked(automationService.getAutomationById).mockResolvedValue(mockAutomation as any);
 
       await expect(
         automationsResolvers.Mutation.setAutomationStatus(
@@ -374,326 +263,14 @@ describe('Automations Resolvers', () => {
           { id: 'automation-123', status: 'ACTIVE' },
           mockContext
         )
-      ).rejects.toThrow(/Invalid cron expression/);
-
-      expect(prisma.automation.update).not.toHaveBeenCalled();
-      expect(triggerService.scheduleAutomationCron).not.toHaveBeenCalled();
+      ).rejects.toThrow(/Access denied/);
+      expect(automationService.setAutomationStatus).not.toHaveBeenCalled();
     });
 
-    it('rejects activating a schedule automation with no triggerConfig', async () => {
+    it('deleteAutomation: fetches the automation, checks EDITOR access, then delegates to the service', async () => {
       grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue({
-        ...scheduleAutomation,
-        triggerConfig: null,
-      } as any);
-      vi.mocked(pluginRegistry.getAvailablePluginTypes).mockReturnValue(['webhook', 'email']);
-      vi.mocked(graphValidator.validateAutomationGraph).mockReturnValue({ valid: true, errors: [] });
-
-      await expect(
-        automationsResolvers.Mutation.setAutomationStatus(
-          {},
-          { id: 'automation-123', status: 'ACTIVE' },
-          mockContext
-        )
-      ).rejects.toThrow(/triggerConfig/);
-    });
-
-    it('pausing a schedule automation unschedules its cron', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue({
-        ...scheduleAutomation,
-        status: 'ACTIVE',
-      } as any);
-      vi.mocked(prisma.automation.update).mockResolvedValue({
-        ...scheduleAutomation,
-        status: 'PAUSED',
-      } as any);
-      vi.mocked(triggerService.unscheduleAutomationCron).mockResolvedValue(undefined as any);
-
-      await automationsResolvers.Mutation.setAutomationStatus(
-        {},
-        { id: 'automation-123', status: 'PAUSED' },
-        mockContext
-      );
-
-      expect(triggerService.unscheduleAutomationCron).toHaveBeenCalledWith('automation-123');
-      expect(triggerService.scheduleAutomationCron).not.toHaveBeenCalled();
-    });
-
-    it('does not touch pg-boss scheduling for non-schedule automations', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(mockAutomation as any);
-      vi.mocked(pluginRegistry.getAvailablePluginTypes).mockReturnValue(['webhook', 'email']);
-      vi.mocked(graphValidator.validateAutomationGraph).mockReturnValue({ valid: true, errors: [] });
-      vi.mocked(prisma.automation.update).mockResolvedValue({
-        ...mockAutomation,
-        status: 'ACTIVE',
-      } as any);
-
-      await automationsResolvers.Mutation.setAutomationStatus(
-        {},
-        { id: 'automation-123', status: 'ACTIVE' },
-        mockContext
-      );
-
-      expect(triggerService.scheduleAutomationCron).not.toHaveBeenCalled();
-      expect(triggerService.unscheduleAutomationCron).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('updateAutomation version bump', () => {
-    it('bumps version when graph is provided', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(mockAutomation as any);
-      const newGraph = {
-        ...mockGraph,
-        nodes: [...mockGraph.nodes, { id: 'delay-1', type: 'delay', data: { amount: 1, unit: 'minutes' } }],
-      };
-      vi.mocked(prisma.automation.update).mockResolvedValue({
-        ...mockAutomation,
-        graph: newGraph,
-        version: 2,
-      } as any);
-
-      const result = await automationsResolvers.Mutation.updateAutomation(
-        {},
-        { id: 'automation-123', graph: newGraph },
-        mockContext
-      );
-
-      expect(prisma.automation.update).toHaveBeenCalledWith({
-        where: { id: 'automation-123' },
-        data: {
-          updatedAt: expect.any(Date),
-          graph: newGraph,
-          version: { increment: 1 },
-        },
-      });
-      expect(result.version).toBe(2);
-    });
-
-    it('does not bump version when only name changes', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(mockAutomation as any);
-      vi.mocked(prisma.automation.update).mockResolvedValue({
-        ...mockAutomation,
-        name: 'Renamed',
-      } as any);
-
-      await automationsResolvers.Mutation.updateAutomation(
-        {},
-        { id: 'automation-123', name: 'Renamed' },
-        mockContext
-      );
-
-      expect(prisma.automation.update).toHaveBeenCalledWith({
-        where: { id: 'automation-123' },
-        data: { updatedAt: expect.any(Date), name: 'Renamed' },
-      });
-    });
-
-    it('does not bump version when the resubmitted graph is unchanged', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(mockAutomation as any);
-      const sameGraph = JSON.parse(JSON.stringify(mockGraph));
-      vi.mocked(prisma.automation.update).mockResolvedValue(mockAutomation as any);
-
-      await automationsResolvers.Mutation.updateAutomation(
-        {},
-        { id: 'automation-123', graph: sameGraph },
-        mockContext
-      );
-
-      expect(prisma.automation.update).toHaveBeenCalledWith({
-        where: { id: 'automation-123' },
-        data: { updatedAt: expect.any(Date), graph: sameGraph },
-      });
-    });
-
-    it('throws AUTOMATION_NOT_FOUND for a missing automation', async () => {
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(null);
-
-      await expect(
-        automationsResolvers.Mutation.updateAutomation(
-          {},
-          { id: 'missing', name: 'x' },
-          mockContext
-        )
-      ).rejects.toThrow('Automation not found');
-    });
-  });
-
-  describe('updateAutomation validates the graph when the automation is already ACTIVE', () => {
-    it('rejects saving an invalid graph to an ACTIVE automation before writing to the DB', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue({
-        ...mockAutomation,
-        status: 'ACTIVE',
-      } as any);
-      vi.mocked(pluginRegistry.getAvailablePluginTypes).mockReturnValue(['webhook', 'email']);
-      const validationErrors = [
-        { nodeId: 'action-1', code: 'UNKNOWN_ACTION_TYPE', message: 'unregistered action type' },
-      ];
-      vi.mocked(graphValidator.validateAutomationGraph).mockReturnValue({
-        valid: false,
-        errors: validationErrors,
-      });
-
-      await expect(
-        automationsResolvers.Mutation.updateAutomation(
-          {},
-          { id: 'automation-123', graph: mockGraph },
-          mockContext
-        )
-      ).rejects.toThrow(GraphQLError);
-
-      expect(graphValidator.validateAutomationGraph).toHaveBeenCalledWith(
-        mockGraph,
-        expect.objectContaining({ triggerType: 'form.submitted' })
-      );
-      expect(prisma.automation.update).not.toHaveBeenCalled();
-    });
-
-    it('allows saving a valid graph to an ACTIVE automation', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue({
-        ...mockAutomation,
-        status: 'ACTIVE',
-      } as any);
-      vi.mocked(pluginRegistry.getAvailablePluginTypes).mockReturnValue(['webhook', 'email']);
-      vi.mocked(graphValidator.validateAutomationGraph).mockReturnValue({ valid: true, errors: [] });
-      vi.mocked(prisma.automation.update).mockResolvedValue({
-        ...mockAutomation,
-        status: 'ACTIVE',
-        graph: mockGraph,
-      } as any);
-
-      await automationsResolvers.Mutation.updateAutomation(
-        {},
-        { id: 'automation-123', graph: mockGraph },
-        mockContext
-      );
-
-      expect(prisma.automation.update).toHaveBeenCalled();
-    });
-
-    it('does not validate the graph when the automation is DRAFT', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(mockAutomation as any);
-      vi.mocked(prisma.automation.update).mockResolvedValue(mockAutomation as any);
-
-      await automationsResolvers.Mutation.updateAutomation(
-        {},
-        { id: 'automation-123', graph: mockGraph },
-        mockContext
-      );
-
-      expect(graphValidator.validateAutomationGraph).not.toHaveBeenCalled();
-      expect(prisma.automation.update).toHaveBeenCalled();
-    });
-  });
-
-  describe('updateAutomation triggerConfig (schedule automations)', () => {
-    const scheduleAutomation = {
-      ...mockAutomation,
-      triggerType: 'schedule',
-      triggerConfig: { cron: '0 9 * * *' },
-    };
-
-    it('rejects an invalid cron expression', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(scheduleAutomation as any);
-
-      await expect(
-        automationsResolvers.Mutation.updateAutomation(
-          {},
-          { id: 'automation-123', triggerConfig: { cron: 'nonsense' } },
-          mockContext
-        )
-      ).rejects.toThrow(/Invalid cron expression/);
-      expect(prisma.automation.update).not.toHaveBeenCalled();
-    });
-
-    it('rejects an invalid timezone', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(scheduleAutomation as any);
-
-      await expect(
-        automationsResolvers.Mutation.updateAutomation(
-          {},
-          { id: 'automation-123', triggerConfig: { cron: '0 9 * * *', timezone: 'Not/A_Zone' } },
-          mockContext
-        )
-      ).rejects.toThrow(/Invalid timezone/);
-    });
-
-    it('re-schedules an ACTIVE schedule automation when triggerConfig changes', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue({
-        ...scheduleAutomation,
-        status: 'ACTIVE',
-      } as any);
-      vi.mocked(prisma.automation.update).mockResolvedValue({
-        ...scheduleAutomation,
-        status: 'ACTIVE',
-        triggerConfig: { cron: '0 18 * * *' },
-      } as any);
-      vi.mocked(triggerService.scheduleAutomationCron).mockResolvedValue(undefined as any);
-
-      await automationsResolvers.Mutation.updateAutomation(
-        {},
-        { id: 'automation-123', triggerConfig: { cron: '0 18 * * *' } },
-        mockContext
-      );
-
-      expect(triggerService.scheduleAutomationCron).toHaveBeenCalledWith(
-        'automation-123',
-        '0 18 * * *',
-        undefined
-      );
-    });
-
-    it('does not re-schedule a DRAFT schedule automation', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(scheduleAutomation as any);
-      vi.mocked(prisma.automation.update).mockResolvedValue({
-        ...scheduleAutomation,
-        triggerConfig: { cron: '0 18 * * *' },
-      } as any);
-
-      await automationsResolvers.Mutation.updateAutomation(
-        {},
-        { id: 'automation-123', triggerConfig: { cron: '0 18 * * *' } },
-        mockContext
-      );
-
-      expect(triggerService.scheduleAutomationCron).not.toHaveBeenCalled();
-    });
-
-    it('does not validate cron for non-schedule automations', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(mockAutomation as any);
-      vi.mocked(prisma.automation.update).mockResolvedValue(mockAutomation as any);
-
-      await automationsResolvers.Mutation.updateAutomation(
-        {},
-        { id: 'automation-123', triggerConfig: { cron: 'anything at all' } },
-        mockContext
-      );
-
-      expect(prisma.automation.update).toHaveBeenCalledWith({
-        where: { id: 'automation-123' },
-        data: { updatedAt: expect.any(Date), triggerConfig: { cron: 'anything at all' } },
-      });
-    });
-  });
-
-  describe('deleteAutomation cancels runs', () => {
-    it('cancels in-flight runs before deleting the automation', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(mockAutomation as any);
-      vi.mocked(triggerService.cancelRunsForAutomation).mockResolvedValue(undefined as any);
-      vi.mocked(prisma.automation.delete).mockResolvedValue(mockAutomation as any);
+      vi.mocked(automationService.getAutomationById).mockResolvedValue(mockAutomation as any);
+      vi.mocked(automationService.deleteAutomation).mockResolvedValue(true);
 
       const result = await automationsResolvers.Mutation.deleteAutomation(
         {},
@@ -701,81 +278,25 @@ describe('Automations Resolvers', () => {
         mockContext
       );
 
-      expect(triggerService.cancelRunsForAutomation).toHaveBeenCalledWith(
-        'automation-123',
-        expect.any(String)
-      );
-      const cancelOrder = vi.mocked(triggerService.cancelRunsForAutomation).mock
-        .invocationCallOrder[0];
-      const deleteOrder = vi.mocked(prisma.automation.delete).mock.invocationCallOrder[0];
-      expect(cancelOrder).toBeLessThan(deleteOrder);
-      expect(prisma.automation.delete).toHaveBeenCalledWith({ where: { id: 'automation-123' } });
+      expect(automationService.deleteAutomation).toHaveBeenCalledWith(mockAutomation);
       expect(result).toBe(true);
     });
 
-    it('denies deletion without EDITOR+ access', async () => {
+    it('deleteAutomation: denies without EDITOR+ access', async () => {
       denyAccess();
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(mockAutomation as any);
+      vi.mocked(automationService.getAutomationById).mockResolvedValue(mockAutomation as any);
 
       await expect(
         automationsResolvers.Mutation.deleteAutomation({}, { id: 'automation-123' }, mockContext)
       ).rejects.toThrow(/Access denied/);
-      expect(triggerService.cancelRunsForAutomation).not.toHaveBeenCalled();
-      expect(prisma.automation.delete).not.toHaveBeenCalled();
+      expect(automationService.deleteAutomation).not.toHaveBeenCalled();
     });
 
-    it('unschedules the cron before deleting a schedule automation', async () => {
+    it('testAutomation: fetches the automation, checks EDITOR access, then delegates to the service', async () => {
       grantAccess('EDITOR');
-      const scheduleAutomation = { ...mockAutomation, triggerType: 'schedule' };
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(scheduleAutomation as any);
-      vi.mocked(triggerService.unscheduleAutomationCron).mockResolvedValue(undefined as any);
-      vi.mocked(triggerService.cancelRunsForAutomation).mockResolvedValue(undefined as any);
-      vi.mocked(prisma.automation.delete).mockResolvedValue(scheduleAutomation as any);
-
-      await automationsResolvers.Mutation.deleteAutomation(
-        {},
-        { id: 'automation-123' },
-        mockContext
-      );
-
-      expect(triggerService.unscheduleAutomationCron).toHaveBeenCalledWith('automation-123');
-      const unscheduleOrder = vi.mocked(triggerService.unscheduleAutomationCron).mock
-        .invocationCallOrder[0];
-      const deleteOrder = vi.mocked(prisma.automation.delete).mock.invocationCallOrder[0];
-      expect(unscheduleOrder).toBeLessThan(deleteOrder);
-    });
-
-    it('does not call unscheduleAutomationCron for non-schedule automations', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(mockAutomation as any);
-      vi.mocked(triggerService.cancelRunsForAutomation).mockResolvedValue(undefined as any);
-      vi.mocked(prisma.automation.delete).mockResolvedValue(mockAutomation as any);
-
-      await automationsResolvers.Mutation.deleteAutomation(
-        {},
-        { id: 'automation-123' },
-        mockContext
-      );
-
-      expect(triggerService.unscheduleAutomationCron).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('testAutomation', () => {
-    const mockResponse = {
-      id: 'response-1',
-      formId: 'form-123',
-      data: { field1: 'value1' },
-      submittedAt: new Date('2026-01-02T00:00:00.000Z'),
-    };
-
-    it('uses the given responseId when provided', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(mockAutomation as any);
-      vi.mocked(prisma.response.findFirst).mockResolvedValue(mockResponse as any);
+      vi.mocked(automationService.getAutomationById).mockResolvedValue(mockAutomation as any);
       const createdRun = { id: 'run-1', automationId: 'automation-123', status: 'RUNNING' };
-      vi.mocked(prisma.automationRun.create).mockResolvedValue(createdRun as any);
-      vi.mocked(engine.enqueueFirstStep).mockResolvedValue(undefined as any);
+      vi.mocked(automationService.testAutomation).mockResolvedValue(createdRun as any);
 
       const result = await automationsResolvers.Mutation.testAutomation(
         {},
@@ -783,52 +304,73 @@ describe('Automations Resolvers', () => {
         mockContext
       );
 
-      expect(prisma.response.findFirst).toHaveBeenCalledWith({
-        where: { id: 'response-1', formId: 'form-123', deletedAt: null },
-      });
-      expect(prisma.automationRun.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
-          automationId: 'automation-123',
-          responseId: 'response-1',
-          status: 'RUNNING',
-          context: expect.objectContaining({
-            test: true,
-            triggerData: expect.objectContaining({ field1: 'value1', responseId: 'response-1' }),
-          }),
-        }),
-      });
-      expect(engine.enqueueFirstStep).toHaveBeenCalledWith(createdRun);
+      expect(automationService.testAutomation).toHaveBeenCalledWith(mockAutomation, 'response-1');
       expect(result).toEqual(createdRun);
     });
 
-    it('falls back to the latest response when none is given', async () => {
-      grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(mockAutomation as any);
-      vi.mocked(prisma.response.findFirst).mockResolvedValue(mockResponse as any);
-      vi.mocked(prisma.automationRun.create).mockResolvedValue({ id: 'run-1' } as any);
-      vi.mocked(engine.enqueueFirstStep).mockResolvedValue(undefined as any);
+    it('testAutomation: denies without EDITOR+ access', async () => {
+      denyAccess();
+      vi.mocked(automationService.getAutomationById).mockResolvedValue(mockAutomation as any);
 
-      await automationsResolvers.Mutation.testAutomation(
-        {},
-        { id: 'automation-123' },
-        mockContext
-      );
-
-      expect(prisma.response.findFirst).toHaveBeenCalledWith({
-        where: { formId: 'form-123', deletedAt: null },
-        orderBy: { submittedAt: 'desc' },
-      });
+      await expect(
+        automationsResolvers.Mutation.testAutomation({}, { id: 'automation-123' }, mockContext)
+      ).rejects.toThrow(/Access denied/);
+      expect(automationService.testAutomation).not.toHaveBeenCalled();
     });
 
-    it('errors when the form has no responses', async () => {
+    it('testAutomation: surfaces a RESPONSE_NOT_FOUND-style error from the service', async () => {
       grantAccess('EDITOR');
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(mockAutomation as any);
-      vi.mocked(prisma.response.findFirst).mockResolvedValue(null);
+      vi.mocked(automationService.getAutomationById).mockResolvedValue(mockAutomation as any);
+      vi.mocked(automationService.testAutomation).mockRejectedValue(
+        new GraphQLError('No response available to test this automation with')
+      );
 
       await expect(
         automationsResolvers.Mutation.testAutomation({}, { id: 'automation-123' }, mockContext)
       ).rejects.toThrow(/No response available/);
-      expect(prisma.automationRun.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('automationRuns / automationRun queries', () => {
+    it('automationRuns: fetches the automation for access, then lists runs via the service', async () => {
+      grantAccess('VIEWER');
+      vi.mocked(automationService.getAutomationById).mockResolvedValue(mockAutomation as any);
+      const runs = [{ id: 'run-1' }];
+      vi.mocked(automationService.listAutomationRuns).mockResolvedValue(runs as any);
+
+      const result = await automationsResolvers.Query.automationRuns(
+        {},
+        { automationId: 'automation-123', limit: 10, offset: 5 },
+        mockContext
+      );
+
+      expect(automationService.listAutomationRuns).toHaveBeenCalledWith('automation-123', 10, 5);
+      expect(result).toEqual(runs);
+    });
+
+    it('automationRun: fetches the run with its automation, checks access, and returns it', async () => {
+      grantAccess('VIEWER');
+      const run = { id: 'run-1', automation: mockAutomation };
+      vi.mocked(automationService.getAutomationRunWithAutomation).mockResolvedValue(run as any);
+
+      const result = await automationsResolvers.Query.automationRun(
+        {},
+        { id: 'run-1' },
+        mockContext
+      );
+
+      expect(automationService.getAutomationRunWithAutomation).toHaveBeenCalledWith('run-1');
+      expect(result).toEqual(run);
+    });
+
+    it('automationRun: propagates a NOT_FOUND-style error from the service', async () => {
+      vi.mocked(automationService.getAutomationRunWithAutomation).mockRejectedValue(
+        new GraphQLError('Automation run not found')
+      );
+
+      await expect(
+        automationsResolvers.Query.automationRun({}, { id: 'missing' }, mockContext)
+      ).rejects.toThrow('Automation run not found');
     });
   });
 
@@ -836,9 +378,9 @@ describe('Automations Resolvers', () => {
     it('cancels a running run', async () => {
       grantAccess('EDITOR');
       const run = { id: 'run-1', automation: mockAutomation };
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(run as any);
+      vi.mocked(automationService.getAutomationRunWithAutomation).mockResolvedValue(run as any);
       const cancelled = { id: 'run-1', status: 'CANCELLED' };
-      vi.mocked(triggerService.cancelSingleAutomationRun).mockResolvedValue(cancelled as any);
+      vi.mocked(automationService.cancelAutomationRun).mockResolvedValue(cancelled as any);
 
       const result = await automationsResolvers.Mutation.cancelAutomationRun(
         {},
@@ -846,30 +388,40 @@ describe('Automations Resolvers', () => {
         mockContext
       );
 
-      expect(triggerService.cancelSingleAutomationRun).toHaveBeenCalledWith('run-1');
+      expect(automationService.cancelAutomationRun).toHaveBeenCalledWith('run-1');
       expect(result).toEqual(cancelled);
     });
 
     it('throws when the run does not exist', async () => {
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(null);
+      vi.mocked(automationService.getAutomationRunWithAutomation).mockRejectedValue(
+        new GraphQLError('Automation run not found')
+      );
 
       await expect(
         automationsResolvers.Mutation.cancelAutomationRun({}, { runId: 'missing' }, mockContext)
       ).rejects.toThrow('Automation run not found');
     });
+
+    it('denies without EDITOR+ access', async () => {
+      denyAccess();
+      const run = { id: 'run-1', automation: mockAutomation };
+      vi.mocked(automationService.getAutomationRunWithAutomation).mockResolvedValue(run as any);
+
+      await expect(
+        automationsResolvers.Mutation.cancelAutomationRun({}, { runId: 'run-1' }, mockContext)
+      ).rejects.toThrow(/Access denied/);
+      expect(automationService.cancelAutomationRun).not.toHaveBeenCalled();
+    });
   });
 
   describe('Field resolvers', () => {
-    it('AutomationRun.stepRuns fetches step runs for the parent run', async () => {
+    it('AutomationRun.stepRuns fetches step runs for the parent run via the service', async () => {
       const stepRuns = [{ id: 'step-1', nodeId: 'trigger-1' }];
-      vi.mocked(prisma.automationStepRun.findMany).mockResolvedValue(stepRuns as any);
+      vi.mocked(automationService.listStepRuns).mockResolvedValue(stepRuns as any);
 
       const result = await automationsResolvers.AutomationRun.stepRuns({ id: 'run-1' } as any);
 
-      expect(prisma.automationStepRun.findMany).toHaveBeenCalledWith({
-        where: { runId: 'run-1' },
-        orderBy: { startedAt: 'asc' },
-      });
+      expect(automationService.listStepRuns).toHaveBeenCalledWith('run-1');
       expect(result).toEqual(stepRuns);
     });
 

--- a/apps/backend/src/graphql/resolvers/automations.ts
+++ b/apps/backend/src/graphql/resolvers/automations.ts
@@ -1,30 +1,17 @@
 import { createGraphQLError } from '#graphql-errors';
 import { GRAPHQL_ERROR_CODES } from '@dculus/types/graphql.js';
-import { generateId } from '@dculus/utils';
-import { prisma } from '../../lib/prisma.js';
 import { BetterAuthContext, requireAuth, requireOrganizationMembership } from '../../middleware/better-auth-middleware.js';
 import { checkFormAccess, PermissionLevel } from './formSharing.js';
-import { getAvailablePluginTypes } from '../../plugins/core/registry.js';
-import { validateAutomationGraph } from '../../services/automation/graphValidator.js';
-import { enqueueFirstStep } from '../../services/automation/engine.js';
-import {
-  cancelRunsForAutomation,
-  cancelSingleAutomationRun,
-  scheduleAutomationCron,
-  unscheduleAutomationCron,
-} from '../../services/automation/triggerService.js';
-import { isValidCronExpression, isValidTimezone } from '../../services/automation/cronValidator.js';
-import type { AutomationGraph, AutomationRunContext } from '../../services/automation/types.js';
+import * as automationService from '../../services/automationService.js';
 
 /**
  * GraphQL Resolvers for the Automations system (#195)
  * Follows apps/backend/src/graphql/resolvers/plugins.ts conventions.
+ * Business logic (graph/cron validation, version bumping, run creation) lives in
+ * automationService.ts — this resolver only orchestrates auth and calls the service.
  */
 
 type Permission = (typeof PermissionLevel)[keyof typeof PermissionLevel];
-
-const AUTOMATION_STATUSES = ['DRAFT', 'ACTIVE', 'PAUSED'] as const;
-const TRIGGER_TYPES = ['form.submitted', 'response.edited', 'schedule'] as const;
 
 const toISOString = (value: Date | string | null | undefined): string | null => {
   if (!value) return null;
@@ -55,53 +42,6 @@ async function assertFormAccess(
   return accessCheck;
 }
 
-/**
- * Validates `triggerConfig` for a `schedule`-triggerType automation on save/activate (#201) —
- * cron is required, must parse as a standard 5-field expression, and an optional timezone must
- * be a real IANA identifier.
- */
-function assertValidScheduleTriggerConfig(triggerConfig: any): asserts triggerConfig is { cron: string; timezone?: string } {
-  if (!triggerConfig || typeof triggerConfig !== 'object') {
-    throw createGraphQLError(
-      'Scheduled automations require a triggerConfig with a cron expression',
-      GRAPHQL_ERROR_CODES.BAD_USER_INPUT
-    );
-  }
-  if (!isValidCronExpression(triggerConfig.cron)) {
-    throw createGraphQLError(
-      `Invalid cron expression: ${triggerConfig.cron}`,
-      GRAPHQL_ERROR_CODES.BAD_USER_INPUT
-    );
-  }
-  if (triggerConfig.timezone !== undefined && !isValidTimezone(triggerConfig.timezone)) {
-    throw createGraphQLError(
-      `Invalid timezone: ${triggerConfig.timezone}`,
-      GRAPHQL_ERROR_CODES.BAD_USER_INPUT
-    );
-  }
-}
-
-async function getAutomationOrThrow(id: string) {
-  const automation = await prisma.automation.findUnique({ where: { id } });
-  if (!automation) {
-    throw createGraphQLError('Automation not found', GRAPHQL_ERROR_CODES.AUTOMATION_NOT_FOUND);
-  }
-  return automation;
-}
-
-/** DRAFT default graph for a brand-new automation: a single trigger wired to a single end. */
-function buildDefaultGraph(triggerType: string): AutomationGraph {
-  const triggerId = generateId();
-  const endId = generateId();
-  return {
-    nodes: [
-      { id: triggerId, type: 'trigger', data: { triggerType } },
-      { id: endId, type: 'end' },
-    ],
-    edges: [{ id: generateId(), source: triggerId, target: endId }],
-  };
-}
-
 export const automationsResolvers = {
   Query: {
     formAutomations: async (
@@ -116,10 +56,7 @@ export const automationsResolvers = {
         'Access denied: You do not have permission to view automations for this form'
       );
 
-      return prisma.automation.findMany({
-        where: { formId },
-        orderBy: { createdAt: 'desc' },
-      });
+      return automationService.listAutomationsByForm(formId);
     },
 
     automation: async (
@@ -128,7 +65,7 @@ export const automationsResolvers = {
       context: { auth: BetterAuthContext }
     ) => {
       requireAuth(context.auth);
-      const automation = await getAutomationOrThrow(id);
+      const automation = await automationService.getAutomationById(id);
       await assertFormAccess(
         context,
         automation.formId,
@@ -144,7 +81,7 @@ export const automationsResolvers = {
       context: { auth: BetterAuthContext }
     ) => {
       requireAuth(context.auth);
-      const automation = await getAutomationOrThrow(automationId);
+      const automation = await automationService.getAutomationById(automationId);
       await assertFormAccess(
         context,
         automation.formId,
@@ -152,12 +89,7 @@ export const automationsResolvers = {
         'Access denied: You do not have permission to view runs for this automation'
       );
 
-      return prisma.automationRun.findMany({
-        where: { automationId },
-        orderBy: { startedAt: 'desc' },
-        take: limit ?? 50,
-        skip: offset ?? 0,
-      });
+      return automationService.listAutomationRuns(automationId, limit, offset);
     },
 
     automationRun: async (
@@ -166,13 +98,7 @@ export const automationsResolvers = {
       context: { auth: BetterAuthContext }
     ) => {
       requireAuth(context.auth);
-      const run = await prisma.automationRun.findUnique({
-        where: { id },
-        include: { automation: true },
-      });
-      if (!run) {
-        throw createGraphQLError('Automation run not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
-      }
+      const run = await automationService.getAutomationRunWithAutomation(id);
 
       await assertFormAccess(
         context,
@@ -198,28 +124,12 @@ export const automationsResolvers = {
         'Access denied: You need EDITOR access to create automations for this form'
       );
 
-      if (!name || name.trim().length === 0) {
-        throw createGraphQLError('Automation name is required', GRAPHQL_ERROR_CODES.BAD_USER_INPUT);
-      }
-      if (!TRIGGER_TYPES.includes(triggerType as (typeof TRIGGER_TYPES)[number])) {
-        throw createGraphQLError(
-          `Invalid trigger type: ${triggerType}. Supported types: ${TRIGGER_TYPES.join(', ')}`,
-          GRAPHQL_ERROR_CODES.BAD_USER_INPUT
-        );
-      }
-
-      return prisma.automation.create({
-        data: {
-          id: generateId(),
-          formId,
-          organizationId: accessCheck.form.organizationId,
-          name,
-          status: 'DRAFT',
-          triggerType,
-          graph: buildDefaultGraph(triggerType) as any,
-          version: 1,
-          createdBy: context.auth.user!.id,
-        },
+      return automationService.createAutomation({
+        formId,
+        organizationId: accessCheck.form.organizationId,
+        name,
+        triggerType,
+        createdBy: context.auth.user!.id,
       });
     },
 
@@ -234,7 +144,7 @@ export const automationsResolvers = {
       context: { auth: BetterAuthContext }
     ) => {
       requireAuth(context.auth);
-      const automation = await getAutomationOrThrow(id);
+      const automation = await automationService.getAutomationById(id);
       await assertFormAccess(
         context,
         automation.formId,
@@ -242,49 +152,7 @@ export const automationsResolvers = {
         'Access denied: You need EDITOR access to update this automation'
       );
 
-      const data: Record<string, any> = { updatedAt: new Date() };
-      if (name !== undefined) data.name = name;
-      if (triggerConfig !== undefined) {
-        if (automation.triggerType === 'schedule') {
-          assertValidScheduleTriggerConfig(triggerConfig);
-        }
-        data.triggerConfig = triggerConfig;
-      }
-      if (graph !== undefined) {
-        // An ACTIVE automation is already live — saving a new graph here must be held to the
-        // same bar as activation, or a schedule automation's response-dependent-node ban (and
-        // any other activation-time rule) could be bypassed by editing an already-active
-        // automation instead of pausing/reactivating it.
-        if (automation.status === 'ACTIVE') {
-          const result = validateAutomationGraph(graph, {
-            pluginTypes: getAvailablePluginTypes(),
-            triggerType: automation.triggerType,
-          });
-          if (!result.valid) {
-            throw createGraphQLError(
-              'Automation graph is invalid and cannot be saved while this automation is active',
-              GRAPHQL_ERROR_CODES.AUTOMATION_INVALID_GRAPH,
-              { extensions: { validationErrors: result.errors } }
-            );
-          }
-        }
-
-        data.graph = graph;
-        const graphChanged = JSON.stringify(graph) !== JSON.stringify(automation.graph);
-        if (graphChanged) {
-          data.version = { increment: 1 };
-        }
-      }
-
-      const updated = await prisma.automation.update({ where: { id }, data });
-
-      // Re-schedule immediately so an ACTIVE scheduled automation picks up a new cron/timezone
-      // without requiring pause+reactivate — boss.schedule upserts by (queue, key).
-      if (automation.triggerType === 'schedule' && triggerConfig !== undefined && updated.status === 'ACTIVE') {
-        await scheduleAutomationCron(updated.id, triggerConfig.cron, triggerConfig.timezone);
-      }
-
-      return updated;
+      return automationService.updateAutomation(automation, { name, graph, triggerConfig });
     },
 
     setAutomationStatus: async (
@@ -293,7 +161,7 @@ export const automationsResolvers = {
       context: { auth: BetterAuthContext }
     ) => {
       requireAuth(context.auth);
-      const automation = await getAutomationOrThrow(id);
+      const automation = await automationService.getAutomationById(id);
       await assertFormAccess(
         context,
         automation.formId,
@@ -301,47 +169,7 @@ export const automationsResolvers = {
         'Access denied: You need EDITOR access to change this automation status'
       );
 
-      if (!AUTOMATION_STATUSES.includes(status as (typeof AUTOMATION_STATUSES)[number])) {
-        throw createGraphQLError(
-          `Invalid status: ${status}. Supported statuses: ${AUTOMATION_STATUSES.join(', ')}`,
-          GRAPHQL_ERROR_CODES.BAD_USER_INPUT
-        );
-      }
-
-      if (status === 'ACTIVE') {
-        const result = validateAutomationGraph(automation.graph, {
-          pluginTypes: getAvailablePluginTypes(),
-          triggerType: automation.triggerType,
-        });
-        if (!result.valid) {
-          throw createGraphQLError(
-            'Automation graph is invalid and cannot be activated',
-            GRAPHQL_ERROR_CODES.AUTOMATION_INVALID_GRAPH,
-            { extensions: { validationErrors: result.errors } }
-          );
-        }
-        if (automation.triggerType === 'schedule') {
-          assertValidScheduleTriggerConfig(automation.triggerConfig);
-        }
-      }
-
-      const updated = await prisma.automation.update({
-        where: { id },
-        data: { status, updatedAt: new Date() },
-      });
-
-      // Schedule/unschedule lifecycle (#201) — boss.schedule upserts, boss.unschedule is a
-      // no-op if nothing is scheduled, so this is safe regardless of prior state.
-      if (automation.triggerType === 'schedule') {
-        if (status === 'ACTIVE') {
-          const { cron, timezone } = automation.triggerConfig as { cron: string; timezone?: string };
-          await scheduleAutomationCron(automation.id, cron, timezone);
-        } else {
-          await unscheduleAutomationCron(automation.id);
-        }
-      }
-
-      return updated;
+      return automationService.setAutomationStatus(automation, status);
     },
 
     deleteAutomation: async (
@@ -350,7 +178,7 @@ export const automationsResolvers = {
       context: { auth: BetterAuthContext }
     ) => {
       requireAuth(context.auth);
-      const automation = await getAutomationOrThrow(id);
+      const automation = await automationService.getAutomationById(id);
       await assertFormAccess(
         context,
         automation.formId,
@@ -358,13 +186,7 @@ export const automationsResolvers = {
         'Access denied: You need EDITOR access to delete this automation'
       );
 
-      if (automation.triggerType === 'schedule') {
-        await unscheduleAutomationCron(id);
-      }
-      await cancelRunsForAutomation(id, 'automation deleted');
-      await prisma.automation.delete({ where: { id } });
-
-      return true;
+      return automationService.deleteAutomation(automation);
     },
 
     testAutomation: async (
@@ -373,7 +195,7 @@ export const automationsResolvers = {
       context: { auth: BetterAuthContext }
     ) => {
       requireAuth(context.auth);
-      const automation = await getAutomationOrThrow(id);
+      const automation = await automationService.getAutomationById(id);
       await assertFormAccess(
         context,
         automation.formId,
@@ -381,47 +203,7 @@ export const automationsResolvers = {
         'Access denied: You need EDITOR access to test this automation'
       );
 
-      const response = responseId
-        ? await prisma.response.findFirst({
-            where: { id: responseId, formId: automation.formId, deletedAt: null },
-          })
-        : await prisma.response.findFirst({
-            where: { formId: automation.formId, deletedAt: null },
-            orderBy: { submittedAt: 'desc' },
-          });
-
-      if (!response) {
-        throw createGraphQLError(
-          'No response available to test this automation with',
-          GRAPHQL_ERROR_CODES.RESPONSE_NOT_FOUND
-        );
-      }
-
-      const context_: AutomationRunContext = {
-        test: true,
-        triggerData: {
-          ...(response.data as Record<string, any>),
-          responseId: response.id,
-          submittedAt: response.submittedAt.toISOString(),
-          isPreview: false,
-        },
-      };
-
-      const run = await prisma.automationRun.create({
-        data: {
-          id: generateId(),
-          automationId: automation.id,
-          responseId: response.id,
-          automationVersion: automation.version,
-          graphSnapshot: automation.graph as any,
-          status: 'RUNNING',
-          context: context_ as any,
-        },
-      });
-
-      await enqueueFirstStep(run);
-
-      return run;
+      return automationService.testAutomation(automation, responseId);
     },
 
     cancelAutomationRun: async (
@@ -430,13 +212,7 @@ export const automationsResolvers = {
       context: { auth: BetterAuthContext }
     ) => {
       requireAuth(context.auth);
-      const run = await prisma.automationRun.findUnique({
-        where: { id: runId },
-        include: { automation: true },
-      });
-      if (!run) {
-        throw createGraphQLError('Automation run not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
-      }
+      const run = await automationService.getAutomationRunWithAutomation(runId);
 
       await assertFormAccess(
         context,
@@ -445,11 +221,7 @@ export const automationsResolvers = {
         'Access denied: You need EDITOR access to cancel this automation run'
       );
 
-      const cancelled = await cancelSingleAutomationRun(runId);
-      if (!cancelled) {
-        throw createGraphQLError('Automation run not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
-      }
-      return cancelled;
+      return automationService.cancelAutomationRun(runId);
     },
   },
 
@@ -461,11 +233,7 @@ export const automationsResolvers = {
   AutomationRun: {
     startedAt: (parent: { startedAt: Date | string }) => toISOString(parent.startedAt),
     completedAt: (parent: { completedAt: Date | string | null }) => toISOString(parent.completedAt),
-    stepRuns: async (parent: { id: string }) =>
-      prisma.automationStepRun.findMany({
-        where: { runId: parent.id },
-        orderBy: { startedAt: 'asc' },
-      }),
+    stepRuns: async (parent: { id: string }) => automationService.listStepRuns(parent.id),
   },
 
   AutomationStepRun: {

--- a/apps/backend/src/repositories/__tests__/automationRepository.test.ts
+++ b/apps/backend/src/repositories/__tests__/automationRepository.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createAutomationRepository } from '../automationRepository.js';
+
+const prismaMock = vi.hoisted(() => ({
+  automation: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    count: vi.fn().mockResolvedValue(0),
+  },
+  automationRun: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+  },
+  automationStepRun: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+  },
+  $executeRaw: vi.fn().mockResolvedValue(1),
+}));
+
+vi.mock('../baseRepository.js', () => ({
+  resolvePrisma: () => prismaMock,
+}));
+
+vi.mock('#prisma-client', () => ({
+  Prisma: {
+    sql: (strings: TemplateStringsArray, ...values: any[]) => ({ strings, values }),
+    raw: (value: string) => ({ raw: value }),
+  },
+}));
+
+describe('automationRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.automation.findMany.mockResolvedValue([]);
+    prismaMock.automation.findUnique.mockResolvedValue(null);
+    prismaMock.automation.create.mockResolvedValue({});
+    prismaMock.automation.update.mockResolvedValue({});
+    prismaMock.automation.delete.mockResolvedValue({});
+    prismaMock.automation.count.mockResolvedValue(0);
+    prismaMock.automationRun.findMany.mockResolvedValue([]);
+    prismaMock.automationRun.findUnique.mockResolvedValue(null);
+    prismaMock.automationRun.create.mockResolvedValue({});
+    prismaMock.automationRun.update.mockResolvedValue({});
+    prismaMock.automationRun.updateMany.mockResolvedValue({ count: 0 });
+    prismaMock.automationStepRun.findMany.mockResolvedValue([]);
+    prismaMock.automationStepRun.findFirst.mockResolvedValue(null);
+    prismaMock.automationStepRun.create.mockResolvedValue({});
+    prismaMock.$executeRaw.mockResolvedValue(1);
+  });
+
+  it('proxies basic prisma delegate methods for Automation', async () => {
+    const repo = createAutomationRepository();
+    const args = { where: { id: 'automation-1' } };
+    await repo.findMany(args);
+    await repo.findUnique(args as any);
+    await repo.create({ data: { id: 'automation-1' } } as any);
+    await repo.update({ where: { id: 'automation-1' }, data: { name: 'New' } } as any);
+    await repo.delete({ where: { id: 'automation-1' } } as any);
+    await repo.count(args as any);
+
+    expect(prismaMock.automation.findMany).toHaveBeenCalledWith(args);
+    expect(prismaMock.automation.findUnique).toHaveBeenCalledWith(args);
+    expect(prismaMock.automation.create).toHaveBeenCalled();
+    expect(prismaMock.automation.update).toHaveBeenCalled();
+    expect(prismaMock.automation.delete).toHaveBeenCalled();
+    expect(prismaMock.automation.count).toHaveBeenCalledWith(args);
+  });
+
+  describe('Automation domain helpers', () => {
+    it('findById looks up by id only', async () => {
+      const repo = createAutomationRepository();
+      await repo.findById('automation-1');
+      expect(prismaMock.automation.findUnique).toHaveBeenCalledWith({ where: { id: 'automation-1' } });
+    });
+
+    it('listByFormId orders by createdAt desc', async () => {
+      const repo = createAutomationRepository();
+      await repo.listByFormId('form-1');
+      expect(prismaMock.automation.findMany).toHaveBeenCalledWith({
+        where: { formId: 'form-1' },
+        orderBy: { createdAt: 'desc' },
+      });
+    });
+
+    it('listActiveByFormAndTrigger scopes to ACTIVE + triggerType', async () => {
+      const repo = createAutomationRepository();
+      await repo.listActiveByFormAndTrigger('form-1', 'form.submitted');
+      expect(prismaMock.automation.findMany).toHaveBeenCalledWith({
+        where: { formId: 'form-1', status: 'ACTIVE', triggerType: 'form.submitted' },
+      });
+    });
+
+    it('createAutomation / updateAutomation / deleteAutomation delegate correctly', async () => {
+      const repo = createAutomationRepository();
+      await repo.createAutomation({ id: 'automation-1' } as any);
+      await repo.updateAutomation('automation-1', { name: 'Renamed' } as any);
+      await repo.deleteAutomation('automation-1');
+
+      expect(prismaMock.automation.create).toHaveBeenCalledWith({ data: { id: 'automation-1' } });
+      expect(prismaMock.automation.update).toHaveBeenCalledWith({
+        where: { id: 'automation-1' },
+        data: { name: 'Renamed' },
+      });
+      expect(prismaMock.automation.delete).toHaveBeenCalledWith({ where: { id: 'automation-1' } });
+    });
+  });
+
+  describe('AutomationRun domain helpers', () => {
+    it('findRunById looks up by id only', async () => {
+      const repo = createAutomationRepository();
+      await repo.findRunById('run-1');
+      expect(prismaMock.automationRun.findUnique).toHaveBeenCalledWith({ where: { id: 'run-1' } });
+    });
+
+    it('findRunByIdWithAutomation includes the automation relation', async () => {
+      const repo = createAutomationRepository();
+      await repo.findRunByIdWithAutomation('run-1');
+      expect(prismaMock.automationRun.findUnique).toHaveBeenCalledWith({
+        where: { id: 'run-1' },
+        include: { automation: true },
+      });
+    });
+
+    it('listRunsByAutomation defaults limit/offset and orders by startedAt desc', async () => {
+      const repo = createAutomationRepository();
+      await repo.listRunsByAutomation('automation-1');
+      expect(prismaMock.automationRun.findMany).toHaveBeenCalledWith({
+        where: { automationId: 'automation-1' },
+        orderBy: { startedAt: 'desc' },
+        take: 50,
+        skip: 0,
+      });
+
+      await repo.listRunsByAutomation('automation-1', { limit: 10, offset: 5 });
+      expect(prismaMock.automationRun.findMany).toHaveBeenCalledWith({
+        where: { automationId: 'automation-1' },
+        orderBy: { startedAt: 'desc' },
+        take: 10,
+        skip: 5,
+      });
+    });
+
+    it('listActiveRunsByAutomation scopes to RUNNING/WAITING and selects only id', async () => {
+      const repo = createAutomationRepository();
+      await repo.listActiveRunsByAutomation('automation-1');
+      expect(prismaMock.automationRun.findMany).toHaveBeenCalledWith({
+        where: { automationId: 'automation-1', status: { in: ['RUNNING', 'WAITING'] } },
+        select: { id: true },
+      });
+    });
+
+    it('createRun / updateRun delegate correctly', async () => {
+      const repo = createAutomationRepository();
+      await repo.createRun({ id: 'run-1' } as any);
+      await repo.updateRun('run-1', { status: 'COMPLETED' } as any);
+
+      expect(prismaMock.automationRun.create).toHaveBeenCalledWith({ data: { id: 'run-1' } });
+      expect(prismaMock.automationRun.update).toHaveBeenCalledWith({
+        where: { id: 'run-1' },
+        data: { status: 'COMPLETED' },
+      });
+    });
+
+    it('cancelRunsByIds marks the given ids CANCELLED unconditionally', async () => {
+      const repo = createAutomationRepository();
+      await repo.cancelRunsByIds(['run-1', 'run-2']);
+      expect(prismaMock.automationRun.updateMany).toHaveBeenCalledWith({
+        where: { id: { in: ['run-1', 'run-2'] } },
+        data: { status: 'CANCELLED', completedAt: expect.any(Date) },
+      });
+    });
+
+    it('cancelRunIfActive scopes the update to RUNNING/WAITING only', async () => {
+      const repo = createAutomationRepository();
+      await repo.cancelRunIfActive('run-1');
+      expect(prismaMock.automationRun.updateMany).toHaveBeenCalledWith({
+        where: { id: 'run-1', status: { in: ['RUNNING', 'WAITING'] } },
+        data: { status: 'CANCELLED', completedAt: expect.any(Date) },
+      });
+    });
+  });
+
+  describe('AutomationStepRun domain helpers', () => {
+    it('listStepRunsByRun orders by startedAt asc', async () => {
+      const repo = createAutomationRepository();
+      await repo.listStepRunsByRun('run-1');
+      expect(prismaMock.automationStepRun.findMany).toHaveBeenCalledWith({
+        where: { runId: 'run-1' },
+        orderBy: { startedAt: 'asc' },
+      });
+    });
+
+    it('createStepRun delegates correctly', async () => {
+      const repo = createAutomationRepository();
+      await repo.createStepRun({ id: 'step-1' } as any);
+      expect(prismaMock.automationStepRun.create).toHaveBeenCalledWith({ data: { id: 'step-1' } });
+    });
+
+    it('findSuccessStepRun scopes to SUCCESS status', async () => {
+      const repo = createAutomationRepository();
+      await repo.findSuccessStepRun('run-1', 'node-1');
+      expect(prismaMock.automationStepRun.findFirst).toHaveBeenCalledWith({
+        where: { runId: 'run-1', nodeId: 'node-1', status: 'SUCCESS' },
+      });
+    });
+
+    it('findStepRunByNode has no status filter', async () => {
+      const repo = createAutomationRepository();
+      await repo.findStepRunByNode('run-1', 'node-1');
+      expect(prismaMock.automationStepRun.findFirst).toHaveBeenCalledWith({
+        where: { runId: 'run-1', nodeId: 'node-1' },
+      });
+    });
+  });
+
+  describe('node config raw writes', () => {
+    it('setNodeConfigInGraph issues a single $executeRaw scoped to the automation id', async () => {
+      const repo = createAutomationRepository();
+      await repo.setNodeConfigInGraph('automation-1', 'node-1', { type: 'webhook' });
+
+      expect(prismaMock.$executeRaw).toHaveBeenCalledTimes(1);
+      const sqlArg = prismaMock.$executeRaw.mock.calls[0][0] as { strings: TemplateStringsArray; values: any[] };
+      expect(sqlArg.strings.join('')).toContain('UPDATE');
+      expect(sqlArg.strings.join('')).toContain('jsonb_set');
+      expect(sqlArg.values).toContain('node-1');
+      expect(sqlArg.values).toContain('automation-1');
+      expect(sqlArg.values).toContain(JSON.stringify({ type: 'webhook' }));
+    });
+
+    it('setNodeConfigInRunSnapshot issues a single $executeRaw scoped to the run id', async () => {
+      const repo = createAutomationRepository();
+      await repo.setNodeConfigInRunSnapshot('run-1', 'node-1', { type: 'webhook' });
+
+      expect(prismaMock.$executeRaw).toHaveBeenCalledTimes(1);
+      const sqlArg = prismaMock.$executeRaw.mock.calls[0][0] as { strings: TemplateStringsArray; values: any[] };
+      expect(sqlArg.values).toContain('node-1');
+      expect(sqlArg.values).toContain('run-1');
+      expect(sqlArg.values).toContain(JSON.stringify({ type: 'webhook' }));
+    });
+  });
+});

--- a/apps/backend/src/repositories/automationRepository.ts
+++ b/apps/backend/src/repositories/automationRepository.ts
@@ -1,0 +1,218 @@
+import { Prisma } from '#prisma-client';
+import { resolvePrisma, type RepositoryContext } from './baseRepository.js';
+
+const ACTIVE_RUN_STATUSES = ['RUNNING', 'WAITING'] as const;
+
+/**
+ * Factory for Automation / AutomationRun / AutomationStepRun data access.
+ * Covers both the CRUD side (automations.ts resolver) and the execution-hot-path
+ * side (services/automation/engine.ts, triggerService.ts).
+ */
+export const createAutomationRepository = (context?: RepositoryContext) => {
+  const prisma = resolvePrisma(context);
+
+  /** --- Generic delegate passthroughs (Automation) --- */
+  const findMany = <T extends Prisma.AutomationFindManyArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.AutomationFindManyArgs>
+  ) => prisma.automation.findMany(args);
+
+  const findUnique = <T extends Prisma.AutomationFindUniqueArgs>(
+    args: Prisma.SelectSubset<T, Prisma.AutomationFindUniqueArgs>
+  ) => prisma.automation.findUnique(args);
+
+  const create = <T extends Prisma.AutomationCreateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.AutomationCreateArgs>
+  ) => prisma.automation.create(args);
+
+  const update = <T extends Prisma.AutomationUpdateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.AutomationUpdateArgs>
+  ) => prisma.automation.update(args);
+
+  const remove = <T extends Prisma.AutomationDeleteArgs>(
+    args: Prisma.SelectSubset<T, Prisma.AutomationDeleteArgs>
+  ) => prisma.automation.delete(args);
+
+  const count = <T extends Prisma.AutomationCountArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.AutomationCountArgs>
+  ) => prisma.automation.count(args);
+
+  /** --- Domain helpers: Automation --- */
+  const findById = async (id: string) => prisma.automation.findUnique({ where: { id } });
+
+  const listByFormId = async (formId: string) =>
+    prisma.automation.findMany({
+      where: { formId },
+      orderBy: { createdAt: 'desc' },
+    });
+
+  const listActiveByFormAndTrigger = async (formId: string, triggerType: string) =>
+    prisma.automation.findMany({
+      where: { formId, status: 'ACTIVE', triggerType },
+    });
+
+  const createAutomation = async (data: Prisma.AutomationCreateArgs['data']) =>
+    prisma.automation.create({ data });
+
+  const updateAutomation = async (id: string, data: Prisma.AutomationUpdateArgs['data']) =>
+    prisma.automation.update({ where: { id }, data });
+
+  const deleteAutomation = async (id: string) => prisma.automation.delete({ where: { id } });
+
+  /** --- Domain helpers: AutomationRun --- */
+  const findRunById = async (id: string) => prisma.automationRun.findUnique({ where: { id } });
+
+  const findRunByIdWithAutomation = async (id: string) =>
+    prisma.automationRun.findUnique({ where: { id }, include: { automation: true } });
+
+  const listRunsByAutomation = async (
+    automationId: string,
+    { limit, offset }: { limit?: number; offset?: number } = {}
+  ) =>
+    prisma.automationRun.findMany({
+      where: { automationId },
+      orderBy: { startedAt: 'desc' },
+      take: limit ?? 50,
+      skip: offset ?? 0,
+    });
+
+  /** Ids of runs still able to be cancelled (RUNNING/WAITING) for a given automation. */
+  const listActiveRunsByAutomation = async (automationId: string) =>
+    prisma.automationRun.findMany({
+      where: { automationId, status: { in: [...ACTIVE_RUN_STATUSES] } },
+      select: { id: true },
+    });
+
+  const createRun = async (data: Prisma.AutomationRunCreateArgs['data']) =>
+    prisma.automationRun.create({ data });
+
+  const updateRun = async (id: string, data: Prisma.AutomationRunUpdateArgs['data']) =>
+    prisma.automationRun.update({ where: { id }, data });
+
+  /** Marks the given run ids CANCELLED unconditionally (caller has already snapshotted them). */
+  const cancelRunsByIds = async (ids: string[]) =>
+    prisma.automationRun.updateMany({
+      where: { id: { in: ids } },
+      data: { status: 'CANCELLED', completedAt: new Date() },
+    });
+
+  /**
+   * Marks a single run CANCELLED only if it is still RUNNING/WAITING — a TOCTOU-safe guard
+   * against a run reaching a terminal state concurrently. Returns the number of rows matched.
+   */
+  const cancelRunIfActive = async (id: string) =>
+    prisma.automationRun.updateMany({
+      where: { id, status: { in: [...ACTIVE_RUN_STATUSES] } },
+      data: { status: 'CANCELLED', completedAt: new Date() },
+    });
+
+  /** --- Domain helpers: AutomationStepRun --- */
+  const listStepRunsByRun = async (runId: string) =>
+    prisma.automationStepRun.findMany({
+      where: { runId },
+      orderBy: { startedAt: 'asc' },
+    });
+
+  const createStepRun = async (data: Prisma.AutomationStepRunCreateArgs['data']) =>
+    prisma.automationStepRun.create({ data });
+
+  const findSuccessStepRun = async (runId: string, nodeId: string) =>
+    prisma.automationStepRun.findFirst({ where: { runId, nodeId, status: 'SUCCESS' } });
+
+  const findStepRunByNode = async (runId: string, nodeId: string) =>
+    prisma.automationStepRun.findFirst({ where: { runId, nodeId } });
+
+  /**
+   * Atomically replaces one node's `data.config` inside a `{ nodes: [...], edges: [...] }`
+   * JSON column, leaving every other node untouched. `SET column = jsonb_set(column, ...)`
+   * re-reads the row's latest *committed* value at execution time, so concurrent writes
+   * targeting different nodes in the same graph correctly compose.
+   */
+  const setNodeConfigInGraph = async (
+    automationId: string,
+    nodeId: string,
+    config: Prisma.InputJsonValue
+  ) =>
+    prisma.$executeRaw(Prisma.sql`
+      UPDATE ${Prisma.raw('"automation"')}
+      SET ${Prisma.raw('"graph"')} = jsonb_set(
+        ${Prisma.raw('"graph"')},
+        '{nodes}',
+        (
+          SELECT COALESCE(jsonb_agg(
+            CASE WHEN elem->>'id' = ${nodeId}
+              THEN jsonb_set(elem, '{data,config}', ${JSON.stringify(config)}::jsonb, true)
+              ELSE elem
+            END
+          ), '[]'::jsonb)
+          FROM jsonb_array_elements(${Prisma.raw('"graph"')}->'nodes') AS elem
+        )
+      )
+      WHERE id = ${automationId}
+    `);
+
+  /** Same as {@link setNodeConfigInGraph}, scoped to a single run's frozen `graphSnapshot`. */
+  const setNodeConfigInRunSnapshot = async (
+    runId: string,
+    nodeId: string,
+    config: Prisma.InputJsonValue
+  ) =>
+    prisma.$executeRaw(Prisma.sql`
+      UPDATE ${Prisma.raw('"automation_run"')}
+      SET ${Prisma.raw('"graphSnapshot"')} = jsonb_set(
+        ${Prisma.raw('"graphSnapshot"')},
+        '{nodes}',
+        (
+          SELECT COALESCE(jsonb_agg(
+            CASE WHEN elem->>'id' = ${nodeId}
+              THEN jsonb_set(elem, '{data,config}', ${JSON.stringify(config)}::jsonb, true)
+              ELSE elem
+            END
+          ), '[]'::jsonb)
+          FROM jsonb_array_elements(${Prisma.raw('"graphSnapshot"')}->'nodes') AS elem
+        )
+      )
+      WHERE id = ${runId}
+    `);
+
+  return {
+    // Generic operations (Automation)
+    findMany,
+    findUnique,
+    create,
+    update,
+    delete: remove,
+    count,
+
+    // Domain helpers (Automation)
+    findById,
+    listByFormId,
+    listActiveByFormAndTrigger,
+    createAutomation,
+    updateAutomation,
+    deleteAutomation,
+
+    // Domain helpers (AutomationRun)
+    findRunById,
+    findRunByIdWithAutomation,
+    listRunsByAutomation,
+    listActiveRunsByAutomation,
+    createRun,
+    updateRun,
+    cancelRunsByIds,
+    cancelRunIfActive,
+
+    // Domain helpers (AutomationStepRun)
+    listStepRunsByRun,
+    createStepRun,
+    findSuccessStepRun,
+    findStepRunByNode,
+
+    // Transaction-participating raw writes (see engine.ts updateAutomationNodeConfig)
+    setNodeConfigInGraph,
+    setNodeConfigInRunSnapshot,
+  };
+};
+
+export type AutomationRepository = ReturnType<typeof createAutomationRepository>;
+
+export const automationRepository = createAutomationRepository();

--- a/apps/backend/src/repositories/index.ts
+++ b/apps/backend/src/repositories/index.ts
@@ -7,3 +7,4 @@ export * from './formMetadataRepository.js';
 export * from './collaborativeDocumentRepository.js';
 export * from './formViewAnalyticsRepository.js';
 export * from './formSubmissionAnalyticsRepository.js';
+export * from './automationRepository.js';

--- a/apps/backend/src/services/__tests__/automationService.test.ts
+++ b/apps/backend/src/services/__tests__/automationService.test.ts
@@ -1,0 +1,531 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GraphQLError } from '#graphql-errors';
+import {
+  getAutomationById,
+  listAutomationsByForm,
+  createAutomation,
+  updateAutomation,
+  setAutomationStatus,
+  deleteAutomation,
+  testAutomation,
+  listAutomationRuns,
+  getAutomationRunWithAutomation,
+  cancelAutomationRun,
+  listStepRuns,
+} from '../automationService.js';
+import { automationRepository, responseRepository } from '../../repositories/index.js';
+import { getAvailablePluginTypes } from '../../plugins/core/registry.js';
+import { validateAutomationGraph } from '../automation/graphValidator.js';
+import { enqueueFirstStep } from '../automation/engine.js';
+import {
+  cancelRunsForAutomation,
+  cancelSingleAutomationRun,
+  scheduleAutomationCron,
+  unscheduleAutomationCron,
+} from '../automation/triggerService.js';
+import { generateId } from '@dculus/utils';
+
+vi.mock('../../repositories/index.js');
+vi.mock('../../plugins/core/registry.js');
+vi.mock('../automation/graphValidator.js');
+vi.mock('../automation/engine.js');
+vi.mock('../automation/triggerService.js');
+vi.mock('@dculus/utils', async () => {
+  const actual = await vi.importActual<typeof import('@dculus/utils')>('@dculus/utils');
+  return { ...actual, generateId: vi.fn() };
+});
+
+describe('automationService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    let idCounter = 0;
+    vi.mocked(generateId).mockImplementation(() => `generated-${++idCounter}`);
+    vi.mocked(getAvailablePluginTypes).mockReturnValue(['webhook', 'email']);
+  });
+
+  describe('getAutomationById', () => {
+    it('returns the automation when found', async () => {
+      const automation = { id: 'automation-1', formId: 'form-1' };
+      vi.mocked(automationRepository.findById).mockResolvedValue(automation as any);
+
+      const result = await getAutomationById('automation-1');
+
+      expect(automationRepository.findById).toHaveBeenCalledWith('automation-1');
+      expect(result).toEqual(automation);
+    });
+
+    it('throws AUTOMATION_NOT_FOUND when missing', async () => {
+      vi.mocked(automationRepository.findById).mockResolvedValue(null);
+
+      await expect(getAutomationById('missing')).rejects.toThrow(GraphQLError);
+      await expect(getAutomationById('missing')).rejects.toThrow('Automation not found');
+    });
+  });
+
+  describe('listAutomationsByForm', () => {
+    it('delegates to the repository', async () => {
+      const automations = [{ id: 'automation-1' }];
+      vi.mocked(automationRepository.listByFormId).mockResolvedValue(automations as any);
+
+      const result = await listAutomationsByForm('form-1');
+
+      expect(automationRepository.listByFormId).toHaveBeenCalledWith('form-1');
+      expect(result).toEqual(automations);
+    });
+  });
+
+  describe('createAutomation', () => {
+    it('rejects an empty/whitespace name', async () => {
+      await expect(
+        createAutomation({
+          formId: 'form-1',
+          organizationId: 'org-1',
+          name: '   ',
+          triggerType: 'form.submitted',
+          createdBy: 'user-1',
+        })
+      ).rejects.toThrow('Automation name is required');
+      expect(automationRepository.createAutomation).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unsupported trigger type', async () => {
+      await expect(
+        createAutomation({
+          formId: 'form-1',
+          organizationId: 'org-1',
+          name: 'Test',
+          triggerType: 'bogus',
+          createdBy: 'user-1',
+        })
+      ).rejects.toThrow(/Invalid trigger type/);
+      expect(automationRepository.createAutomation).not.toHaveBeenCalled();
+    });
+
+    it('creates a DRAFT automation with a default trigger->end graph', async () => {
+      vi.mocked(automationRepository.createAutomation).mockResolvedValue({ id: 'automation-1' } as any);
+
+      const result = await createAutomation({
+        formId: 'form-1',
+        organizationId: 'org-1',
+        name: 'Welcome flow',
+        triggerType: 'form.submitted',
+        createdBy: 'user-1',
+      });
+
+      expect(automationRepository.createAutomation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          formId: 'form-1',
+          organizationId: 'org-1',
+          name: 'Welcome flow',
+          status: 'DRAFT',
+          triggerType: 'form.submitted',
+          version: 1,
+          createdBy: 'user-1',
+          graph: expect.objectContaining({
+            nodes: [
+              expect.objectContaining({ type: 'trigger', data: { triggerType: 'form.submitted' } }),
+              expect.objectContaining({ type: 'end' }),
+            ],
+            edges: expect.any(Array),
+          }),
+        })
+      );
+      expect(result).toEqual({ id: 'automation-1' });
+    });
+  });
+
+  describe('updateAutomation', () => {
+    const baseAutomation = {
+      id: 'automation-1',
+      status: 'DRAFT',
+      triggerType: 'form.submitted',
+      graph: { nodes: [], edges: [] },
+    };
+
+    it('updates only name, without bumping version', async () => {
+      vi.mocked(automationRepository.updateAutomation).mockResolvedValue({
+        ...baseAutomation,
+        name: 'Renamed',
+      } as any);
+
+      await updateAutomation(baseAutomation, { name: 'Renamed' });
+
+      expect(automationRepository.updateAutomation).toHaveBeenCalledWith('automation-1', {
+        updatedAt: expect.any(Date),
+        name: 'Renamed',
+      });
+    });
+
+    it('bumps version when the graph actually changes', async () => {
+      const newGraph = { nodes: [{ id: 'n1', type: 'end' }], edges: [] };
+      vi.mocked(automationRepository.updateAutomation).mockResolvedValue({
+        ...baseAutomation,
+        graph: newGraph,
+      } as any);
+
+      await updateAutomation(baseAutomation, { graph: newGraph });
+
+      expect(automationRepository.updateAutomation).toHaveBeenCalledWith('automation-1', {
+        updatedAt: expect.any(Date),
+        graph: newGraph,
+        version: { increment: 1 },
+      });
+    });
+
+    it('does not bump version when the resubmitted graph is unchanged', async () => {
+      const sameGraph = JSON.parse(JSON.stringify(baseAutomation.graph));
+      vi.mocked(automationRepository.updateAutomation).mockResolvedValue(baseAutomation as any);
+
+      await updateAutomation(baseAutomation, { graph: sameGraph });
+
+      expect(automationRepository.updateAutomation).toHaveBeenCalledWith('automation-1', {
+        updatedAt: expect.any(Date),
+        graph: sameGraph,
+      });
+    });
+
+    it('validates the graph when the automation is ACTIVE and rejects an invalid one before writing', async () => {
+      const activeAutomation = { ...baseAutomation, status: 'ACTIVE' };
+      const validationErrors = [{ nodeId: 'n1', code: 'UNKNOWN_ACTION_TYPE', message: 'bad' }];
+      vi.mocked(validateAutomationGraph).mockReturnValue({ valid: false, errors: validationErrors });
+
+      await expect(
+        updateAutomation(activeAutomation, { graph: { nodes: [], edges: [] } })
+      ).rejects.toThrow(GraphQLError);
+      expect(automationRepository.updateAutomation).not.toHaveBeenCalled();
+    });
+
+    it('allows a valid graph on an ACTIVE automation', async () => {
+      const activeAutomation = { ...baseAutomation, status: 'ACTIVE' };
+      const newGraph = { nodes: [{ id: 'n1', type: 'end' }], edges: [] };
+      vi.mocked(validateAutomationGraph).mockReturnValue({ valid: true, errors: [] });
+      vi.mocked(automationRepository.updateAutomation).mockResolvedValue({
+        ...activeAutomation,
+        graph: newGraph,
+      } as any);
+
+      await updateAutomation(activeAutomation, { graph: newGraph });
+
+      expect(automationRepository.updateAutomation).toHaveBeenCalled();
+    });
+
+    it('does not validate the graph when the automation is DRAFT', async () => {
+      vi.mocked(automationRepository.updateAutomation).mockResolvedValue(baseAutomation as any);
+
+      await updateAutomation(baseAutomation, { graph: { nodes: [], edges: [] } });
+
+      expect(validateAutomationGraph).not.toHaveBeenCalled();
+    });
+
+    it('validates triggerConfig for a schedule automation and rejects a bad cron', async () => {
+      const scheduleAutomation = { ...baseAutomation, triggerType: 'schedule' };
+
+      await expect(
+        updateAutomation(scheduleAutomation, { triggerConfig: { cron: 'nonsense' } })
+      ).rejects.toThrow(/Invalid cron expression/);
+      expect(automationRepository.updateAutomation).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid timezone for a schedule automation', async () => {
+      const scheduleAutomation = { ...baseAutomation, triggerType: 'schedule' };
+
+      await expect(
+        updateAutomation(scheduleAutomation, {
+          triggerConfig: { cron: '0 9 * * *', timezone: 'Not/AZone' },
+        })
+      ).rejects.toThrow(/Invalid timezone/);
+    });
+
+    it('does not validate triggerConfig for a non-schedule automation', async () => {
+      vi.mocked(automationRepository.updateAutomation).mockResolvedValue(baseAutomation as any);
+
+      await updateAutomation(baseAutomation, { triggerConfig: { anything: 'goes' } });
+
+      expect(automationRepository.updateAutomation).toHaveBeenCalledWith('automation-1', {
+        updatedAt: expect.any(Date),
+        triggerConfig: { anything: 'goes' },
+      });
+    });
+
+    it('re-schedules the cron when an ACTIVE schedule automation changes triggerConfig', async () => {
+      const activeSchedule = { ...baseAutomation, triggerType: 'schedule' };
+      vi.mocked(automationRepository.updateAutomation).mockResolvedValue({
+        ...activeSchedule,
+        status: 'ACTIVE',
+      } as any);
+
+      await updateAutomation(activeSchedule, {
+        triggerConfig: { cron: '0 9 * * *', timezone: 'America/Chicago' },
+      });
+
+      expect(scheduleAutomationCron).toHaveBeenCalledWith('automation-1', '0 9 * * *', 'America/Chicago');
+    });
+
+    it('does not re-schedule when the updated automation is not ACTIVE', async () => {
+      const scheduleAutomation = { ...baseAutomation, triggerType: 'schedule' };
+      vi.mocked(automationRepository.updateAutomation).mockResolvedValue({
+        ...scheduleAutomation,
+        status: 'DRAFT',
+      } as any);
+
+      await updateAutomation(scheduleAutomation, { triggerConfig: { cron: '0 9 * * *' } });
+
+      expect(scheduleAutomationCron).not.toHaveBeenCalled();
+    });
+
+    it('does not re-schedule when triggerConfig is not part of this update', async () => {
+      const activeSchedule = { ...baseAutomation, triggerType: 'schedule', status: 'ACTIVE' };
+      vi.mocked(automationRepository.updateAutomation).mockResolvedValue(activeSchedule as any);
+
+      await updateAutomation(activeSchedule, { name: 'Renamed' });
+
+      expect(scheduleAutomationCron).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setAutomationStatus', () => {
+    const automation = {
+      id: 'automation-1',
+      triggerType: 'form.submitted',
+      graph: { nodes: [], edges: [] },
+      triggerConfig: null,
+    };
+
+    it('rejects an unknown status', async () => {
+      await expect(setAutomationStatus(automation, 'BOGUS')).rejects.toThrow(/Invalid status/);
+      expect(automationRepository.updateAutomation).not.toHaveBeenCalled();
+    });
+
+    it('validates the graph before activating and blocks on failure', async () => {
+      const validationErrors = [{ nodeId: 'n1', code: 'UNKNOWN_ACTION_TYPE', message: 'bad' }];
+      vi.mocked(validateAutomationGraph).mockReturnValue({ valid: false, errors: validationErrors });
+
+      await expect(setAutomationStatus(automation, 'ACTIVE')).rejects.toThrow(GraphQLError);
+      expect(automationRepository.updateAutomation).not.toHaveBeenCalled();
+    });
+
+    it('activates when the graph is valid (non-schedule automation touches no scheduling calls)', async () => {
+      vi.mocked(validateAutomationGraph).mockReturnValue({ valid: true, errors: [] });
+      vi.mocked(automationRepository.updateAutomation).mockResolvedValue({
+        ...automation,
+        status: 'ACTIVE',
+      } as any);
+
+      const result = await setAutomationStatus(automation, 'ACTIVE');
+
+      expect(automationRepository.updateAutomation).toHaveBeenCalledWith('automation-1', {
+        status: 'ACTIVE',
+        updatedAt: expect.any(Date),
+      });
+      expect(scheduleAutomationCron).not.toHaveBeenCalled();
+      expect(unscheduleAutomationCron).not.toHaveBeenCalled();
+      expect(result.status).toBe('ACTIVE');
+    });
+
+    it('does not validate the graph when pausing', async () => {
+      vi.mocked(automationRepository.updateAutomation).mockResolvedValue({
+        ...automation,
+        status: 'PAUSED',
+      } as any);
+
+      await setAutomationStatus(automation, 'PAUSED');
+
+      expect(validateAutomationGraph).not.toHaveBeenCalled();
+    });
+
+    it('validates triggerConfig before activating a schedule automation', async () => {
+      const scheduleAutomation = { ...automation, triggerType: 'schedule', triggerConfig: null };
+      vi.mocked(validateAutomationGraph).mockReturnValue({ valid: true, errors: [] });
+
+      await expect(setAutomationStatus(scheduleAutomation, 'ACTIVE')).rejects.toThrow(/triggerConfig/);
+      expect(automationRepository.updateAutomation).not.toHaveBeenCalled();
+      expect(scheduleAutomationCron).not.toHaveBeenCalled();
+    });
+
+    it('schedules the cron when activating a valid schedule automation', async () => {
+      const scheduleAutomation = {
+        ...automation,
+        triggerType: 'schedule',
+        triggerConfig: { cron: '0 9 * * *', timezone: 'America/Chicago' },
+      };
+      vi.mocked(validateAutomationGraph).mockReturnValue({ valid: true, errors: [] });
+      vi.mocked(automationRepository.updateAutomation).mockResolvedValue({
+        ...scheduleAutomation,
+        status: 'ACTIVE',
+      } as any);
+
+      await setAutomationStatus(scheduleAutomation, 'ACTIVE');
+
+      expect(scheduleAutomationCron).toHaveBeenCalledWith('automation-1', '0 9 * * *', 'America/Chicago');
+      expect(unscheduleAutomationCron).not.toHaveBeenCalled();
+    });
+
+    it('unschedules the cron when pausing a schedule automation', async () => {
+      const scheduleAutomation = { ...automation, triggerType: 'schedule' };
+      vi.mocked(automationRepository.updateAutomation).mockResolvedValue({
+        ...scheduleAutomation,
+        status: 'PAUSED',
+      } as any);
+
+      await setAutomationStatus(scheduleAutomation, 'PAUSED');
+
+      expect(unscheduleAutomationCron).toHaveBeenCalledWith('automation-1');
+      expect(scheduleAutomationCron).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteAutomation', () => {
+    it('unschedules, cancels runs, then deletes a schedule automation, in that order', async () => {
+      vi.mocked(unscheduleAutomationCron).mockResolvedValue(undefined as any);
+      vi.mocked(cancelRunsForAutomation).mockResolvedValue(undefined as any);
+      vi.mocked(automationRepository.deleteAutomation).mockResolvedValue({} as any);
+
+      const result = await deleteAutomation({ id: 'automation-1', triggerType: 'schedule' });
+
+      expect(unscheduleAutomationCron).toHaveBeenCalledWith('automation-1');
+      expect(cancelRunsForAutomation).toHaveBeenCalledWith('automation-1', 'automation deleted');
+      expect(automationRepository.deleteAutomation).toHaveBeenCalledWith('automation-1');
+
+      const unscheduleOrder = vi.mocked(unscheduleAutomationCron).mock.invocationCallOrder[0];
+      const cancelOrder = vi.mocked(cancelRunsForAutomation).mock.invocationCallOrder[0];
+      const deleteOrder = vi.mocked(automationRepository.deleteAutomation).mock.invocationCallOrder[0];
+      expect(unscheduleOrder).toBeLessThan(cancelOrder);
+      expect(cancelOrder).toBeLessThan(deleteOrder);
+      expect(result).toBe(true);
+    });
+
+    it('does not unschedule for a non-schedule automation', async () => {
+      vi.mocked(cancelRunsForAutomation).mockResolvedValue(undefined as any);
+      vi.mocked(automationRepository.deleteAutomation).mockResolvedValue({} as any);
+
+      await deleteAutomation({ id: 'automation-1', triggerType: 'form.submitted' });
+
+      expect(unscheduleAutomationCron).not.toHaveBeenCalled();
+      expect(cancelRunsForAutomation).toHaveBeenCalledWith('automation-1', 'automation deleted');
+    });
+  });
+
+  describe('testAutomation', () => {
+    const automation = {
+      id: 'automation-1',
+      formId: 'form-1',
+      version: 2,
+      graph: { nodes: [], edges: [] },
+    };
+    const mockResponse = {
+      id: 'response-1',
+      formId: 'form-1',
+      data: { field1: 'value1' },
+      submittedAt: new Date('2026-01-02T00:00:00.000Z'),
+    };
+
+    it('uses the given responseId when provided', async () => {
+      vi.mocked(responseRepository.findFirst).mockResolvedValue(mockResponse as any);
+      const createdRun = { id: 'run-1' };
+      vi.mocked(automationRepository.createRun).mockResolvedValue(createdRun as any);
+      vi.mocked(enqueueFirstStep).mockResolvedValue(undefined as any);
+
+      const result = await testAutomation(automation, 'response-1');
+
+      expect(responseRepository.findFirst).toHaveBeenCalledWith({
+        where: { id: 'response-1', formId: 'form-1', deletedAt: null },
+      });
+      expect(automationRepository.createRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          automationId: 'automation-1',
+          responseId: 'response-1',
+          automationVersion: 2,
+          status: 'RUNNING',
+          context: expect.objectContaining({
+            test: true,
+            triggerData: expect.objectContaining({ field1: 'value1', responseId: 'response-1' }),
+          }),
+        })
+      );
+      expect(enqueueFirstStep).toHaveBeenCalledWith(createdRun);
+      expect(result).toEqual(createdRun);
+    });
+
+    it('falls back to the latest response (by submittedAt desc) when none is given', async () => {
+      vi.mocked(responseRepository.findFirst).mockResolvedValue(mockResponse as any);
+      vi.mocked(automationRepository.createRun).mockResolvedValue({ id: 'run-1' } as any);
+      vi.mocked(enqueueFirstStep).mockResolvedValue(undefined as any);
+
+      await testAutomation(automation);
+
+      expect(responseRepository.findFirst).toHaveBeenCalledWith({
+        where: { formId: 'form-1', deletedAt: null },
+        orderBy: { submittedAt: 'desc' },
+      });
+    });
+
+    it('throws RESPONSE_NOT_FOUND-style error when the form has no responses', async () => {
+      vi.mocked(responseRepository.findFirst).mockResolvedValue(null);
+
+      await expect(testAutomation(automation)).rejects.toThrow(/No response available/);
+      expect(automationRepository.createRun).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listAutomationRuns', () => {
+    it('delegates limit/offset to the repository', async () => {
+      const runs = [{ id: 'run-1' }];
+      vi.mocked(automationRepository.listRunsByAutomation).mockResolvedValue(runs as any);
+
+      const result = await listAutomationRuns('automation-1', 10, 5);
+
+      expect(automationRepository.listRunsByAutomation).toHaveBeenCalledWith('automation-1', {
+        limit: 10,
+        offset: 5,
+      });
+      expect(result).toEqual(runs);
+    });
+  });
+
+  describe('getAutomationRunWithAutomation', () => {
+    it('returns the run when found', async () => {
+      const run = { id: 'run-1', automation: { formId: 'form-1' } };
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(run as any);
+
+      const result = await getAutomationRunWithAutomation('run-1');
+
+      expect(result).toEqual(run);
+    });
+
+    it('throws a NOT_FOUND-style error when the run does not exist', async () => {
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(null);
+
+      await expect(getAutomationRunWithAutomation('missing')).rejects.toThrow('Automation run not found');
+    });
+  });
+
+  describe('cancelAutomationRun', () => {
+    it('returns the cancelled run', async () => {
+      const cancelled = { id: 'run-1', status: 'CANCELLED' };
+      vi.mocked(cancelSingleAutomationRun).mockResolvedValue(cancelled as any);
+
+      const result = await cancelAutomationRun('run-1');
+
+      expect(cancelSingleAutomationRun).toHaveBeenCalledWith('run-1');
+      expect(result).toEqual(cancelled);
+    });
+
+    it('throws a NOT_FOUND-style error when the run does not exist', async () => {
+      vi.mocked(cancelSingleAutomationRun).mockResolvedValue(null as any);
+
+      await expect(cancelAutomationRun('missing')).rejects.toThrow('Automation run not found');
+    });
+  });
+
+  describe('listStepRuns', () => {
+    it('delegates to the repository', async () => {
+      const stepRuns = [{ id: 'step-1' }];
+      vi.mocked(automationRepository.listStepRunsByRun).mockResolvedValue(stepRuns as any);
+
+      const result = await listStepRuns('run-1');
+
+      expect(automationRepository.listStepRunsByRun).toHaveBeenCalledWith('run-1');
+      expect(result).toEqual(stepRuns);
+    });
+  });
+});

--- a/apps/backend/src/services/automation/__tests__/engine.test.ts
+++ b/apps/backend/src/services/automation/__tests__/engine.test.ts
@@ -7,35 +7,46 @@ import {
   registerAutomationWorker,
   ACTION_RETRY_LIMIT,
 } from '../engine.js';
-import { prisma } from '../../../lib/prisma.js';
+import { automationRepository } from '../../../repositories/index.js';
 import { getPluginHandler } from '../../../plugins/core/registry.js';
 import { createPluginContext } from '../../../plugins/core/context.js';
 import { evaluateCondition } from '../conditionEvaluator.js';
 import { getBoss, AUTOMATION_QUEUE } from '../boss.js';
 import type { AutomationGraph } from '../types.js';
 
-vi.mock('../../../lib/prisma.js', () => ({
-  prisma: {
-    automationStepRun: {
-      findFirst: vi.fn(),
-      create: vi.fn(),
-    },
-    automationRun: {
-      findUnique: vi.fn(),
-      update: vi.fn(),
-    },
-    // Array-form $transaction: operations are already-invoked PrismaPromises by the time
-    // $transaction receives them, so resolving them as-is mirrors the real API.
-    $transaction: vi.fn((ops: unknown[]) => Promise.all(ops)),
-    $executeRaw: vi.fn().mockResolvedValue(1),
-  },
+// The tx-scoped repository created inside `prisma.$transaction(async (tx) => ...)` calls
+// (updateAutomationNodeConfig, recordUnhandleableStepFailure) is a *second* repository
+// instance built via `createAutomationRepository(withPrisma(tx))` — it is NOT the same
+// object as the singleton `automationRepository` mocked below. We mock the factory to
+// always return the same spy-bearing object so assertions can inspect calls made through
+// either the singleton or a tx-scoped instance uniformly.
+const txRepoMock = vi.hoisted(() => ({
+  setNodeConfigInGraph: vi.fn().mockResolvedValue(1),
+  setNodeConfigInRunSnapshot: vi.fn().mockResolvedValue(1),
+  createStepRun: vi.fn().mockResolvedValue({}),
+  updateRun: vi.fn().mockResolvedValue({}),
 }));
 
-vi.mock('#prisma-client', () => ({
-  Prisma: {
-    sql: (strings: TemplateStringsArray, ...values: any[]) => ({ strings, values }),
-    raw: (value: string) => ({ raw: value }),
+vi.mock('../../../repositories/index.js', () => ({
+  automationRepository: {
+    findSuccessStepRun: vi.fn(),
+    findRunByIdWithAutomation: vi.fn(),
+    createStepRun: vi.fn().mockResolvedValue({}),
+    updateRun: vi.fn().mockResolvedValue({}),
+    findStepRunByNode: vi.fn(),
   },
+  createAutomationRepository: vi.fn(() => txRepoMock),
+}));
+
+vi.mock('../../../repositories/baseRepository.js', () => ({
+  withPrisma: (client: unknown) => ({ prisma: client }),
+}));
+
+vi.mock('../../../lib/prisma.js', () => ({
+  // Callback-style $transaction: invoke the callback with a stub tx client — the repo
+  // methods called inside are routed to txRepoMock via the createAutomationRepository mock
+  // above, so this stub client itself never needs real query methods.
+  prisma: { $transaction: vi.fn((cb: (tx: unknown) => Promise<unknown>) => cb({})) },
 }));
 
 vi.mock('../../../lib/logger.js', () => ({
@@ -107,6 +118,10 @@ describe('automation engine', () => {
       prisma: {} as any,
       logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
     } as any);
+    txRepoMock.setNodeConfigInGraph.mockResolvedValue(1);
+    txRepoMock.setNodeConfigInRunSnapshot.mockResolvedValue(1);
+    txRepoMock.createStepRun.mockResolvedValue({});
+    txRepoMock.updateRun.mockResolvedValue({});
   });
 
   describe('redelivery reconciliation (existing SUCCESS step found)', () => {
@@ -120,21 +135,17 @@ describe('automation engine', () => {
       };
       const delayUntil = new Date('2026-01-01T02:00:00.000Z');
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockImplementation((({ where }: any) => {
-        if (where.status === 'SUCCESS') {
-          // The step already succeeded and recorded its decision...
-          return { output: { delayUntil: delayUntil.toISOString(), capped: false } } as any;
-        }
-        // ...but the crash happened before the successor was ever enqueued or run.
-        return null;
-      }) as any);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue({
+        output: { delayUntil: delayUntil.toISOString(), capped: false },
+      } as any);
+      vi.mocked(automationRepository.findStepRunByNode).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ status: 'WAITING', graphSnapshot: graph }) as any
       );
 
       await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'delay-1' }));
 
-      expect(prisma.automationStepRun.create).not.toHaveBeenCalled();
+      expect(automationRepository.createStepRun).not.toHaveBeenCalled();
       expect(mockBoss.send).toHaveBeenCalledWith(
         AUTOMATION_QUEUE,
         { runId: 'run-1', nodeId: 'action-1' },
@@ -155,13 +166,11 @@ describe('automation engine', () => {
         ],
       };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockImplementation((({ where }: any) => {
-        if (where.status === 'SUCCESS') {
-          return { output: { result: true, branch: 'true' } } as any;
-        }
-        return null;
-      }) as any);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue({
+        output: { result: true, branch: 'true' },
+      } as any);
+      vi.mocked(automationRepository.findStepRunByNode).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ status: 'RUNNING', graphSnapshot: graph }) as any
       );
 
@@ -181,18 +190,18 @@ describe('automation engine', () => {
         edges: [],
       };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue({
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue({
         output: { delayUntil: new Date().toISOString(), capped: false },
       } as any);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ status: 'WAITING', graphSnapshot: graph }) as any
       );
 
       await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'delay-1' }));
 
-      expect(prisma.automationRun.update).toHaveBeenCalledWith({
-        where: { id: 'run-1' },
-        data: { status: 'COMPLETED', completedAt: expect.any(Date) },
+      expect(automationRepository.updateRun).toHaveBeenCalledWith('run-1', {
+        status: 'COMPLETED',
+        completedAt: expect.any(Date),
       });
       expect(mockBoss.send).not.toHaveBeenCalled();
     });
@@ -206,22 +215,19 @@ describe('automation engine', () => {
         edges: [{ id: 'e1', source: 'action-1', target: 'end-1' }],
       };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockImplementation((({ where }: any) => {
-        if (where.status === 'SUCCESS') {
-          return { output: { delivered: true } } as any;
-        }
-        return null;
-      }) as any);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue({
+        output: { delivered: true },
+      } as any);
+      vi.mocked(automationRepository.findStepRunByNode).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ status: 'RUNNING', graphSnapshot: graph, context: { triggerData: {} } }) as any
       );
 
       await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'action-1' }));
 
       expect(getPluginHandler).not.toHaveBeenCalled();
-      expect(prisma.automationRun.update).toHaveBeenCalledWith({
-        where: { id: 'run-1' },
-        data: { context: { triggerData: {}, stepOutputs: { 'action-1': { delivered: true } } } },
+      expect(automationRepository.updateRun).toHaveBeenCalledWith('run-1', {
+        context: { triggerData: {}, stepOutputs: { 'action-1': { delivered: true } } },
       });
       expect(mockBoss.send).toHaveBeenCalledWith(
         AUTOMATION_QUEUE,
@@ -239,21 +245,19 @@ describe('automation engine', () => {
         edges: [{ id: 'e1', source: 'delay-1', target: 'action-1' }],
       };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockImplementation((({ where }: any) => {
-        if (where.status === 'SUCCESS') {
-          return { output: { delayUntil: new Date().toISOString(), capped: false } } as any;
-        }
-        // The successor already ran (or is itself further along).
-        return { id: 'already-ran' } as any;
-      }) as any);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue({
+        output: { delayUntil: new Date().toISOString(), capped: false },
+      } as any);
+      // The successor already ran (or is itself further along).
+      vi.mocked(automationRepository.findStepRunByNode).mockResolvedValue({ id: 'already-ran' } as any);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ status: 'WAITING', graphSnapshot: graph }) as any
       );
 
       await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'delay-1' }));
 
       expect(mockBoss.send).not.toHaveBeenCalled();
-      expect(prisma.automationRun.update).not.toHaveBeenCalled();
+      expect(automationRepository.updateRun).not.toHaveBeenCalled();
     });
 
     it('does not merge stepOutputs again for an action node whose context already recorded the output', async () => {
@@ -262,13 +266,11 @@ describe('automation engine', () => {
         edges: [],
       };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockImplementation((({ where }: any) => {
-        if (where.status === 'SUCCESS') {
-          return { output: { delivered: true } } as any;
-        }
-        return null;
-      }) as any);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue({
+        output: { delivered: true },
+      } as any);
+      vi.mocked(automationRepository.findStepRunByNode).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({
           status: 'RUNNING',
           graphSnapshot: graph,
@@ -280,10 +282,10 @@ describe('automation engine', () => {
 
       // Only the completion update should fire — no redundant context merge, since stepOutputs
       // already has this node's output on record.
-      expect(prisma.automationRun.update).toHaveBeenCalledTimes(1);
-      expect(prisma.automationRun.update).toHaveBeenCalledWith({
-        where: { id: 'run-1' },
-        data: { status: 'COMPLETED', completedAt: expect.any(Date) },
+      expect(automationRepository.updateRun).toHaveBeenCalledTimes(1);
+      expect(automationRepository.updateRun).toHaveBeenCalledWith('run-1', {
+        status: 'COMPLETED',
+        completedAt: expect.any(Date),
       });
       expect(mockBoss.send).not.toHaveBeenCalled();
     });
@@ -291,32 +293,32 @@ describe('automation engine', () => {
 
   describe('run lookup guards', () => {
     it('drops the job when the run no longer exists', async () => {
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(null);
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(null);
 
       await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'node-1' }));
 
-      expect(prisma.automationRun.update).not.toHaveBeenCalled();
+      expect(automationRepository.updateRun).not.toHaveBeenCalled();
       expect(mockBoss.send).not.toHaveBeenCalled();
     });
 
     it('skips execution when the run is already in a terminal state', async () => {
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ status: 'COMPLETED', graphSnapshot: { nodes: [], edges: [] } }) as any
       );
 
       await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'node-1' }));
 
-      expect(prisma.automationRun.update).not.toHaveBeenCalled();
+      expect(automationRepository.updateRun).not.toHaveBeenCalled();
       expect(mockBoss.send).not.toHaveBeenCalled();
     });
   });
 
   describe('unhandleable node failures', () => {
     it('records a FAILED step run and reports to Sentry when the node is missing from the graph snapshot', async () => {
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ graphSnapshot: { nodes: [], edges: [] } }) as any
       );
 
@@ -325,17 +327,19 @@ describe('automation engine', () => {
       expect(Sentry.captureException).toHaveBeenCalledWith(
         expect.objectContaining({ message: expect.stringContaining('missing-node') })
       );
-      expect(prisma.automationStepRun.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
+      // recordUnhandleableStepFailure runs inside prisma.$transaction, using a tx-scoped
+      // repository (txRepoMock) rather than the singleton automationRepository mock.
+      expect(txRepoMock.createStepRun).toHaveBeenCalledWith(
+        expect.objectContaining({
           runId: 'run-1',
           nodeId: 'missing-node',
           nodeType: 'unknown',
           status: 'FAILED',
-        }),
-      });
-      expect(prisma.automationRun.update).toHaveBeenCalledWith({
-        where: { id: 'run-1' },
-        data: { status: 'FAILED', completedAt: expect.any(Date) },
+        })
+      );
+      expect(txRepoMock.updateRun).toHaveBeenCalledWith('run-1', {
+        status: 'FAILED',
+        completedAt: expect.any(Date),
       });
     });
 
@@ -345,8 +349,8 @@ describe('automation engine', () => {
         edges: [],
       };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ graphSnapshot: graph }) as any
       );
 
@@ -355,17 +359,17 @@ describe('automation engine', () => {
       expect(Sentry.captureException).toHaveBeenCalledWith(
         expect.objectContaining({ message: expect.stringContaining('trigger-1') })
       );
-      expect(prisma.automationStepRun.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
+      expect(txRepoMock.createStepRun).toHaveBeenCalledWith(
+        expect.objectContaining({
           runId: 'run-1',
           nodeId: 'trigger-1',
           nodeType: 'trigger',
           status: 'FAILED',
-        }),
-      });
-      expect(prisma.automationRun.update).toHaveBeenCalledWith({
-        where: { id: 'run-1' },
-        data: { status: 'FAILED', completedAt: expect.any(Date) },
+        })
+      );
+      expect(txRepoMock.updateRun).toHaveBeenCalledWith('run-1', {
+        status: 'FAILED',
+        completedAt: expect.any(Date),
       });
     });
   });
@@ -384,8 +388,8 @@ describe('automation engine', () => {
         edges: [{ id: 'e1', source: 'delay-1', target: 'action-1' }],
       };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ graphSnapshot: graph }) as any
       );
 
@@ -393,19 +397,19 @@ describe('automation engine', () => {
 
       const delayUntil = new Date(now.getTime() + 2 * 60 * 60 * 1000);
 
-      expect(prisma.automationStepRun.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
+      expect(automationRepository.createStepRun).toHaveBeenCalledWith(
+        expect.objectContaining({
           runId: 'run-1',
           nodeId: 'delay-1',
           nodeType: 'delay',
           status: 'SUCCESS',
           output: { delayUntil: delayUntil.toISOString(), capped: false },
-        }),
-      });
+        })
+      );
 
-      expect(prisma.automationRun.update).toHaveBeenCalledWith({
-        where: { id: 'run-1' },
-        data: { status: 'WAITING', currentNodeId: 'action-1' },
+      expect(automationRepository.updateRun).toHaveBeenCalledWith('run-1', {
+        status: 'WAITING',
+        currentNodeId: 'action-1',
       });
 
       expect(mockBoss.send).toHaveBeenCalledWith(
@@ -435,8 +439,8 @@ describe('automation engine', () => {
         edges: [{ id: 'e1', source: 'delay-1', target: 'end-1' }],
       };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ graphSnapshot: graph }) as any
       );
 
@@ -444,11 +448,11 @@ describe('automation engine', () => {
 
       const cappedUntil = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
 
-      expect(prisma.automationStepRun.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
+      expect(automationRepository.createStepRun).toHaveBeenCalledWith(
+        expect.objectContaining({
           output: { delayUntil: cappedUntil.toISOString(), capped: true },
-        }),
-      });
+        })
+      );
 
       vi.useRealTimers();
     });
@@ -459,16 +463,16 @@ describe('automation engine', () => {
         edges: [],
       };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ graphSnapshot: graph }) as any
       );
 
       await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'delay-1' }));
 
-      expect(prisma.automationRun.update).toHaveBeenCalledWith({
-        where: { id: 'run-1' },
-        data: { status: 'COMPLETED', completedAt: expect.any(Date) },
+      expect(automationRepository.updateRun).toHaveBeenCalledWith('run-1', {
+        status: 'COMPLETED',
+        completedAt: expect.any(Date),
       });
       expect(mockBoss.send).not.toHaveBeenCalled();
     });
@@ -484,8 +488,8 @@ describe('automation engine', () => {
         edges: [{ id: 'e1', source: 'action-1', target: 'end-1' }],
       };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ graphSnapshot: graph, context: { triggerData: { email: 'a@b.com' } } }) as any
       );
 
@@ -506,23 +510,22 @@ describe('automation engine', () => {
         expect.any(Object)
       );
 
-      expect(prisma.automationRun.update).toHaveBeenCalledWith({
-        where: { id: 'run-1' },
-        data: { status: 'RUNNING', currentNodeId: 'action-1' },
+      expect(automationRepository.updateRun).toHaveBeenCalledWith('run-1', {
+        status: 'RUNNING',
+        currentNodeId: 'action-1',
       });
 
-      expect(prisma.automationStepRun.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
+      expect(automationRepository.createStepRun).toHaveBeenCalledWith(
+        expect.objectContaining({
           nodeType: 'action:webhook',
           status: 'SUCCESS',
           output: { delivered: true },
           attempt: 1,
-        }),
-      });
+        })
+      );
 
-      expect(prisma.automationRun.update).toHaveBeenCalledWith({
-        where: { id: 'run-1' },
-        data: { context: { triggerData: { email: 'a@b.com' }, stepOutputs: { 'action-1': { delivered: true } } } },
+      expect(automationRepository.updateRun).toHaveBeenCalledWith('run-1', {
+        context: { triggerData: { email: 'a@b.com' }, stepOutputs: { 'action-1': { delivered: true } } },
       });
 
       expect(mockBoss.send).toHaveBeenCalledWith(
@@ -538,8 +541,8 @@ describe('automation engine', () => {
         edges: [],
       };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ graphSnapshot: graph, context: { triggerData: { name: 'Ada' } } }) as any
       );
 
@@ -563,20 +566,20 @@ describe('automation engine', () => {
         edges: [],
       };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ graphSnapshot: graph, automation: { status: 'PAUSED', formId: 'f', organizationId: 'o', triggerType: 'form.submitted' } }) as any
       );
 
       await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'action-1' }));
 
       expect(getPluginHandler).not.toHaveBeenCalled();
-      expect(prisma.automationStepRun.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({ status: 'SKIPPED', errorMessage: expect.stringContaining('PAUSED') }),
-      });
-      expect(prisma.automationRun.update).toHaveBeenCalledWith({
-        where: { id: 'run-1' },
-        data: { status: 'CANCELLED', completedAt: expect.any(Date) },
+      expect(automationRepository.createStepRun).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'SKIPPED', errorMessage: expect.stringContaining('PAUSED') })
+      );
+      expect(automationRepository.updateRun).toHaveBeenCalledWith('run-1', {
+        status: 'CANCELLED',
+        completedAt: expect.any(Date),
       });
       expect(mockBoss.send).not.toHaveBeenCalled();
     });
@@ -587,8 +590,8 @@ describe('automation engine', () => {
         edges: [],
       };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ graphSnapshot: graph }) as any
       );
 
@@ -600,11 +603,12 @@ describe('automation engine', () => {
       ).rejects.toThrow('boom');
 
       expect(Sentry.captureException).toHaveBeenCalled();
-      expect(prisma.automationStepRun.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({ status: 'FAILED', errorMessage: 'boom', attempt: 1 }),
-      });
-      expect(prisma.automationRun.update).not.toHaveBeenCalledWith(
-        expect.objectContaining({ data: expect.objectContaining({ status: 'FAILED' }) })
+      expect(automationRepository.createStepRun).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'FAILED', errorMessage: 'boom', attempt: 1 })
+      );
+      expect(automationRepository.updateRun).not.toHaveBeenCalledWith(
+        'run-1',
+        expect.objectContaining({ status: 'FAILED' })
       );
     });
 
@@ -614,8 +618,8 @@ describe('automation engine', () => {
         edges: [],
       };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ graphSnapshot: graph }) as any
       );
 
@@ -626,12 +630,12 @@ describe('automation engine', () => {
         executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'action-1' }, ACTION_RETRY_LIMIT, ACTION_RETRY_LIMIT))
       ).resolves.toBeUndefined();
 
-      expect(prisma.automationStepRun.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({ status: 'FAILED', attempt: ACTION_RETRY_LIMIT + 1 }),
-      });
-      expect(prisma.automationRun.update).toHaveBeenCalledWith({
-        where: { id: 'run-1' },
-        data: { status: 'FAILED', completedAt: expect.any(Date) },
+      expect(automationRepository.createStepRun).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'FAILED', attempt: ACTION_RETRY_LIMIT + 1 })
+      );
+      expect(automationRepository.updateRun).toHaveBeenCalledWith('run-1', {
+        status: 'FAILED',
+        completedAt: expect.any(Date),
       });
     });
 
@@ -641,8 +645,8 @@ describe('automation engine', () => {
         edges: [],
       };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ graphSnapshot: graph }) as any
       );
       vi.mocked(getPluginHandler).mockReturnValue(undefined);
@@ -652,14 +656,14 @@ describe('automation engine', () => {
       ).rejects.toThrow('No handler registered for action type: unregistered-type');
     });
 
-    it('wires createPluginContext with a persistence strategy that jsonb_sets the node config into both the live Automation.graph and this run\'s graphSnapshot (#222 regression: handlers previously wrote to a nonexistent FormPlugin row for automation-triggered actions)', async () => {
+    it("wires createPluginContext with a persistence strategy that jsonb_sets the node config into both the live Automation.graph and this run's graphSnapshot (#222 regression: handlers previously wrote to a nonexistent FormPlugin row for automation-triggered actions)", async () => {
       const graph: AutomationGraph = {
         nodes: [{ id: 'action-1', type: 'action', data: { actionType: 'google-sheets', config: { type: 'google-sheets' } } }],
         edges: [],
       };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ graphSnapshot: graph }) as any
       );
 
@@ -683,29 +687,12 @@ describe('automation engine', () => {
       const newConfig = { type: 'google-sheets', spreadsheetId: 'sheet-123', spreadsheetUrl: 'https://sheets.google.com/sheet-123' };
       await capturedPersist!(newConfig);
 
-      expect(prisma.$executeRaw).toHaveBeenCalledTimes(2);
-      // Both writes must go through a single $transaction, not Promise.all — otherwise one
-      // write succeeding while the other fails would leave Automation.graph and this run's
+      // Both writes must go through the same interactive `prisma.$transaction(async (tx) => ...)`
+      // callback (via a tx-scoped repository), not independently — otherwise one write
+      // succeeding while the other fails would leave Automation.graph and this run's
       // graphSnapshot permanently diverged.
-      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
-      expect(vi.mocked(prisma.$transaction).mock.calls[0][0]).toHaveLength(2);
-
-      const [graphCall, snapshotCall] = vi.mocked(prisma.$executeRaw).mock.calls.map(
-        (call) => call[0] as unknown as { strings: TemplateStringsArray; values: any[] }
-      );
-
-      // Update against the live Automation row — keyed by automationId, not runId — so the
-      // NEXT run's fresh graphSnapshot picks up the same spreadsheet instead of recreating one.
-      expect(graphCall.strings.join('')).toContain('UPDATE');
-      expect(graphCall.values).toContain('action-1');
-      expect(graphCall.values).toContain('automation-1');
-      expect(graphCall.values).toContain(JSON.stringify(newConfig));
-
-      // Update against this run's graphSnapshot — keyed by runId — so a retry of THIS run
-      // doesn't recreate the spreadsheet after a transient failure post-creation.
-      expect(snapshotCall.values).toContain('action-1');
-      expect(snapshotCall.values).toContain('run-1');
-      expect(snapshotCall.values).toContain(JSON.stringify(newConfig));
+      expect(txRepoMock.setNodeConfigInGraph).toHaveBeenCalledWith('automation-1', 'action-1', newConfig);
+      expect(txRepoMock.setNodeConfigInRunSnapshot).toHaveBeenCalledWith('run-1', 'action-1', newConfig);
     });
   });
 
@@ -719,18 +706,15 @@ describe('automation engine', () => {
     };
 
     it('follows the true edge when evaluateCondition returns true', async () => {
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ graphSnapshot: graph, context: { triggerData: {} } }) as any
       );
       vi.mocked(evaluateCondition).mockReturnValue(true);
 
       await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'cond-1' }));
 
-      expect(prisma.automationRun.update).toHaveBeenCalledWith({
-        where: { id: 'run-1' },
-        data: { currentNodeId: 'true-1' },
-      });
+      expect(automationRepository.updateRun).toHaveBeenCalledWith('run-1', { currentNodeId: 'true-1' });
       expect(mockBoss.send).toHaveBeenCalledWith(
         AUTOMATION_QUEUE,
         { runId: 'run-1', nodeId: 'true-1' },
@@ -739,17 +723,17 @@ describe('automation engine', () => {
     });
 
     it('jumps to end (completes the run) when the matching branch has no outgoing edge', async () => {
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ graphSnapshot: graph, context: { triggerData: {} } }) as any
       );
       vi.mocked(evaluateCondition).mockReturnValue(false);
 
       await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'cond-1' }));
 
-      expect(prisma.automationRun.update).toHaveBeenCalledWith({
-        where: { id: 'run-1' },
-        data: { status: 'COMPLETED', completedAt: expect.any(Date) },
+      expect(automationRepository.updateRun).toHaveBeenCalledWith('run-1', {
+        status: 'COMPLETED',
+        completedAt: expect.any(Date),
       });
       expect(mockBoss.send).not.toHaveBeenCalled();
     });
@@ -759,19 +743,19 @@ describe('automation engine', () => {
     it('logs a SUCCESS step and marks the run COMPLETED', async () => {
       const graph: AutomationGraph = { nodes: [{ id: 'end-1', type: 'end' }], edges: [] };
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue(null);
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunByIdWithAutomation).mockResolvedValue(
         makeRun({ graphSnapshot: graph }) as any
       );
 
       await executeAutomationStep(makeJob({ runId: 'run-1', nodeId: 'end-1' }));
 
-      expect(prisma.automationStepRun.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({ nodeType: 'end', status: 'SUCCESS' }),
-      });
-      expect(prisma.automationRun.update).toHaveBeenCalledWith({
-        where: { id: 'run-1' },
-        data: { status: 'COMPLETED', completedAt: expect.any(Date) },
+      expect(automationRepository.createStepRun).toHaveBeenCalledWith(
+        expect.objectContaining({ nodeType: 'end', status: 'SUCCESS' })
+      );
+      expect(automationRepository.updateRun).toHaveBeenCalledWith('run-1', {
+        status: 'COMPLETED',
+        completedAt: expect.any(Date),
       });
     });
   });
@@ -834,14 +818,14 @@ describe('automation engine', () => {
       };
       await registerAutomationWorker(boss as any);
 
-      vi.mocked(prisma.automationStepRun.findFirst).mockResolvedValue({ status: 'SUCCESS' } as any);
+      vi.mocked(automationRepository.findSuccessStepRun).mockResolvedValue({ status: 'SUCCESS' } as any);
 
       await handler([
         makeJob({ runId: 'r1', nodeId: 'n1' }),
         makeJob({ runId: 'r2', nodeId: 'n2' }),
       ]);
 
-      expect(prisma.automationStepRun.findFirst).toHaveBeenCalledTimes(2);
+      expect(automationRepository.findSuccessStepRun).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/apps/backend/src/services/automation/__tests__/triggerService.test.ts
+++ b/apps/backend/src/services/automation/__tests__/triggerService.test.ts
@@ -12,22 +12,19 @@ import {
 import { enqueueFirstStep } from '../engine.js';
 import { getBoss, AUTOMATION_QUEUE, AUTOMATION_CRON_QUEUE } from '../boss.js';
 import { getEventEmitter } from '../../../plugins/core/events.js';
-import { prisma } from '../../../lib/prisma.js';
+import { automationRepository } from '../../../repositories/index.js';
 import { logger } from '../../../lib/logger.js';
 import type { PluginEvent } from '../../../plugins/core/types.js';
 
-vi.mock('../../../lib/prisma.js', () => ({
-  prisma: {
-    automation: {
-      findMany: vi.fn(),
-      findUnique: vi.fn(),
-    },
-    automationRun: {
-      create: vi.fn(),
-      findMany: vi.fn(),
-      findUnique: vi.fn(),
-      updateMany: vi.fn(),
-    },
+vi.mock('../../../repositories/index.js', () => ({
+  automationRepository: {
+    listActiveByFormAndTrigger: vi.fn(),
+    createRun: vi.fn(),
+    listActiveRunsByAutomation: vi.fn(),
+    cancelRunsByIds: vi.fn(),
+    findRunById: vi.fn(),
+    cancelRunIfActive: vi.fn(),
+    findById: vi.fn(),
   },
 }));
 
@@ -89,7 +86,7 @@ describe('triggerService', () => {
     vi.clearAllMocks();
     getEventEmitter().removeAllListeners('plugin:event');
     vi.mocked(generateId).mockReturnValue('generated-run-id');
-    vi.mocked(prisma.automationRun.create).mockResolvedValue({ id: 'generated-run-id' } as any);
+    vi.mocked(automationRepository.createRun).mockResolvedValue({ id: 'generated-run-id' } as any);
   });
 
   afterEach(() => {
@@ -110,27 +107,26 @@ describe('triggerService', () => {
     it('creates one AutomationRun and enqueues the first step for a single matching automation', async () => {
       initializeAutomationTriggers();
       const automation = makeAutomation();
-      vi.mocked(prisma.automation.findMany).mockResolvedValue([automation] as any);
+      vi.mocked(automationRepository.listActiveByFormAndTrigger).mockResolvedValue([automation] as any);
 
       await emitAndFlush(makeEvent());
 
-      expect(prisma.automation.findMany).toHaveBeenCalledWith({
-        where: { formId: 'form-1', status: 'ACTIVE', triggerType: 'form.submitted' },
-      });
+      expect(automationRepository.listActiveByFormAndTrigger).toHaveBeenCalledWith(
+        'form-1',
+        'form.submitted'
+      );
 
-      expect(prisma.automationRun.create).toHaveBeenCalledWith({
-        data: {
-          id: 'generated-run-id',
-          automationId: 'automation-1',
-          responseId: 'resp-1',
-          automationVersion: 3,
-          graphSnapshot: automation.graph,
-          status: 'RUNNING',
-          context: {
-            triggerData: { responseId: 'resp-1', email: 'a@b.com' },
-            formId: 'form-1',
-            organizationId: 'org-1',
-          },
+      expect(automationRepository.createRun).toHaveBeenCalledWith({
+        id: 'generated-run-id',
+        automationId: 'automation-1',
+        responseId: 'resp-1',
+        automationVersion: 3,
+        graphSnapshot: automation.graph,
+        status: 'RUNNING',
+        context: {
+          triggerData: { responseId: 'resp-1', email: 'a@b.com' },
+          formId: 'form-1',
+          organizationId: 'org-1',
         },
       });
 
@@ -139,7 +135,7 @@ describe('triggerService', () => {
 
     it('creates N runs for N matching automations', async () => {
       initializeAutomationTriggers();
-      vi.mocked(prisma.automation.findMany).mockResolvedValue([
+      vi.mocked(automationRepository.listActiveByFormAndTrigger).mockResolvedValue([
         makeAutomation({ id: 'automation-1' }),
         makeAutomation({ id: 'automation-2' }),
         makeAutomation({ id: 'automation-3' }),
@@ -147,29 +143,30 @@ describe('triggerService', () => {
 
       await emitAndFlush(makeEvent());
 
-      expect(prisma.automationRun.create).toHaveBeenCalledTimes(3);
+      expect(automationRepository.createRun).toHaveBeenCalledTimes(3);
       expect(enqueueFirstStep).toHaveBeenCalledTimes(3);
     });
 
     it('does nothing when there are 0 matching automations', async () => {
       initializeAutomationTriggers();
-      vi.mocked(prisma.automation.findMany).mockResolvedValue([]);
+      vi.mocked(automationRepository.listActiveByFormAndTrigger).mockResolvedValue([]);
 
       await emitAndFlush(makeEvent());
 
-      expect(prisma.automationRun.create).not.toHaveBeenCalled();
+      expect(automationRepository.createRun).not.toHaveBeenCalled();
       expect(enqueueFirstStep).not.toHaveBeenCalled();
     });
 
     it('only queries ACTIVE automations with triggerType form.submitted (inactive/draft excluded by the query)', async () => {
       initializeAutomationTriggers();
-      vi.mocked(prisma.automation.findMany).mockResolvedValue([]);
+      vi.mocked(automationRepository.listActiveByFormAndTrigger).mockResolvedValue([]);
 
       await emitAndFlush(makeEvent());
 
-      expect(prisma.automation.findMany).toHaveBeenCalledWith({
-        where: { formId: 'form-1', status: 'ACTIVE', triggerType: 'form.submitted' },
-      });
+      expect(automationRepository.listActiveByFormAndTrigger).toHaveBeenCalledWith(
+        'form-1',
+        'form.submitted'
+      );
     });
 
     it('ignores non form.submitted/response.edited events', async () => {
@@ -177,28 +174,29 @@ describe('triggerService', () => {
 
       await emitAndFlush(makeEvent({ type: 'plugin.test' }));
 
-      expect(prisma.automation.findMany).not.toHaveBeenCalled();
+      expect(automationRepository.listActiveByFormAndTrigger).not.toHaveBeenCalled();
     });
 
     it('creates a run for a matching response.edited automation', async () => {
       initializeAutomationTriggers();
       const automation = makeAutomation({ triggerType: 'response.edited' });
-      vi.mocked(prisma.automation.findMany).mockResolvedValue([automation] as any);
+      vi.mocked(automationRepository.listActiveByFormAndTrigger).mockResolvedValue([automation] as any);
 
       await emitAndFlush(
         makeEvent({ type: 'response.edited', data: { responseId: 'resp-1', editType: 'MANUAL' } })
       );
 
-      expect(prisma.automation.findMany).toHaveBeenCalledWith({
-        where: { formId: 'form-1', status: 'ACTIVE', triggerType: 'response.edited' },
-      });
-      expect(prisma.automationRun.create).toHaveBeenCalled();
+      expect(automationRepository.listActiveByFormAndTrigger).toHaveBeenCalledWith(
+        'form-1',
+        'response.edited'
+      );
+      expect(automationRepository.createRun).toHaveBeenCalled();
       expect(enqueueFirstStep).toHaveBeenCalledWith({ id: 'generated-run-id' });
     });
 
     it('loop guard: suppresses run creation for a response.edited event carrying sourceRunId', async () => {
       initializeAutomationTriggers();
-      vi.mocked(prisma.automation.findMany).mockResolvedValue([
+      vi.mocked(automationRepository.listActiveByFormAndTrigger).mockResolvedValue([
         makeAutomation({ triggerType: 'response.edited' }),
       ] as any);
 
@@ -209,20 +207,22 @@ describe('triggerService', () => {
         })
       );
 
-      expect(prisma.automation.findMany).not.toHaveBeenCalled();
-      expect(prisma.automationRun.create).not.toHaveBeenCalled();
+      expect(automationRepository.listActiveByFormAndTrigger).not.toHaveBeenCalled();
+      expect(automationRepository.createRun).not.toHaveBeenCalled();
     });
 
     it('does not suppress form.submitted events that happen to carry a sourceRunId-shaped field', async () => {
       // sourceRunId only matters for response.edited — a form.submitted event is never
       // itself caused by an automation action, so the loop guard must not touch it.
       initializeAutomationTriggers();
-      vi.mocked(prisma.automation.findMany).mockResolvedValue([makeAutomation()] as any);
+      vi.mocked(automationRepository.listActiveByFormAndTrigger).mockResolvedValue([
+        makeAutomation(),
+      ] as any);
 
       await emitAndFlush(makeEvent({ data: { responseId: 'resp-1', sourceRunId: 'run-1' } }));
 
-      expect(prisma.automation.findMany).toHaveBeenCalled();
-      expect(prisma.automationRun.create).toHaveBeenCalled();
+      expect(automationRepository.listActiveByFormAndTrigger).toHaveBeenCalled();
+      expect(automationRepository.createRun).toHaveBeenCalled();
     });
 
     it('ignores preview submissions', async () => {
@@ -230,12 +230,12 @@ describe('triggerService', () => {
 
       await emitAndFlush(makeEvent({ data: { responseId: 'resp-1', isPreview: true } }));
 
-      expect(prisma.automation.findMany).not.toHaveBeenCalled();
+      expect(automationRepository.listActiveByFormAndTrigger).not.toHaveBeenCalled();
     });
 
     it('never throws or propagates when the automation lookup fails', async () => {
       initializeAutomationTriggers();
-      vi.mocked(prisma.automation.findMany).mockRejectedValue(new Error('db down'));
+      vi.mocked(automationRepository.listActiveByFormAndTrigger).mockRejectedValue(new Error('db down'));
 
       expect(() => getEventEmitter().emit('plugin:event', makeEvent())).not.toThrow();
       await emitAndFlush(makeEvent());
@@ -246,17 +246,17 @@ describe('triggerService', () => {
 
     it('logs and reports to Sentry but still processes other automations when one run fails to create', async () => {
       initializeAutomationTriggers();
-      vi.mocked(prisma.automation.findMany).mockResolvedValue([
+      vi.mocked(automationRepository.listActiveByFormAndTrigger).mockResolvedValue([
         makeAutomation({ id: 'automation-1' }),
         makeAutomation({ id: 'automation-2' }),
       ] as any);
-      vi.mocked(prisma.automationRun.create)
+      vi.mocked(automationRepository.createRun)
         .mockRejectedValueOnce(new Error('create failed'))
         .mockResolvedValueOnce({ id: 'generated-run-id' } as any);
 
       await emitAndFlush(makeEvent());
 
-      expect(prisma.automationRun.create).toHaveBeenCalledTimes(2);
+      expect(automationRepository.createRun).toHaveBeenCalledTimes(2);
       expect(enqueueFirstStep).toHaveBeenCalledTimes(1);
       expect(logger.error).toHaveBeenCalled();
       expect(Sentry.captureException).toHaveBeenCalled();
@@ -264,27 +264,29 @@ describe('triggerService', () => {
 
     it('falls back to null responseId when the event data has none', async () => {
       initializeAutomationTriggers();
-      vi.mocked(prisma.automation.findMany).mockResolvedValue([makeAutomation()] as any);
+      vi.mocked(automationRepository.listActiveByFormAndTrigger).mockResolvedValue([
+        makeAutomation(),
+      ] as any);
 
       await emitAndFlush(makeEvent({ data: { email: 'a@b.com' } }));
 
-      expect(prisma.automationRun.create).toHaveBeenCalledWith(
-        expect.objectContaining({ data: expect.objectContaining({ responseId: null }) })
+      expect(automationRepository.createRun).toHaveBeenCalledWith(
+        expect.objectContaining({ responseId: null })
       );
     });
   });
 
   describe('cancelRunsForAutomation', () => {
     it('does nothing when there are no RUNNING/WAITING runs', async () => {
-      vi.mocked(prisma.automationRun.findMany).mockResolvedValue([]);
+      vi.mocked(automationRepository.listActiveRunsByAutomation).mockResolvedValue([]);
 
       await cancelRunsForAutomation('automation-1', 'automation deleted');
 
-      expect(prisma.automationRun.updateMany).not.toHaveBeenCalled();
+      expect(automationRepository.cancelRunsByIds).not.toHaveBeenCalled();
     });
 
     it('cancels outstanding pg-boss jobs and marks matching runs CANCELLED', async () => {
-      vi.mocked(prisma.automationRun.findMany).mockResolvedValue([
+      vi.mocked(automationRepository.listActiveRunsByAutomation).mockResolvedValue([
         { id: 'run-1' },
         { id: 'run-2' },
       ] as any);
@@ -303,26 +305,22 @@ describe('triggerService', () => {
       expect(cancel).toHaveBeenCalledWith(AUTOMATION_QUEUE, ['job-1']);
       expect(cancel).toHaveBeenCalledTimes(1);
 
-      expect(prisma.automationRun.updateMany).toHaveBeenCalledWith({
-        where: { id: { in: ['run-1', 'run-2'] } },
-        data: { status: 'CANCELLED', completedAt: expect.any(Date) },
-      });
+      expect(automationRepository.cancelRunsByIds).toHaveBeenCalledWith(['run-1', 'run-2']);
     });
 
     it('still marks runs CANCELLED when pg-boss is disabled (getBoss returns null)', async () => {
-      vi.mocked(prisma.automationRun.findMany).mockResolvedValue([{ id: 'run-1' }] as any);
+      vi.mocked(automationRepository.listActiveRunsByAutomation).mockResolvedValue([
+        { id: 'run-1' },
+      ] as any);
       vi.mocked(getBoss).mockReturnValue(null);
 
       await cancelRunsForAutomation('automation-1', 'automation paused');
 
-      expect(prisma.automationRun.updateMany).toHaveBeenCalledWith({
-        where: { id: { in: ['run-1'] } },
-        data: { status: 'CANCELLED', completedAt: expect.any(Date) },
-      });
+      expect(automationRepository.cancelRunsByIds).toHaveBeenCalledWith(['run-1']);
     });
 
     it('never throws when the run lookup fails', async () => {
-      vi.mocked(prisma.automationRun.findMany).mockRejectedValue(new Error('db down'));
+      vi.mocked(automationRepository.listActiveRunsByAutomation).mockRejectedValue(new Error('db down'));
 
       await expect(cancelRunsForAutomation('automation-1', 'reason')).resolves.toBeUndefined();
       expect(logger.error).toHaveBeenCalled();
@@ -330,7 +328,7 @@ describe('triggerService', () => {
     });
 
     it('continues cancelling remaining runs and still updates DB state when one pg-boss cancel call fails', async () => {
-      vi.mocked(prisma.automationRun.findMany).mockResolvedValue([
+      vi.mocked(automationRepository.listActiveRunsByAutomation).mockResolvedValue([
         { id: 'run-1' },
         { id: 'run-2' },
       ] as any);
@@ -342,7 +340,7 @@ describe('triggerService', () => {
       await cancelRunsForAutomation('automation-1', 'reason');
 
       expect(cancel).toHaveBeenCalledTimes(2);
-      expect(prisma.automationRun.updateMany).toHaveBeenCalled();
+      expect(automationRepository.cancelRunsByIds).toHaveBeenCalled();
       expect(logger.error).toHaveBeenCalled();
       expect(Sentry.captureException).toHaveBeenCalled();
     });
@@ -350,54 +348,51 @@ describe('triggerService', () => {
 
   describe('cancelSingleAutomationRun', () => {
     it('returns null when the run does not exist', async () => {
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(null);
+      vi.mocked(automationRepository.findRunById).mockResolvedValue(null);
 
       const result = await cancelSingleAutomationRun('missing-run');
 
       expect(result).toBeNull();
-      expect(prisma.automationRun.updateMany).not.toHaveBeenCalled();
+      expect(automationRepository.cancelRunIfActive).not.toHaveBeenCalled();
     });
 
     it('returns an already-terminal run unchanged without touching pg-boss or the DB', async () => {
       const terminalRun = { id: 'run-1', status: 'COMPLETED' };
-      vi.mocked(prisma.automationRun.findUnique).mockResolvedValue(terminalRun as any);
+      vi.mocked(automationRepository.findRunById).mockResolvedValue(terminalRun as any);
 
       const result = await cancelSingleAutomationRun('run-1');
 
       expect(result).toEqual(terminalRun);
       expect(getBoss).not.toHaveBeenCalled();
-      expect(prisma.automationRun.updateMany).not.toHaveBeenCalled();
+      expect(automationRepository.cancelRunIfActive).not.toHaveBeenCalled();
     });
 
     it('cancels outstanding pg-boss jobs and marks a RUNNING run CANCELLED', async () => {
-      vi.mocked(prisma.automationRun.findUnique)
+      vi.mocked(automationRepository.findRunById)
         .mockResolvedValueOnce({ id: 'run-1', status: 'RUNNING' } as any)
         .mockResolvedValueOnce({ id: 'run-1', status: 'CANCELLED' } as any);
       const findJobs = vi.fn().mockResolvedValue([{ id: 'job-1' }]);
       const cancel = vi.fn().mockResolvedValue(undefined);
       vi.mocked(getBoss).mockReturnValue({ findJobs, cancel } as any);
-      vi.mocked(prisma.automationRun.updateMany).mockResolvedValue({ count: 1 } as any);
+      vi.mocked(automationRepository.cancelRunIfActive).mockResolvedValue({ count: 1 } as any);
 
       const result = await cancelSingleAutomationRun('run-1');
 
       expect(findJobs).toHaveBeenCalledWith(AUTOMATION_QUEUE, { data: { runId: 'run-1' } });
       expect(cancel).toHaveBeenCalledWith(AUTOMATION_QUEUE, ['job-1']);
-      expect(prisma.automationRun.updateMany).toHaveBeenCalledWith({
-        where: { id: 'run-1', status: { in: ['RUNNING', 'WAITING'] } },
-        data: { status: 'CANCELLED', completedAt: expect.any(Date) },
-      });
+      expect(automationRepository.cancelRunIfActive).toHaveBeenCalledWith('run-1');
       expect(result).toEqual({ id: 'run-1', status: 'CANCELLED' });
     });
 
     it('does not corrupt a run that reaches a terminal state concurrently (TOCTOU-safe)', async () => {
-      // The initial read sees RUNNING, but by the time the guarded updateMany runs the
-      // engine has already completed it — updateMany's status-scoped where clause matches
-      // 0 rows, and the final state must be read back rather than assumed to be CANCELLED.
-      vi.mocked(prisma.automationRun.findUnique)
+      // The initial read sees RUNNING, but by the time the guarded update runs the
+      // engine has already completed it — cancelRunIfActive's status-scoped where clause
+      // matches 0 rows, and the final state must be read back rather than assumed to be CANCELLED.
+      vi.mocked(automationRepository.findRunById)
         .mockResolvedValueOnce({ id: 'run-1', status: 'RUNNING' } as any)
         .mockResolvedValueOnce({ id: 'run-1', status: 'COMPLETED' } as any);
       vi.mocked(getBoss).mockReturnValue(null);
-      vi.mocked(prisma.automationRun.updateMany).mockResolvedValue({ count: 0 } as any);
+      vi.mocked(automationRepository.cancelRunIfActive).mockResolvedValue({ count: 0 } as any);
 
       const result = await cancelSingleAutomationRun('run-1');
 
@@ -406,18 +401,15 @@ describe('triggerService', () => {
     });
 
     it('still cancels when pg-boss is disabled (getBoss returns null)', async () => {
-      vi.mocked(prisma.automationRun.findUnique)
+      vi.mocked(automationRepository.findRunById)
         .mockResolvedValueOnce({ id: 'run-1', status: 'WAITING' } as any)
         .mockResolvedValueOnce({ id: 'run-1', status: 'CANCELLED' } as any);
       vi.mocked(getBoss).mockReturnValue(null);
-      vi.mocked(prisma.automationRun.updateMany).mockResolvedValue({ count: 1 } as any);
+      vi.mocked(automationRepository.cancelRunIfActive).mockResolvedValue({ count: 1 } as any);
 
       const result = await cancelSingleAutomationRun('run-1');
 
-      expect(prisma.automationRun.updateMany).toHaveBeenCalledWith({
-        where: { id: 'run-1', status: { in: ['RUNNING', 'WAITING'] } },
-        data: { status: 'CANCELLED', completedAt: expect.any(Date) },
-      });
+      expect(automationRepository.cancelRunIfActive).toHaveBeenCalledWith('run-1');
       expect(result).toEqual({ id: 'run-1', status: 'CANCELLED' });
     });
   });
@@ -505,50 +497,48 @@ describe('triggerService', () => {
 
     it('creates a run with responseId null and enqueues the first step for an ACTIVE schedule automation', async () => {
       const automation = makeAutomation({ triggerType: 'schedule', status: 'ACTIVE' });
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(automation as any);
+      vi.mocked(automationRepository.findById).mockResolvedValue(automation as any);
 
       await fireTick('automation-1');
 
-      expect(prisma.automationRun.create).toHaveBeenCalledWith({
-        data: {
-          id: 'generated-run-id',
-          automationId: automation.id,
-          responseId: null,
-          automationVersion: automation.version,
-          graphSnapshot: automation.graph,
-          status: 'RUNNING',
-          context: expect.objectContaining({
-            triggerData: {},
-            formId: 'form-1',
-            organizationId: 'org-1',
-            trigger: { scheduledAt: expect.any(String) },
-          }),
-        },
+      expect(automationRepository.createRun).toHaveBeenCalledWith({
+        id: 'generated-run-id',
+        automationId: automation.id,
+        responseId: null,
+        automationVersion: automation.version,
+        graphSnapshot: automation.graph,
+        status: 'RUNNING',
+        context: expect.objectContaining({
+          triggerData: {},
+          formId: 'form-1',
+          organizationId: 'org-1',
+          trigger: { scheduledAt: expect.any(String) },
+        }),
       });
       expect(enqueueFirstStep).toHaveBeenCalledWith({ id: 'generated-run-id' });
     });
 
     it('skips a tick when the automation was paused/deleted concurrently', async () => {
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(
+      vi.mocked(automationRepository.findById).mockResolvedValue(
         makeAutomation({ triggerType: 'schedule', status: 'PAUSED' }) as any
       );
 
       await fireTick('automation-1');
 
-      expect(prisma.automationRun.create).not.toHaveBeenCalled();
+      expect(automationRepository.createRun).not.toHaveBeenCalled();
       expect(enqueueFirstStep).not.toHaveBeenCalled();
     });
 
     it('skips a tick when the automation no longer exists', async () => {
-      vi.mocked(prisma.automation.findUnique).mockResolvedValue(null);
+      vi.mocked(automationRepository.findById).mockResolvedValue(null);
 
       await fireTick('missing-automation');
 
-      expect(prisma.automationRun.create).not.toHaveBeenCalled();
+      expect(automationRepository.createRun).not.toHaveBeenCalled();
     });
 
     it('never throws when the run lookup/creation fails', async () => {
-      vi.mocked(prisma.automation.findUnique).mockRejectedValue(new Error('db down'));
+      vi.mocked(automationRepository.findById).mockRejectedValue(new Error('db down'));
 
       await fireTick('automation-1');
 

--- a/apps/backend/src/services/automation/engine.ts
+++ b/apps/backend/src/services/automation/engine.ts
@@ -1,8 +1,9 @@
 import type { PgBoss, JobWithMetadata } from 'pg-boss';
 import * as Sentry from '@sentry/node';
-import { Prisma } from '#prisma-client';
 import { generateId, substituteMentions } from '@dculus/utils';
 import { prisma } from '../../lib/prisma.js';
+import { automationRepository, createAutomationRepository } from '../../repositories/index.js';
+import { withPrisma } from '../../repositories/baseRepository.js';
 import { logger } from '../../lib/logger.js';
 import { getPluginHandler } from '../../plugins/core/registry.js';
 import { createPluginContext } from '../../plugins/core/context.js';
@@ -39,10 +40,7 @@ function findNextNodeId(
 }
 
 async function completeRun(runId: string): Promise<void> {
-  await prisma.automationRun.update({
-    where: { id: runId },
-    data: { status: 'COMPLETED', completedAt: new Date() },
-  });
+  await automationRepository.updateRun(runId, { status: 'COMPLETED', completedAt: new Date() });
 }
 
 async function enqueueStep(
@@ -125,70 +123,22 @@ function mergeStepOutput(context: unknown, nodeId: string, output: any): Automat
 }
 
 /**
- * Builds (without executing) an atomic UPDATE that replaces one node's `data.config` inside a
- * `{ nodes: [...], edges: [...] }` JSON column, leaving every other node untouched. Returns
- * the unresolved `$executeRaw` PrismaPromise so callers can batch it into `$transaction`.
- *
- * Because each single statement's `SET column = jsonb_set(column, ...)` re-reads the row's
- * latest *committed* value at execution time — not a value cached in application memory —
- * two concurrent writes targeting DIFFERENT nodes in the same graph correctly compose:
- * Postgres serializes the two UPDATEs (the second waits for the first to commit, then
- * evaluates against its result), so neither writer's change is lost to the other.
- *
- * This does NOT protect two concurrent *runs* writing to the SAME node from each other. Each
- * run computes its own full replacement `data.config` from whatever it read when its own
- * execution started; if two runs of the same automation both reach the "auto-create
- * spreadsheet/workbook" branch for the same action node before either has persisted an
- * id, each creates its own resource and whichever write lands last wins — the other run's
- * newly created spreadsheet/workbook is silently orphaned (created, but never referenced
- * again). Accepted as a narrow edge case for now: it can only surface on an action's very
- * first-ever execution, and no response data is lost (every run's row still lands in *some*
- * spreadsheet). Closing it fully would mean serializing the auto-create branch itself — e.g.
- * a per-node advisory lock or `SELECT ... FOR UPDATE` before that branch runs — not just this
- * config write.
- */
-function jsonSetNodeConfigQuery(
-  table: 'automation' | 'automation_run',
-  column: 'graph' | 'graphSnapshot',
-  rowId: string,
-  nodeId: string,
-  config: PluginConfig
-) {
-  const tableIdent = Prisma.raw(`"${table}"`);
-  const columnIdent = Prisma.raw(`"${column}"`);
-  const configJson = JSON.stringify(config);
-
-  return prisma.$executeRaw(Prisma.sql`
-    UPDATE ${tableIdent}
-    SET ${columnIdent} = jsonb_set(
-      ${columnIdent},
-      '{nodes}',
-      (
-        SELECT COALESCE(jsonb_agg(
-          CASE WHEN elem->>'id' = ${nodeId}
-            THEN jsonb_set(elem, '{data,config}', ${configJson}::jsonb, true)
-            ELSE elem
-          END
-        ), '[]'::jsonb)
-        FROM jsonb_array_elements(${columnIdent}->'nodes') AS elem
-      )
-    )
-    WHERE id = ${rowId}
-  `);
-}
-
-/**
  * Persists an action-node handler's updated config (auto-created spreadsheet/workbook ID,
  * refreshed OAuth token, etc.) for the Automations system — see `PluginContext.updatePluginConfig`
  * for why handlers can't just write to a `FormPlugin` row here.
  *
- * Writes to two places, both inside one Prisma `$transaction` so they can't diverge if one
+ * Writes to two places, both inside one Prisma transaction so they can't diverge if one
  * write fails after the other succeeds:
  *  - `AutomationRun.graphSnapshot` for THIS run, so a retry after a transient failure (e.g.
  *    the workbook was created but the network dropped before this write) sees the
  *    already-created workbook/spreadsheet instead of creating a duplicate.
  *  - `Automation.graph`, the live graph, so the NEXT run — which snapshots fresh from this
  *    column — reuses the same workbook/spreadsheet and refreshed token too.
+ *
+ * Uses the callback-style `prisma.$transaction(async (tx) => ...)` form (rather than
+ * array-style batching) so both writes share one interactive transaction via a
+ * transaction-scoped repository, per the standard convention — see formService.ts
+ * `createForm()`.
  */
 async function updateAutomationNodeConfig(
   automationId: string,
@@ -196,10 +146,11 @@ async function updateAutomationNodeConfig(
   nodeId: string,
   config: PluginConfig
 ): Promise<void> {
-  await prisma.$transaction([
-    jsonSetNodeConfigQuery('automation', 'graph', automationId, nodeId, config),
-    jsonSetNodeConfigQuery('automation_run', 'graphSnapshot', runId, nodeId, config),
-  ]);
+  await prisma.$transaction(async (tx) => {
+    const txRepo = createAutomationRepository(withPrisma(tx as any));
+    await txRepo.setNodeConfigInGraph(automationId, nodeId, config as any);
+    await txRepo.setNodeConfigInRunSnapshot(runId, nodeId, config as any);
+  });
 }
 
 async function handleDelayNode(
@@ -220,17 +171,15 @@ async function handleDelayNode(
   if (isTest) {
     // Test runs (testAutomation mutation, #195) fast-forward delay nodes instead of
     // scheduling with startAfter, so the user sees end-to-end results immediately.
-    await prisma.automationStepRun.create({
-      data: {
-        id: generateId(),
-        runId: run.id,
-        nodeId: node.id,
-        nodeType: 'delay',
-        status: 'SKIPPED',
-        output: { fastForwarded: true, requestedDelayMs: requestedMs },
-        attempt: 1,
-        finishedAt: new Date(),
-      },
+    await automationRepository.createStepRun({
+      id: generateId(),
+      runId: run.id,
+      nodeId: node.id,
+      nodeType: 'delay',
+      status: 'SKIPPED',
+      output: { fastForwarded: true, requestedDelayMs: requestedMs },
+      attempt: 1,
+      finishedAt: new Date(),
     });
 
     if (!nextNodeId) {
@@ -238,25 +187,20 @@ async function handleDelayNode(
       return;
     }
 
-    await prisma.automationRun.update({
-      where: { id: run.id },
-      data: { currentNodeId: nextNodeId },
-    });
+    await automationRepository.updateRun(run.id, { currentNodeId: nextNodeId });
     await enqueueStep(run.id, nextNodeId, graph);
     return;
   }
 
-  await prisma.automationStepRun.create({
-    data: {
-      id: generateId(),
-      runId: run.id,
-      nodeId: node.id,
-      nodeType: 'delay',
-      status: 'SUCCESS',
-      output: { delayUntil: delayUntil.toISOString(), capped: delayMs < requestedMs },
-      attempt: 1,
-      finishedAt: new Date(),
-    },
+  await automationRepository.createStepRun({
+    id: generateId(),
+    runId: run.id,
+    nodeId: node.id,
+    nodeType: 'delay',
+    status: 'SUCCESS',
+    output: { delayUntil: delayUntil.toISOString(), capped: delayMs < requestedMs },
+    attempt: 1,
+    finishedAt: new Date(),
   });
 
   if (!nextNodeId) {
@@ -264,10 +208,7 @@ async function handleDelayNode(
     return;
   }
 
-  await prisma.automationRun.update({
-    where: { id: run.id },
-    data: { status: 'WAITING', currentNodeId: nextNodeId },
-  });
+  await automationRepository.updateRun(run.id, { status: 'WAITING', currentNodeId: nextNodeId });
   await enqueueStep(run.id, nextNodeId, graph, delayUntil);
 }
 
@@ -281,17 +222,15 @@ async function handleConditionNode(
   const branch: 'true' | 'false' = result ? 'true' : 'false';
   const nextNodeId = findNextNodeId(graph, node.id, branch);
 
-  await prisma.automationStepRun.create({
-    data: {
-      id: generateId(),
-      runId: run.id,
-      nodeId: node.id,
-      nodeType: 'condition',
-      status: 'SUCCESS',
-      output: { result, branch: nextNodeId ? branch : 'end' },
-      attempt: 1,
-      finishedAt: new Date(),
-    },
+  await automationRepository.createStepRun({
+    id: generateId(),
+    runId: run.id,
+    nodeId: node.id,
+    nodeType: 'condition',
+    status: 'SUCCESS',
+    output: { result, branch: nextNodeId ? branch : 'end' },
+    attempt: 1,
+    finishedAt: new Date(),
   });
 
   if (!nextNodeId) {
@@ -299,7 +238,7 @@ async function handleConditionNode(
     return;
   }
 
-  await prisma.automationRun.update({ where: { id: run.id }, data: { currentNodeId: nextNodeId } });
+  await automationRepository.updateRun(run.id, { currentNodeId: nextNodeId });
   await enqueueStep(run.id, nextNodeId, graph);
 }
 
@@ -307,16 +246,14 @@ async function handleEndNode(
   run: { id: string },
   node: Extract<AutomationNode, { type: 'end' }>
 ): Promise<void> {
-  await prisma.automationStepRun.create({
-    data: {
-      id: generateId(),
-      runId: run.id,
-      nodeId: node.id,
-      nodeType: 'end',
-      status: 'SUCCESS',
-      attempt: 1,
-      finishedAt: new Date(),
-    },
+  await automationRepository.createStepRun({
+    id: generateId(),
+    runId: run.id,
+    nodeId: node.id,
+    nodeType: 'end',
+    status: 'SUCCESS',
+    attempt: 1,
+    finishedAt: new Date(),
   });
   await completeRun(run.id);
 }
@@ -337,29 +274,21 @@ async function handleActionNode(
   const attempt = job.retryCount + 1;
 
   if (run.automation.status !== 'ACTIVE') {
-    await prisma.automationStepRun.create({
-      data: {
-        id: generateId(),
-        runId: run.id,
-        nodeId: node.id,
-        nodeType,
-        status: 'SKIPPED',
-        errorMessage: `Automation is ${run.automation.status}, not ACTIVE`,
-        attempt: 1,
-        finishedAt: new Date(),
-      },
+    await automationRepository.createStepRun({
+      id: generateId(),
+      runId: run.id,
+      nodeId: node.id,
+      nodeType,
+      status: 'SKIPPED',
+      errorMessage: `Automation is ${run.automation.status}, not ACTIVE`,
+      attempt: 1,
+      finishedAt: new Date(),
     });
-    await prisma.automationRun.update({
-      where: { id: run.id },
-      data: { status: 'CANCELLED', completedAt: new Date() },
-    });
+    await automationRepository.updateRun(run.id, { status: 'CANCELLED', completedAt: new Date() });
     return;
   }
 
-  await prisma.automationRun.update({
-    where: { id: run.id },
-    data: { status: 'RUNNING', currentNodeId: node.id },
-  });
+  await automationRepository.updateRun(run.id, { status: 'RUNNING', currentNodeId: node.id });
 
   const event = buildPluginEvent(run.automation, run);
   const substitutedConfig = substituteConfigMentions(config, event.data) as PluginConfig;
@@ -378,22 +307,19 @@ async function handleActionNode(
       )
     );
 
-    await prisma.automationStepRun.create({
-      data: {
-        id: generateId(),
-        runId: run.id,
-        nodeId: node.id,
-        nodeType,
-        status: 'SUCCESS',
-        output: result ?? {},
-        attempt,
-        finishedAt: new Date(),
-      },
+    await automationRepository.createStepRun({
+      id: generateId(),
+      runId: run.id,
+      nodeId: node.id,
+      nodeType,
+      status: 'SUCCESS',
+      output: result ?? {},
+      attempt,
+      finishedAt: new Date(),
     });
 
-    await prisma.automationRun.update({
-      where: { id: run.id },
-      data: { context: mergeStepOutput(run.context, node.id, result) },
+    await automationRepository.updateRun(run.id, {
+      context: mergeStepOutput(run.context, node.id, result),
     });
 
     const nextNodeId = findNextNodeId(graph, node.id);
@@ -406,25 +332,20 @@ async function handleActionNode(
     Sentry.captureException(error);
     logger.error(`[Automation Engine] Action step failed: run=${run.id} node=${node.id}`, error);
 
-    await prisma.automationStepRun.create({
-      data: {
-        id: generateId(),
-        runId: run.id,
-        nodeId: node.id,
-        nodeType,
-        status: 'FAILED',
-        errorMessage: error?.message || 'Unknown error',
-        attempt,
-        finishedAt: new Date(),
-      },
+    await automationRepository.createStepRun({
+      id: generateId(),
+      runId: run.id,
+      nodeId: node.id,
+      nodeType,
+      status: 'FAILED',
+      errorMessage: error?.message || 'Unknown error',
+      attempt,
+      finishedAt: new Date(),
     });
 
     const isFinalAttempt = job.retryLimit <= job.retryCount;
     if (isFinalAttempt) {
-      await prisma.automationRun.update({
-        where: { id: run.id },
-        data: { status: 'FAILED', completedAt: new Date() },
-      });
+      await automationRepository.updateRun(run.id, { status: 'FAILED', completedAt: new Date() });
       return;
     }
 
@@ -456,9 +377,7 @@ async function reconcileSuccessor(
   // If the successor already has its own step run, it has executed (or progressed further) —
   // the crash window has already closed safely and re-enqueuing now would risk a duplicate
   // execution once pg-boss's singletonKey slot has freed up behind a completed job.
-  const successorStarted = await prisma.automationStepRun.findFirst({
-    where: { runId: run.id, nodeId: nextNodeId },
-  });
+  const successorStarted = await automationRepository.findStepRunByNode(run.id, nextNodeId);
   if (successorStarted) {
     return;
   }
@@ -494,9 +413,8 @@ async function reconcileSuccessStep(
       // step output rather than the (unavailable) live handler result.
       const context = (run.context as AutomationRunContext) ?? {};
       if (!(node.id in (context.stepOutputs ?? {}))) {
-        await prisma.automationRun.update({
-          where: { id: run.id },
-          data: { context: mergeStepOutput(run.context, node.id, existingSuccess.output) },
+        await automationRepository.updateRun(run.id, {
+          context: mergeStepOutput(run.context, node.id, existingSuccess.output),
         });
       }
       await reconcileSuccessor(run, findNextNodeId(graph, node.id), graph);
@@ -525,37 +443,28 @@ async function recordUnhandleableStepFailure(
   // Single transaction: a crash between these two writes would otherwise leave the run
   // non-terminal, causing redelivery to hit this same branch again and insert a duplicate
   // FAILED step run for the same node.
-  await prisma.$transaction([
-    prisma.automationStepRun.create({
-      data: {
-        id: generateId(),
-        runId,
-        nodeId,
-        nodeType,
-        status: 'FAILED',
-        errorMessage: message,
-        attempt,
-        finishedAt: new Date(),
-      },
-    }),
-    prisma.automationRun.update({
-      where: { id: runId },
-      data: { status: 'FAILED', completedAt: new Date() },
-    }),
-  ]);
+  await prisma.$transaction(async (tx) => {
+    const txRepo = createAutomationRepository(withPrisma(tx as any));
+    await txRepo.createStepRun({
+      id: generateId(),
+      runId,
+      nodeId,
+      nodeType,
+      status: 'FAILED',
+      errorMessage: message,
+      attempt,
+      finishedAt: new Date(),
+    });
+    await txRepo.updateRun(runId, { status: 'FAILED', completedAt: new Date() });
+  });
 }
 
 export async function executeAutomationStep(job: JobWithMetadata<AutomationStepJobData>): Promise<void> {
   const { runId, nodeId } = job.data;
 
-  const existingSuccess = await prisma.automationStepRun.findFirst({
-    where: { runId, nodeId, status: 'SUCCESS' },
-  });
+  const existingSuccess = await automationRepository.findSuccessStepRun(runId, nodeId);
 
-  const run = await prisma.automationRun.findUnique({
-    where: { id: runId },
-    include: { automation: true },
-  });
+  const run = await automationRepository.findRunByIdWithAutomation(runId);
   if (!run) {
     logger.error(`[Automation Engine] Run ${runId} not found — dropping job`);
     return;

--- a/apps/backend/src/services/automation/triggerService.ts
+++ b/apps/backend/src/services/automation/triggerService.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/node';
 import type { Prisma } from '#prisma-client';
 import { generateId } from '@dculus/utils';
-import { prisma } from '../../lib/prisma.js';
+import { automationRepository } from '../../repositories/index.js';
 import { logger } from '../../lib/logger.js';
 import { getEventEmitter } from '../../plugins/core/events.js';
 import type { PluginEvent } from '../../plugins/core/types.js';
@@ -42,9 +42,7 @@ async function handlePluginEvent(event: PluginEvent): Promise<void> {
   // via its own writes.
   if (event.type === 'response.edited' && event.data?.sourceRunId) return;
 
-  const automations = await prisma.automation.findMany({
-    where: { formId: event.formId, status: 'ACTIVE', triggerType: event.type },
-  });
+  const automations = await automationRepository.listActiveByFormAndTrigger(event.formId, event.type);
 
   for (const automation of automations) {
     try {
@@ -54,16 +52,14 @@ async function handlePluginEvent(event: PluginEvent): Promise<void> {
         organizationId: event.organizationId,
       };
 
-      const run = await prisma.automationRun.create({
-        data: {
-          id: generateId(),
-          automationId: automation.id,
-          responseId: event.data?.responseId ?? null,
-          automationVersion: automation.version,
-          graphSnapshot: automation.graph as Prisma.InputJsonValue,
-          status: 'RUNNING',
-          context: context as Prisma.InputJsonValue,
-        },
+      const run = await automationRepository.createRun({
+        id: generateId(),
+        automationId: automation.id,
+        responseId: event.data?.responseId ?? null,
+        automationVersion: automation.version,
+        graphSnapshot: automation.graph as Prisma.InputJsonValue,
+        status: 'RUNNING',
+        context: context as Prisma.InputJsonValue,
       });
 
       await enqueueFirstStep(run);
@@ -84,10 +80,7 @@ async function handlePluginEvent(event: PluginEvent): Promise<void> {
  */
 export async function cancelRunsForAutomation(automationId: string, reason: string): Promise<void> {
   try {
-    const runs = await prisma.automationRun.findMany({
-      where: { automationId, status: { in: ['RUNNING', 'WAITING'] } },
-      select: { id: true },
-    });
+    const runs = await automationRepository.listActiveRunsByAutomation(automationId);
 
     if (runs.length === 0) return;
 
@@ -117,10 +110,7 @@ export async function cancelRunsForAutomation(automationId: string, reason: stri
     // Scoped to the exact run ids captured above (not re-queried by status) so a run
     // created for this automation after the findMany snapshot — e.g. a new submission
     // arriving mid-cancellation — is never swept into this update.
-    await prisma.automationRun.updateMany({
-      where: { id: { in: runs.map((run) => run.id) } },
-      data: { status: 'CANCELLED', completedAt: new Date() },
-    });
+    await automationRepository.cancelRunsByIds(runs.map((run) => run.id));
 
     logger.info(
       `[Automation Triggers] Cancelled ${runs.length} run(s) for automation ${automationId}: ${reason}`
@@ -137,7 +127,7 @@ export async function cancelRunsForAutomation(automationId: string, reason: stri
  * returned unchanged rather than re-cancelled. Returns null if the run doesn't exist.
  */
 export async function cancelSingleAutomationRun(runId: string) {
-  const run = await prisma.automationRun.findUnique({ where: { id: runId } });
+  const run = await automationRepository.findRunById(runId);
   if (!run) return null;
   if (run.status !== 'RUNNING' && run.status !== 'WAITING') {
     return run;
@@ -161,16 +151,13 @@ export async function cancelSingleAutomationRun(runId: string) {
   // id: the run may have reached a terminal state concurrently (e.g. the engine completed
   // it) while the pg-boss cancel above was in flight, and this must not overwrite that
   // outcome with a stale CANCELLED.
-  const { count } = await prisma.automationRun.updateMany({
-    where: { id: runId, status: { in: ['RUNNING', 'WAITING'] } },
-    data: { status: 'CANCELLED', completedAt: new Date() },
-  });
+  const { count } = await automationRepository.cancelRunIfActive(runId);
   if (count === 0) {
     logger.info(
       `[Automation Triggers] Run ${runId} reached a terminal state concurrently — skipping cancellation write`
     );
   }
-  return prisma.automationRun.findUnique({ where: { id: runId } });
+  return automationRepository.findRunById(runId);
 }
 
 /**
@@ -216,7 +203,7 @@ export async function unscheduleAutomationCron(automationId: string): Promise<vo
  */
 async function handleScheduledTick(automationId: string): Promise<void> {
   try {
-    const automation = await prisma.automation.findUnique({ where: { id: automationId } });
+    const automation = await automationRepository.findById(automationId);
     if (!automation || automation.status !== 'ACTIVE' || automation.triggerType !== 'schedule') {
       logger.info(
         `[Automation Triggers] Skipping scheduled tick for ${automationId} — automation is not an ACTIVE schedule automation`
@@ -232,16 +219,14 @@ async function handleScheduledTick(automationId: string): Promise<void> {
       trigger: { scheduledAt: scheduledAt.toISOString() },
     };
 
-    const run = await prisma.automationRun.create({
-      data: {
-        id: generateId(),
-        automationId: automation.id,
-        responseId: null,
-        automationVersion: automation.version,
-        graphSnapshot: automation.graph as Prisma.InputJsonValue,
-        status: 'RUNNING',
-        context: context as Prisma.InputJsonValue,
-      },
+    const run = await automationRepository.createRun({
+      id: generateId(),
+      automationId: automation.id,
+      responseId: null,
+      automationVersion: automation.version,
+      graphSnapshot: automation.graph as Prisma.InputJsonValue,
+      status: 'RUNNING',
+      context: context as Prisma.InputJsonValue,
     });
 
     await enqueueFirstStep(run);

--- a/apps/backend/src/services/automationService.ts
+++ b/apps/backend/src/services/automationService.ts
@@ -1,0 +1,295 @@
+import { createGraphQLError } from '#graphql-errors';
+import { GRAPHQL_ERROR_CODES } from '@dculus/types/graphql.js';
+import { generateId } from '@dculus/utils';
+import { automationRepository, responseRepository } from '../repositories/index.js';
+import { getAvailablePluginTypes } from '../plugins/core/registry.js';
+import { validateAutomationGraph } from './automation/graphValidator.js';
+import { enqueueFirstStep } from './automation/engine.js';
+import {
+  cancelRunsForAutomation,
+  cancelSingleAutomationRun,
+  scheduleAutomationCron,
+  unscheduleAutomationCron,
+} from './automation/triggerService.js';
+import { isValidCronExpression, isValidTimezone } from './automation/cronValidator.js';
+import type { AutomationGraph, AutomationRunContext } from './automation/types.js';
+
+/**
+ * CRUD + orchestration service for the Automations system (#195). Distinct from
+ * `services/automation/engine.ts` (the execution engine) and `triggerService.ts`
+ * (trigger-time run creation) — this file owns list/get/create/update/delete for
+ * `Automation` records plus run/step-run reads, backing the automations.ts resolver.
+ */
+
+const AUTOMATION_STATUSES = ['DRAFT', 'ACTIVE', 'PAUSED'] as const;
+const TRIGGER_TYPES = ['form.submitted', 'response.edited', 'schedule'] as const;
+
+/**
+ * Validates `triggerConfig` for a `schedule`-triggerType automation on save/activate (#201) —
+ * cron is required, must parse as a standard 5-field expression, and an optional timezone must
+ * be a real IANA identifier.
+ */
+function assertValidScheduleTriggerConfig(
+  triggerConfig: any
+): asserts triggerConfig is { cron: string; timezone?: string } {
+  if (!triggerConfig || typeof triggerConfig !== 'object') {
+    throw createGraphQLError(
+      'Scheduled automations require a triggerConfig with a cron expression',
+      GRAPHQL_ERROR_CODES.BAD_USER_INPUT
+    );
+  }
+  if (!isValidCronExpression(triggerConfig.cron)) {
+    throw createGraphQLError(
+      `Invalid cron expression: ${triggerConfig.cron}`,
+      GRAPHQL_ERROR_CODES.BAD_USER_INPUT
+    );
+  }
+  if (triggerConfig.timezone !== undefined && !isValidTimezone(triggerConfig.timezone)) {
+    throw createGraphQLError(
+      `Invalid timezone: ${triggerConfig.timezone}`,
+      GRAPHQL_ERROR_CODES.BAD_USER_INPUT
+    );
+  }
+}
+
+/** DRAFT default graph for a brand-new automation: a single trigger wired to a single end. */
+function buildDefaultGraph(triggerType: string): AutomationGraph {
+  const triggerId = generateId();
+  const endId = generateId();
+  return {
+    nodes: [
+      { id: triggerId, type: 'trigger', data: { triggerType } },
+      { id: endId, type: 'end' },
+    ],
+    edges: [{ id: generateId(), source: triggerId, target: endId }],
+  };
+}
+
+export async function getAutomationById(id: string) {
+  const automation = await automationRepository.findById(id);
+  if (!automation) {
+    throw createGraphQLError('Automation not found', GRAPHQL_ERROR_CODES.AUTOMATION_NOT_FOUND);
+  }
+  return automation;
+}
+
+export async function listAutomationsByForm(formId: string) {
+  return automationRepository.listByFormId(formId);
+}
+
+export async function createAutomation(params: {
+  formId: string;
+  organizationId: string;
+  name: string;
+  triggerType: string;
+  createdBy: string;
+}) {
+  const { formId, organizationId, name, triggerType, createdBy } = params;
+
+  if (!name || name.trim().length === 0) {
+    throw createGraphQLError('Automation name is required', GRAPHQL_ERROR_CODES.BAD_USER_INPUT);
+  }
+  if (!TRIGGER_TYPES.includes(triggerType as (typeof TRIGGER_TYPES)[number])) {
+    throw createGraphQLError(
+      `Invalid trigger type: ${triggerType}. Supported types: ${TRIGGER_TYPES.join(', ')}`,
+      GRAPHQL_ERROR_CODES.BAD_USER_INPUT
+    );
+  }
+
+  return automationRepository.createAutomation({
+    id: generateId(),
+    formId,
+    organizationId,
+    name,
+    status: 'DRAFT',
+    triggerType,
+    graph: buildDefaultGraph(triggerType) as any,
+    version: 1,
+    createdBy,
+  });
+}
+
+/**
+ * Updates name/graph/triggerConfig on an already-fetched `automation` record. Validates the
+ * graph against the same bar as activation when the automation is already ACTIVE (an active
+ * automation is already live, so a new graph must not bypass activation-time rules such as the
+ * schedule automation response-dependent-node ban), and re-schedules the cron immediately when
+ * an ACTIVE schedule automation's triggerConfig changes.
+ */
+export async function updateAutomation(
+  automation: { id: string; status: string; triggerType: string; graph: unknown },
+  updates: { name?: string; graph?: any; triggerConfig?: any }
+) {
+  const { name, graph, triggerConfig } = updates;
+  const data: Record<string, any> = { updatedAt: new Date() };
+
+  if (name !== undefined) data.name = name;
+  if (triggerConfig !== undefined) {
+    if (automation.triggerType === 'schedule') {
+      assertValidScheduleTriggerConfig(triggerConfig);
+    }
+    data.triggerConfig = triggerConfig;
+  }
+  if (graph !== undefined) {
+    if (automation.status === 'ACTIVE') {
+      const result = validateAutomationGraph(graph, {
+        pluginTypes: getAvailablePluginTypes(),
+        triggerType: automation.triggerType,
+      });
+      if (!result.valid) {
+        throw createGraphQLError(
+          'Automation graph is invalid and cannot be saved while this automation is active',
+          GRAPHQL_ERROR_CODES.AUTOMATION_INVALID_GRAPH,
+          { extensions: { validationErrors: result.errors } }
+        );
+      }
+    }
+
+    data.graph = graph;
+    const graphChanged = JSON.stringify(graph) !== JSON.stringify(automation.graph);
+    if (graphChanged) {
+      data.version = { increment: 1 };
+    }
+  }
+
+  const updated = await automationRepository.updateAutomation(automation.id, data);
+
+  // Re-schedule immediately so an ACTIVE scheduled automation picks up a new cron/timezone
+  // without requiring pause+reactivate — boss.schedule upserts by (queue, key).
+  if (automation.triggerType === 'schedule' && triggerConfig !== undefined && updated.status === 'ACTIVE') {
+    await scheduleAutomationCron(updated.id, triggerConfig.cron, triggerConfig.timezone);
+  }
+
+  return updated;
+}
+
+export async function setAutomationStatus(
+  automation: { id: string; triggerType: string; graph: unknown; triggerConfig: unknown },
+  status: string
+) {
+  if (!AUTOMATION_STATUSES.includes(status as (typeof AUTOMATION_STATUSES)[number])) {
+    throw createGraphQLError(
+      `Invalid status: ${status}. Supported statuses: ${AUTOMATION_STATUSES.join(', ')}`,
+      GRAPHQL_ERROR_CODES.BAD_USER_INPUT
+    );
+  }
+
+  if (status === 'ACTIVE') {
+    const result = validateAutomationGraph(automation.graph, {
+      pluginTypes: getAvailablePluginTypes(),
+      triggerType: automation.triggerType,
+    });
+    if (!result.valid) {
+      throw createGraphQLError(
+        'Automation graph is invalid and cannot be activated',
+        GRAPHQL_ERROR_CODES.AUTOMATION_INVALID_GRAPH,
+        { extensions: { validationErrors: result.errors } }
+      );
+    }
+    if (automation.triggerType === 'schedule') {
+      assertValidScheduleTriggerConfig(automation.triggerConfig);
+    }
+  }
+
+  const updated = await automationRepository.updateAutomation(automation.id, {
+    status,
+    updatedAt: new Date(),
+  });
+
+  // Schedule/unschedule lifecycle (#201) — boss.schedule upserts, boss.unschedule is a
+  // no-op if nothing is scheduled, so this is safe regardless of prior state.
+  if (automation.triggerType === 'schedule') {
+    if (status === 'ACTIVE') {
+      const { cron, timezone } = automation.triggerConfig as { cron: string; timezone?: string };
+      await scheduleAutomationCron(automation.id, cron, timezone);
+    } else {
+      await unscheduleAutomationCron(automation.id);
+    }
+  }
+
+  return updated;
+}
+
+export async function deleteAutomation(automation: { id: string; triggerType: string }) {
+  if (automation.triggerType === 'schedule') {
+    await unscheduleAutomationCron(automation.id);
+  }
+  await cancelRunsForAutomation(automation.id, 'automation deleted');
+  await automationRepository.deleteAutomation(automation.id);
+  return true;
+}
+
+export async function testAutomation(automation: {
+  id: string;
+  formId: string;
+  version: number;
+  graph: unknown;
+}, responseId?: string) {
+  const response = responseId
+    ? await responseRepository.findFirst({
+        where: { id: responseId, formId: automation.formId, deletedAt: null },
+      })
+    : await responseRepository.findFirst({
+        where: { formId: automation.formId, deletedAt: null },
+        orderBy: { submittedAt: 'desc' },
+      });
+
+  if (!response) {
+    throw createGraphQLError(
+      'No response available to test this automation with',
+      GRAPHQL_ERROR_CODES.RESPONSE_NOT_FOUND
+    );
+  }
+
+  const context: AutomationRunContext = {
+    test: true,
+    triggerData: {
+      ...(response.data as Record<string, any>),
+      responseId: response.id,
+      submittedAt: response.submittedAt.toISOString(),
+      isPreview: false,
+    },
+  };
+
+  const run = await automationRepository.createRun({
+    id: generateId(),
+    automationId: automation.id,
+    responseId: response.id,
+    automationVersion: automation.version,
+    graphSnapshot: automation.graph as any,
+    status: 'RUNNING',
+    context: context as any,
+  });
+
+  await enqueueFirstStep(run);
+
+  return run;
+}
+
+export async function listAutomationRuns(
+  automationId: string,
+  limit?: number,
+  offset?: number
+) {
+  return automationRepository.listRunsByAutomation(automationId, { limit, offset });
+}
+
+export async function getAutomationRunWithAutomation(id: string) {
+  const run = await automationRepository.findRunByIdWithAutomation(id);
+  if (!run) {
+    throw createGraphQLError('Automation run not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
+  }
+  return run;
+}
+
+export async function cancelAutomationRun(runId: string) {
+  const cancelled = await cancelSingleAutomationRun(runId);
+  if (!cancelled) {
+    throw createGraphQLError('Automation run not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
+  }
+  return cancelled;
+}
+
+export async function listStepRuns(runId: string) {
+  return automationRepository.listStepRunsByRun(runId);
+}


### PR DESCRIPTION
## Summary

Implements Story 06 of the Repository Pattern Rollout epic (#245): adds a new `automationRepository` and `automationService`, and routes `automations.ts`, `services/automation/triggerService.ts`, and `services/automation/engine.ts` through them instead of calling Prisma directly.

Closes #252.

- **`automationRepository.ts`** — covers `Automation` / `AutomationRun` / `AutomationStepRun`, including the two raw `jsonb_set` node-config writes as repository methods.
- **`automationService.ts`** (new) — CRUD/orchestration service: list/get/create/update/delete automations, run/step-run reads, graph + cron validation, version bumping. The resolver now only handles auth/permission orchestration and delegates business logic here.
- **`automations.ts` resolver** — all 13 direct Prisma call sites replaced with `automationService` calls.
- **`triggerService.ts` / `engine.ts`** — all direct Prisma calls replaced with `automationRepository`. The two array-style `prisma.$transaction([...])` batches (node-config jsonb_set writes, and the unhandleable-failure step+run write) were refactored to callback-style `prisma.$transaction(async (tx) => ...)` with a tx-scoped repository, matching the epic's canonical convention from `formService.ts` — atomicity is preserved (interactive transaction, not `Promise.all`).

## Test plan

- [x] `apps/backend/src/repositories/__tests__/automationRepository.test.ts` — new, 18 tests, mocked Prisma
- [x] `apps/backend/src/services/__tests__/automationService.test.ts` — new, 36 tests, 100% statement/branch/function coverage on the file
- [x] Rewrote `automations.test.ts`, `triggerService.test.ts`, `engine.test.ts` to mock the service/repository layer instead of raw Prisma
- [x] `grep -n "prisma\."` on the three owned files shows only `prisma.$transaction` in `engine.ts` (same pattern as the epic's reference implementation, `formService.ts`)
- [x] `pnpm --filter backend exec tsc --noEmit` clean
- [x] `pnpm test:unit` — 103 files / 2928 tests passing
- [x] Full coverage run (`vitest run --coverage`) passes the repo's global thresholds
- [ ] Cucumber integration suite for automations (`test/integration/features/automations*.feature`) — not run in this session (would require a local disposable Postgres via docker/colima instead of the shared dev DB); recommend running in CI before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)