### PR TITLE
Story 04: PDF Templates — pdfTemplateRepository + pdfTemplateService CRUD

### DIFF
--- a/apps/backend/src/graphql/resolvers/__tests__/pdfTemplates.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/pdfTemplates.test.ts
@@ -4,6 +4,8 @@ import * as betterAuthMiddleware from '../../../middleware/better-auth-middlewar
 import * as formSharingResolvers from '../formSharing.js';
 import { prisma } from '../../../lib/prisma.js';
 import { generatePdfForResponse } from '../../../services/pdfTemplateService.js';
+import { getFormById } from '../../../services/formService.js';
+import { getResponseById } from '../../../services/responseService.js';
 
 vi.mock('../../../middleware/better-auth-middleware.js');
 vi.mock('../formSharing.js');
@@ -16,12 +18,6 @@ vi.mock('../../../lib/prisma.js', () => ({
       update: vi.fn(),
       delete: vi.fn(),
       count: vi.fn().mockResolvedValue(0),
-    },
-    response: {
-      findUnique: vi.fn(),
-    },
-    form: {
-      findUnique: vi.fn(),
     },
   },
 }));
@@ -44,6 +40,18 @@ vi.mock('../../../services/pdfTemplateService.js', async () => {
     ...actual,
     generatePdfForResponse: vi.fn(),
   };
+});
+vi.mock('../../../services/formService.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../services/formService.js')>(
+    '../../../services/formService.js'
+  );
+  return { ...actual, getFormById: vi.fn() };
+});
+vi.mock('../../../services/responseService.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../services/responseService.js')>(
+    '../../../services/responseService.js'
+  );
+  return { ...actual, getResponseById: vi.fn() };
 });
 vi.mock('@dculus/utils', async () => {
   const actual = await vi.importActual<typeof import('@dculus/utils')>('@dculus/utils');
@@ -174,13 +182,12 @@ describe('PDF Templates Resolvers', () => {
         template: { basePdf: BLANK_A4, schemas: [[]] },
         name: 'Certificate',
       } as any);
-      vi.mocked(prisma.response.findUnique).mockResolvedValue({
+      vi.mocked(getResponseById).mockResolvedValue({
         id: 'response-1',
         formId: 'form-123',
-        deletedAt: null,
         data: {},
       } as any);
-      vi.mocked(prisma.form.findUnique).mockResolvedValue({
+      vi.mocked(getFormById).mockResolvedValue({
         formSchema: { pages: [] },
       } as any);
       vi.mocked(generatePdfForResponse).mockRejectedValue(

--- a/apps/backend/src/graphql/resolvers/pdfTemplates.ts
+++ b/apps/backend/src/graphql/resolvers/pdfTemplates.ts
@@ -2,7 +2,6 @@ import { createGraphQLError } from '#graphql-errors';
 import { GRAPHQL_ERROR_CODES } from '@dculus/types/graphql.js';
 import { deserializeFormSchema } from '@dculus/types';
 import { generateId } from '@dculus/utils';
-import { prisma } from '../../lib/prisma.js';
 import { logger } from '../../lib/logger.js';
 import {
   BetterAuthContext,
@@ -19,8 +18,14 @@ import {
   buildPdfFilename,
   buildSampleResponseData,
   coerceAiSampleData,
+  countTemplates,
+  createTemplate,
+  deleteTemplate,
   generatePdfForResponse,
+  getTemplateById,
+  listTemplates,
   stripBasePdf,
+  updateTemplate,
   validatePdfTemplate,
 } from '../../services/pdfTemplateService.js';
 import { generateAiSampleData } from '../../services/aiService.js';
@@ -28,6 +33,8 @@ import {
   checkAITokenBudget,
   recordAITokenUsage,
 } from '../../services/aiUsageService.js';
+import { getFormById } from '../../services/formService.js';
+import { getResponseById } from '../../services/responseService.js';
 
 /**
  * GraphQL Resolvers for PDF Templates (issue #87)
@@ -44,7 +51,7 @@ import {
 const MAX_PDF_TEMPLATES_PER_FORM = 6;
 
 async function getTemplateOrThrow(id: string) {
-  const template = await prisma.pdfTemplate.findUnique({ where: { id } });
+  const template = await getTemplateById(id);
   if (!template) {
     throw createGraphQLError('PDF template not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
   }
@@ -75,10 +82,7 @@ export const pdfTemplatesResolvers = {
         );
       }
 
-      return prisma.pdfTemplate.findMany({
-        where: { formId },
-        orderBy: { createdAt: 'desc' },
-      });
+      return listTemplates(formId);
     },
 
     /**
@@ -146,7 +150,7 @@ export const pdfTemplatesResolvers = {
         throw createGraphQLError('Template name is required', GRAPHQL_ERROR_CODES.BAD_USER_INPUT);
       }
 
-      const existingTemplateCount = await prisma.pdfTemplate.count({ where: { formId: input.formId } });
+      const existingTemplateCount = await countTemplates(input.formId);
       if (existingTemplateCount >= MAX_PDF_TEMPLATES_PER_FORM) {
         throw createGraphQLError(
           `This form already has the maximum of ${MAX_PDF_TEMPLATES_PER_FORM} PDF templates`,
@@ -176,19 +180,17 @@ export const pdfTemplatesResolvers = {
 
       const storedTemplate = stripBasePdf(input.template, hasUploadedPdf);
 
-      return prisma.pdfTemplate.create({
-        data: {
-          id: generateId(),
-          formId: input.formId,
-          name: input.name.trim(),
-          template: storedTemplate,
-          fileKey: input.fileKey ?? null,
-          fileName: input.fileName ?? null,
-          pageCount: Array.isArray(input.template?.schemas)
-            ? Math.max(input.template.schemas.length, 1)
-            : 1,
-          createdById: context.auth.user!.id,
-        },
+      return createTemplate({
+        id: generateId(),
+        formId: input.formId,
+        name: input.name.trim(),
+        template: storedTemplate,
+        fileKey: input.fileKey ?? null,
+        fileName: input.fileName ?? null,
+        pageCount: Array.isArray(input.template?.schemas)
+          ? Math.max(input.template.schemas.length, 1)
+          : 1,
+        createdById: context.auth.user!.id,
       });
     },
 
@@ -247,7 +249,7 @@ export const pdfTemplatesResolvers = {
           : existing.pageCount;
       }
 
-      return prisma.pdfTemplate.update({ where: { id }, data });
+      return updateTemplate(id, data);
     },
 
     /**
@@ -274,7 +276,7 @@ export const pdfTemplatesResolvers = {
         );
       }
 
-      await prisma.pdfTemplate.delete({ where: { id } });
+      await deleteTemplate(id);
 
       // Best-effort cleanup of the base PDF in R2 — the DB row is already gone
       if (existing.fileKey) {
@@ -313,17 +315,12 @@ export const pdfTemplatesResolvers = {
         );
       }
 
-      const response = await prisma.response.findUnique({
-        where: { id: responseId },
-      });
-      if (!response || response.deletedAt || response.formId !== template.formId) {
+      const response = await getResponseById(responseId);
+      if (!response || response.formId !== template.formId) {
         throw createGraphQLError('Response not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
       }
 
-      const form = await prisma.form.findUnique({
-        where: { id: template.formId },
-        select: { formSchema: true },
-      });
+      const form = await getFormById(template.formId);
       if (!form) {
         throw createGraphQLError('Form not found', GRAPHQL_ERROR_CODES.FORM_NOT_FOUND);
       }
@@ -418,10 +415,7 @@ export const pdfTemplatesResolvers = {
         workingTemplate = stripBasePdf(template, !!stored.fileKey);
       }
 
-      const form = await prisma.form.findUnique({
-        where: { id: stored.formId },
-        select: { formSchema: true, organizationId: true, title: true },
-      });
+      const form = await getFormById(stored.formId);
       if (!form) {
         throw createGraphQLError('Form not found', GRAPHQL_ERROR_CODES.FORM_NOT_FOUND);
       }
@@ -429,8 +423,8 @@ export const pdfTemplatesResolvers = {
 
       let responseData: Record<string, any>;
       if (responseId) {
-        const response = await prisma.response.findUnique({ where: { id: responseId } });
-        if (!response || response.deletedAt || response.formId !== stored.formId) {
+        const response = await getResponseById(responseId);
+        if (!response || response.formId !== stored.formId) {
           throw createGraphQLError('Response not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
         }
         responseData = (response.data as Record<string, any>) ?? {};

--- a/apps/backend/src/repositories/__tests__/pdfTemplateRepository.test.ts
+++ b/apps/backend/src/repositories/__tests__/pdfTemplateRepository.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createPdfTemplateRepository } from '../pdfTemplateRepository.js';
+
+const prismaMock = vi.hoisted(() => ({
+  pdfTemplate: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    count: vi.fn().mockResolvedValue(0),
+  },
+}));
+
+vi.mock('../baseRepository.js', () => ({
+  resolvePrisma: () => prismaMock,
+}));
+
+describe('pdfTemplateRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.pdfTemplate.findMany.mockResolvedValue([]);
+    prismaMock.pdfTemplate.findUnique.mockResolvedValue(null);
+    prismaMock.pdfTemplate.create.mockResolvedValue({});
+    prismaMock.pdfTemplate.update.mockResolvedValue({});
+    prismaMock.pdfTemplate.delete.mockResolvedValue({});
+    prismaMock.pdfTemplate.count.mockResolvedValue(0);
+  });
+
+  it('should proxy basic prisma delegate methods', async () => {
+    const repo = createPdfTemplateRepository();
+    const args = { where: { id: 'template-1' } };
+
+    await repo.findMany(args as any);
+    await repo.findUnique(args as any);
+    await repo.create({ data: { id: 'template-1' } } as any);
+    await repo.update({ where: { id: 'template-1' }, data: { name: 'New' } } as any);
+    await repo.delete({ where: { id: 'template-1' } } as any);
+    await repo.count(args as any);
+
+    expect(prismaMock.pdfTemplate.findMany).toHaveBeenCalledWith(args);
+    expect(prismaMock.pdfTemplate.findUnique).toHaveBeenCalledWith(args);
+    expect(prismaMock.pdfTemplate.create).toHaveBeenCalled();
+    expect(prismaMock.pdfTemplate.update).toHaveBeenCalled();
+    expect(prismaMock.pdfTemplate.delete).toHaveBeenCalled();
+    expect(prismaMock.pdfTemplate.count).toHaveBeenCalledWith(args);
+  });
+
+  it('should find a template by id', async () => {
+    const repo = createPdfTemplateRepository();
+    prismaMock.pdfTemplate.findUnique.mockResolvedValueOnce({ id: 'template-1' } as any);
+
+    const result = await repo.findById('template-1');
+
+    expect(prismaMock.pdfTemplate.findUnique).toHaveBeenCalledWith({ where: { id: 'template-1' } });
+    expect(result).toEqual({ id: 'template-1' });
+  });
+
+  it('should list templates for a form, most recent first', async () => {
+    const repo = createPdfTemplateRepository();
+    prismaMock.pdfTemplate.findMany.mockResolvedValueOnce([{ id: 'template-1' }] as any);
+
+    const result = await repo.listByForm('form-1');
+
+    expect(prismaMock.pdfTemplate.findMany).toHaveBeenCalledWith({
+      where: { formId: 'form-1' },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(result).toEqual([{ id: 'template-1' }]);
+  });
+
+  it('should count templates for a form', async () => {
+    const repo = createPdfTemplateRepository();
+    prismaMock.pdfTemplate.count.mockResolvedValueOnce(3);
+
+    const result = await repo.countByForm('form-1');
+
+    expect(prismaMock.pdfTemplate.count).toHaveBeenCalledWith({ where: { formId: 'form-1' } });
+    expect(result).toBe(3);
+  });
+
+  it('should create a template', async () => {
+    const repo = createPdfTemplateRepository();
+    const data = { id: 'template-1', formId: 'form-1', name: 'Test' };
+
+    await repo.createTemplate(data as any);
+
+    expect(prismaMock.pdfTemplate.create).toHaveBeenCalledWith({ data });
+  });
+
+  it('should update a template by id', async () => {
+    const repo = createPdfTemplateRepository();
+    const data = { name: 'Updated' };
+
+    await repo.updateTemplate('template-1', data as any);
+
+    expect(prismaMock.pdfTemplate.update).toHaveBeenCalledWith({
+      where: { id: 'template-1' },
+      data,
+    });
+  });
+
+  it('should delete a template by id', async () => {
+    const repo = createPdfTemplateRepository();
+
+    await repo.deleteTemplate('template-1');
+
+    expect(prismaMock.pdfTemplate.delete).toHaveBeenCalledWith({ where: { id: 'template-1' } });
+  });
+});

--- a/apps/backend/src/repositories/index.ts
+++ b/apps/backend/src/repositories/index.ts
@@ -16,3 +16,4 @@ export * from './aiChatRepository.js';
 export * from './pluginRepository.js';
 export * from './invitationRepository.js';
 export * from './tagRepository.js';
+export * from './pdfTemplateRepository.js';

--- a/apps/backend/src/repositories/pdfTemplateRepository.ts
+++ b/apps/backend/src/repositories/pdfTemplateRepository.ts
@@ -1,0 +1,93 @@
+import type { Prisma } from '#prisma-client';
+import { resolvePrisma, type RepositoryContext } from './baseRepository.js';
+
+/**
+ * Factory for all PdfTemplate data access.
+ */
+export const createPdfTemplateRepository = (context?: RepositoryContext) => {
+  const prisma = resolvePrisma(context);
+
+  /** --- Generic delegate passthroughs (keep API flexibility) --- */
+  const findMany = <T extends Prisma.PdfTemplateFindManyArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.PdfTemplateFindManyArgs>
+  ) => prisma.pdfTemplate.findMany(args);
+
+  const findUnique = <T extends Prisma.PdfTemplateFindUniqueArgs>(
+    args: Prisma.SelectSubset<T, Prisma.PdfTemplateFindUniqueArgs>
+  ) => prisma.pdfTemplate.findUnique(args);
+
+  const create = <T extends Prisma.PdfTemplateCreateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.PdfTemplateCreateArgs>
+  ) => prisma.pdfTemplate.create(args);
+
+  const update = <T extends Prisma.PdfTemplateUpdateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.PdfTemplateUpdateArgs>
+  ) => prisma.pdfTemplate.update(args);
+
+  const remove = <T extends Prisma.PdfTemplateDeleteArgs>(
+    args: Prisma.SelectSubset<T, Prisma.PdfTemplateDeleteArgs>
+  ) => prisma.pdfTemplate.delete(args);
+
+  const count = <T extends Prisma.PdfTemplateCountArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.PdfTemplateCountArgs>
+  ) => prisma.pdfTemplate.count(args);
+
+  /** --- Domain-oriented helpers for common access patterns --- */
+
+  /**
+   * Fetch a single template by id (no relations — `PdfTemplate` has no soft
+   * delete flag, so this is a plain existence/ownership lookup).
+   */
+  const findById = async (id: string) =>
+    prisma.pdfTemplate.findUnique({ where: { id } });
+
+  /**
+   * All templates for a form, most recently created first — matches the
+   * `pdfTemplates` GraphQL query ordering.
+   */
+  const listByForm = async (formId: string) =>
+    prisma.pdfTemplate.findMany({
+      where: { formId },
+      orderBy: { createdAt: 'desc' },
+    });
+
+  /**
+   * Number of templates already saved for a form — used to enforce the
+   * per-form template cap.
+   */
+  const countByForm = async (formId: string) =>
+    prisma.pdfTemplate.count({ where: { formId } });
+
+  const createTemplate = async (data: Prisma.PdfTemplateCreateArgs['data']) =>
+    prisma.pdfTemplate.create({ data });
+
+  const updateTemplate = async (
+    id: string,
+    data: Prisma.PdfTemplateUpdateArgs['data']
+  ) => prisma.pdfTemplate.update({ where: { id }, data });
+
+  const deleteTemplate = async (id: string) =>
+    prisma.pdfTemplate.delete({ where: { id } });
+
+  return {
+    // Generic operations (used when custom queries are needed)
+    findMany,
+    findUnique,
+    create,
+    update,
+    delete: remove,
+    count,
+
+    // Domain helpers (preferred for service layer)
+    findById,
+    listByForm,
+    countByForm,
+    createTemplate,
+    updateTemplate,
+    deleteTemplate,
+  };
+};
+
+export type PdfTemplateRepository = ReturnType<typeof createPdfTemplateRepository>;
+
+export const pdfTemplateRepository = createPdfTemplateRepository();

--- a/apps/backend/src/services/pdfTemplateService.ts
+++ b/apps/backend/src/services/pdfTemplateService.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import type { Prisma } from '#prisma-client';
 import { checkTemplate, getDefaultFont, BLANK_PDF, type Font, type Template } from '@pdfme/common';
 import { generate } from '@pdfme/generator';
 import {
@@ -19,6 +20,8 @@ import { parsePhoneNumberFromString } from 'libphonenumber-js/max';
 import { FieldType } from '@dculus/types';
 import { substitutePlaceholdersPlainText, createFieldLabelsMap } from '@dculus/utils';
 import { downloadFileBuffer } from './fileUploadService.js';
+import { pdfTemplateRepository, createPdfTemplateRepository } from '../repositories/index.js';
+import { withPrisma } from '../repositories/baseRepository.js';
 import { logger } from '../lib/logger.js';
 
 /**
@@ -54,6 +57,33 @@ export const PDF_GENERATOR_PLUGINS = {
  * Roboto has no Tamil glyphs.
  */
 export const TAMIL_FONT_NAME = 'NotoSansTamil';
+
+/**
+ * PDF Template CRUD — thin pass-throughs onto pdfTemplateRepository. Business
+ * rules (name validation, the per-form template cap, fileKey ownership
+ * checks, template JSON validation) stay in the resolver; this layer is only
+ * the data-access boundary.
+ */
+
+export const listTemplates = async (formId: string) =>
+  pdfTemplateRepository.listByForm(formId);
+
+export const getTemplateById = async (id: string) =>
+  pdfTemplateRepository.findById(id);
+
+export const countTemplates = async (formId: string) =>
+  pdfTemplateRepository.countByForm(formId);
+
+export const createTemplate = async (data: Prisma.PdfTemplateCreateArgs['data']) =>
+  pdfTemplateRepository.createTemplate(data);
+
+export const updateTemplate = async (
+  id: string,
+  data: Prisma.PdfTemplateUpdateArgs['data']
+) => pdfTemplateRepository.updateTemplate(id, data);
+
+export const deleteTemplate = async (id: string) =>
+  pdfTemplateRepository.deleteTemplate(id);
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -479,7 +509,9 @@ export async function resolveResponsePdfAttachment(
   const { pdfTemplateId, formId, responseId, deserializedSchema, responseData } = params;
 
   try {
-    const pdfTemplate = await prisma.pdfTemplate.findUnique({ where: { id: pdfTemplateId } });
+    const pdfTemplate = await createPdfTemplateRepository(withPrisma(prisma)).findUnique({
+      where: { id: pdfTemplateId },
+    });
 
     if (!pdfTemplate || pdfTemplate.formId !== formId) {
       return { error: `PDF template "${pdfTemplateId}" no longer exists` };


### PR DESCRIPTION
## Summary
- Adds `pdfTemplateRepository.ts` covering the `PdfTemplate` model (generic passthroughs + `findById`/`listByForm`/`countByForm`/`createTemplate`/`updateTemplate`/`deleteTemplate`), registered in `repositories/index.ts`.
- Extends `pdfTemplateService.ts` with matching CRUD methods and routes the existing `resolveResponsePdfAttachment` lookup through the new repository instead of a raw `prisma.pdfTemplate.findUnique`.
- Routes `graphql/resolvers/pdfTemplates.ts`'s 6 direct `prisma.pdfTemplate.*` call sites through `pdfTemplateService`, and its 2 form + 2 response existence checks through `formService.getFormById` / `responseService.getResponseById` (per #246). All existing `requireAuth`/`checkFormAccess` guards are unchanged.
- Pure structural refactor — no behavior change.

Closes #250. Part of epic #245 (Backend — Repository Pattern Rollout), depended on #246 (already merged).

## Test plan
- [x] New `repositories/__tests__/pdfTemplateRepository.test.ts` (mocked Prisma, 7 tests)
- [x] Updated `graphql/resolvers/__tests__/pdfTemplates.test.ts` mocks to match the new service call sites (was asserting on raw `prisma.response.findUnique`/`prisma.form.findUnique`)
- [x] `pnpm --filter backend exec tsc --noEmit` — clean
- [x] `pnpm test:unit` — 2981/2981 passing
- [x] `grep -n "prisma\."` on `pdfTemplates.ts` and `pdfTemplateService.ts` — zero matches
- [x] Pre-push hooks (backend tests, form-app/form-viewer/admin-app builds) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved PDF template creation, editing, deletion, and listing reliability.
  * Strengthened form and response ownership checks during PDF generation and previews.
  * Improved consistency when retrieving templates, forms, and responses.
  * Preserved clear generic error messages without exposing internal details.

* **Tests**
  * Added coverage for PDF template operations and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->