### PR TITLE
Story 11: Response & Analytics Reconnect

### DIFF
--- a/apps/backend/src/graphql/resolvers/__tests__/analytics.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/analytics.test.ts
@@ -2,13 +2,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { analyticsResolvers } from '../analytics.js';
 import { GraphQLError } from '#graphql-errors';
 import { analyticsService } from '../../../services/analyticsService.js';
-import { prisma } from '../../../lib/prisma.js';
+import * as formService from '../../../services/formService.js';
+import * as responseService from '../../../services/responseService.js';
 import * as events from '../../../subscriptions/events.js';
 import * as betterAuthMiddleware from '../../../middleware/better-auth-middleware.js';
 import * as formSharingModule from '../formSharing.js';
 
 // Mock all dependencies
 vi.mock('../../../services/analyticsService.js');
+vi.mock('../../../services/formService.js');
+vi.mock('../../../services/responseService.js');
 vi.mock('../../../subscriptions/events.js');
 vi.mock('../formSharing.js');
 vi.mock('../../../middleware/better-auth-middleware.js', async (importOriginal) => {
@@ -19,16 +22,6 @@ vi.mock('../../../middleware/better-auth-middleware.js', async (importOriginal) 
     requireOrganizationMembership: vi.fn(),
   };
 });
-vi.mock('../../../lib/prisma.js', () => ({
-  prisma: {
-    form: {
-      findUnique: vi.fn(),
-    },
-    response: {
-      findUnique: vi.fn(),
-    },
-  },
-}));
 vi.mock('../../../lib/logger.js', () => ({
   logger: {
     info: vi.fn(),
@@ -94,7 +87,7 @@ describe('Analytics Resolvers', () => {
     };
 
     it('should track form view successfully with published form', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
       vi.mocked(analyticsService.trackFormView).mockResolvedValue(undefined);
       vi.mocked(events.emitFormViewed).mockReturnValue(undefined);
 
@@ -104,10 +97,7 @@ describe('Analytics Resolvers', () => {
         mockContext
       );
 
-      expect(prisma.form.findUnique).toHaveBeenCalledWith({
-        where: { id: 'form-123' },
-        select: { id: true, isPublished: true, organizationId: true },
-      });
+      expect(formService.getFormById).toHaveBeenCalledWith('form-123');
 
       expect(analyticsService.trackFormView).toHaveBeenCalledWith(
         {
@@ -140,7 +130,7 @@ describe('Analytics Resolvers', () => {
         },
       };
 
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
       vi.mocked(analyticsService.trackFormView).mockResolvedValue(undefined);
 
       await analyticsResolvers.Mutation.trackFormView(
@@ -156,7 +146,7 @@ describe('Analytics Resolvers', () => {
     });
 
     it('should throw error when form not found', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(null);
+      vi.mocked(formService.getFormById).mockResolvedValue(null);
 
       await expect(
         analyticsResolvers.Mutation.trackFormView(
@@ -175,7 +165,7 @@ describe('Analytics Resolvers', () => {
     });
 
     it('should throw error when form is not published', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockUnpublishedForm as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockUnpublishedForm as any);
 
       await expect(
         analyticsResolvers.Mutation.trackFormView(
@@ -194,7 +184,7 @@ describe('Analytics Resolvers', () => {
     });
 
     it('should return success: false on analytics service error', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
       vi.mocked(analyticsService.trackFormView).mockRejectedValue(
         new Error('Analytics service error')
       );
@@ -209,7 +199,7 @@ describe('Analytics Resolvers', () => {
     });
 
     it('should handle subscription event emission errors gracefully', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
       vi.mocked(analyticsService.trackFormView).mockResolvedValue(undefined);
       vi.mocked(events.emitFormViewed).mockImplementation(() => {
         throw new Error('Event emission error');
@@ -232,7 +222,7 @@ describe('Analytics Resolvers', () => {
         userAgent: 'Mozilla/5.0',
       };
 
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
       vi.mocked(analyticsService.trackFormView).mockResolvedValue(undefined);
 
       const result = await analyticsResolvers.Mutation.trackFormView(
@@ -264,7 +254,7 @@ describe('Analytics Resolvers', () => {
     };
 
     it('should update form start time successfully', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
       vi.mocked(analyticsService.updateFormStartTime).mockResolvedValue(undefined);
 
       const result = await analyticsResolvers.Mutation.updateFormStartTime(
@@ -272,10 +262,7 @@ describe('Analytics Resolvers', () => {
         { input: updateFormStartTimeInput }
       );
 
-      expect(prisma.form.findUnique).toHaveBeenCalledWith({
-        where: { id: 'form-123' },
-        select: { id: true, isPublished: true },
-      });
+      expect(formService.getFormById).toHaveBeenCalledWith('form-123');
 
       expect(analyticsService.updateFormStartTime).toHaveBeenCalledWith({
         formId: 'form-123',
@@ -287,7 +274,7 @@ describe('Analytics Resolvers', () => {
     });
 
     it('should return success: false when form not found', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(null);
+      vi.mocked(formService.getFormById).mockResolvedValue(null);
 
       const result = await analyticsResolvers.Mutation.updateFormStartTime(
         {},
@@ -298,7 +285,7 @@ describe('Analytics Resolvers', () => {
     });
 
     it('should return success: false when form is not published', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockUnpublishedForm as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockUnpublishedForm as any);
 
       const result = await analyticsResolvers.Mutation.updateFormStartTime(
         {},
@@ -309,7 +296,7 @@ describe('Analytics Resolvers', () => {
     });
 
     it('should return success: false on service error without throwing', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
       vi.mocked(analyticsService.updateFormStartTime).mockRejectedValue(
         new Error('Service error')
       );
@@ -335,8 +322,8 @@ describe('Analytics Resolvers', () => {
     };
 
     it('should track form submission successfully', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
-      vi.mocked(prisma.response.findUnique).mockResolvedValue(mockResponse as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(responseService.getResponseById).mockResolvedValue(mockResponse as any);
       vi.mocked(analyticsService.trackFormSubmission).mockResolvedValue(undefined);
 
       const result = await analyticsResolvers.Mutation.trackFormSubmission(
@@ -345,15 +332,9 @@ describe('Analytics Resolvers', () => {
         mockContext
       );
 
-      expect(prisma.form.findUnique).toHaveBeenCalledWith({
-        where: { id: 'form-123' },
-        select: { id: true, isPublished: true },
-      });
+      expect(formService.getFormById).toHaveBeenCalledWith('form-123');
 
-      expect(prisma.response.findUnique).toHaveBeenCalledWith({
-        where: { id: 'response-123' },
-        select: { id: true, formId: true },
-      });
+      expect(responseService.getResponseById).toHaveBeenCalledWith('response-123');
 
       expect(analyticsService.trackFormSubmission).toHaveBeenCalledWith(
         {
@@ -372,7 +353,7 @@ describe('Analytics Resolvers', () => {
     });
 
     it('should throw error when form not found', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(null);
+      vi.mocked(formService.getFormById).mockResolvedValue(null);
 
       await expect(
         analyticsResolvers.Mutation.trackFormSubmission(
@@ -391,7 +372,7 @@ describe('Analytics Resolvers', () => {
     });
 
     it('should throw error when form is not published', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockUnpublishedForm as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockUnpublishedForm as any);
 
       await expect(
         analyticsResolvers.Mutation.trackFormSubmission(
@@ -410,8 +391,8 @@ describe('Analytics Resolvers', () => {
     });
 
     it('should throw error when response not found', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
-      vi.mocked(prisma.response.findUnique).mockResolvedValue(null);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(responseService.getResponseById).mockResolvedValue(null);
 
       await expect(
         analyticsResolvers.Mutation.trackFormSubmission(
@@ -430,8 +411,8 @@ describe('Analytics Resolvers', () => {
     });
 
     it('should throw error when response does not belong to form', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
-      vi.mocked(prisma.response.findUnique).mockResolvedValue({
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(responseService.getResponseById).mockResolvedValue({
         id: 'response-123',
         formId: 'different-form-456',
       } as any);
@@ -453,8 +434,8 @@ describe('Analytics Resolvers', () => {
     });
 
     it('should return success: false on analytics service error', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
-      vi.mocked(prisma.response.findUnique).mockResolvedValue(mockResponse as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(responseService.getResponseById).mockResolvedValue(mockResponse as any);
       vi.mocked(analyticsService.trackFormSubmission).mockRejectedValue(
         new Error('Analytics service error')
       );
@@ -476,8 +457,8 @@ describe('Analytics Resolvers', () => {
         userAgent: 'Mozilla/5.0',
       };
 
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
-      vi.mocked(prisma.response.findUnique).mockResolvedValue(mockResponse as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(responseService.getResponseById).mockResolvedValue(mockResponse as any);
       vi.mocked(analyticsService.trackFormSubmission).mockResolvedValue(undefined);
 
       const result = await analyticsResolvers.Mutation.trackFormSubmission(
@@ -509,8 +490,8 @@ describe('Analytics Resolvers', () => {
         },
       };
 
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
-      vi.mocked(prisma.response.findUnique).mockResolvedValue(mockResponse as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(responseService.getResponseById).mockResolvedValue(mockResponse as any);
       vi.mocked(analyticsService.trackFormSubmission).mockResolvedValue(undefined);
 
       await analyticsResolvers.Mutation.trackFormSubmission(
@@ -905,7 +886,7 @@ describe('Analytics Resolvers', () => {
         },
       };
 
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
       vi.mocked(analyticsService.trackFormView).mockResolvedValue(undefined);
 
       await analyticsResolvers.Mutation.trackFormView(
@@ -934,7 +915,7 @@ describe('Analytics Resolvers', () => {
         auth: mockContext.auth,
       };
 
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
       vi.mocked(analyticsService.trackFormView).mockResolvedValue(undefined);
 
       await analyticsResolvers.Mutation.trackFormView(
@@ -963,7 +944,7 @@ describe('Analytics Resolvers', () => {
         auth: mockContext.auth,
       };
 
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
       vi.mocked(analyticsService.trackFormView).mockResolvedValue(undefined);
 
       await analyticsResolvers.Mutation.trackFormView(
@@ -994,7 +975,7 @@ describe('Analytics Resolvers', () => {
         auth: mockContext.auth,
       };
 
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
       vi.mocked(analyticsService.trackFormView).mockResolvedValue(undefined);
 
       await analyticsResolvers.Mutation.trackFormView(
@@ -1021,7 +1002,7 @@ describe('Analytics Resolvers', () => {
         auth: mockContext.auth,
       };
 
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
       vi.mocked(analyticsService.trackFormView).mockResolvedValue(undefined);
 
       await analyticsResolvers.Mutation.trackFormView(
@@ -1045,7 +1026,7 @@ describe('Analytics Resolvers', () => {
 
   describe('Error handling and resilience', () => {
     it('should not disrupt form viewing on analytics tracking failures', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
       vi.mocked(analyticsService.trackFormView).mockRejectedValue(
         new Error('Database connection lost')
       );
@@ -1067,8 +1048,8 @@ describe('Analytics Resolvers', () => {
     });
 
     it('should not disrupt form submission on analytics tracking failures', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(mockPublishedForm as any);
-      vi.mocked(prisma.response.findUnique).mockResolvedValue(mockResponse as any);
+      vi.mocked(formService.getFormById).mockResolvedValue(mockPublishedForm as any);
+      vi.mocked(responseService.getResponseById).mockResolvedValue(mockResponse as any);
       vi.mocked(analyticsService.trackFormSubmission).mockRejectedValue(
         new Error('Database connection lost')
       );
@@ -1091,7 +1072,7 @@ describe('Analytics Resolvers', () => {
     });
 
     it('should rethrow GraphQL errors from validation', async () => {
-      vi.mocked(prisma.form.findUnique).mockResolvedValue(null);
+      vi.mocked(formService.getFormById).mockResolvedValue(null);
 
       // These should throw, not return success: false
       await expect(

--- a/apps/backend/src/graphql/resolvers/__tests__/forms.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/forms.test.ts
@@ -35,6 +35,8 @@ vi.mock('../../../lib/prisma.js', () => ({
     formFile: {
       create: vi.fn(),
     },
+    // Backs formSubmissionAnalyticsRepository.getAverageCompletionTime (SQL-computed avg)
+    $queryRaw: vi.fn(),
   },
   isLocalDatabase: vi.fn(() => true),
 }));
@@ -81,6 +83,8 @@ describe('Forms Resolvers', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: no completion-time data (individual tests override as needed)
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -502,11 +506,8 @@ describe('Forms Resolvers', () => {
       // rateThisWeek=(20/200)*100=10, rateLastWeek=(16/200)*100=8 → trendResponseRate=2
       vi.mocked(prisma.formViewAnalytics.count).mockResolvedValue(200);
 
-      vi.mocked(prisma.formSubmissionAnalytics.findMany).mockResolvedValue([
-        { completionTimeSeconds: 120 },
-        { completionTimeSeconds: 180 },
-        { completionTimeSeconds: 150 },
-      ] as any);
+      // Average of [120, 180, 150] = 150, now computed in SQL
+      vi.mocked(prisma.$queryRaw).mockResolvedValue([{ avg: 150 }] as any);
 
       const result = await formsResolvers.Form.dashboardStats({ id: 'form-123' });
 

--- a/apps/backend/src/graphql/resolvers/__tests__/responses.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/responses.test.ts
@@ -14,33 +14,9 @@ import * as editTrackingService from '../../../services/responseEditTrackingServ
 import * as tagService from '../../../services/tagService.js';
 import * as responseCopyService from '../../../services/responseCopyService.js';
 
-// Shared tx client for $transaction tests
-const mockTxClient = {
-  response: {
-    count: vi.fn(),
-    create: vi.fn(),
-  },
-};
-
 // Mock all dependencies
 vi.mock('../../../services/responseService.js');
 vi.mock('../../../services/formService.js');
-vi.mock('../../../repositories/responseRepository.js', () => ({
-  responseRepository: {
-    count: vi.fn(),
-  },
-}));
-vi.mock('../../../lib/prisma.js', () => ({
-  prisma: {
-    form: {
-      findMany: vi.fn(),
-    },
-    $transaction: vi.fn((callback: (tx: typeof mockTxClient) => Promise<any>) =>
-      callback(mockTxClient)
-    ),
-  },
-  isLocalDatabase: vi.fn(() => true),
-}));
 vi.mock('../../../middleware/better-auth-middleware.js');
 vi.mock('../formSharing.js');
 vi.mock('../../../services/analyticsService.js');
@@ -137,9 +113,8 @@ describe('Responses Resolvers', () => {
 
   describe('Query: responses', () => {
     it('should return responses for accessible forms only', async () => {
-      const { prisma } = await import('../../../lib/prisma.js');
       vi.mocked(betterAuthMiddleware.requireOrganizationMembership).mockResolvedValue(undefined);
-      vi.mocked(prisma.form.findMany as any).mockResolvedValue([{ id: 'form-123' }]);
+      vi.mocked(formService.getAccessibleFormIds).mockResolvedValue(['form-123']);
       vi.mocked(responseService.getAllResponses).mockResolvedValue([mockResponse] as any);
 
       const result = await responsesResolvers.Query.responses(
@@ -158,10 +133,9 @@ describe('Responses Resolvers', () => {
     });
 
     it('should exclude responses from forms the user cannot access', async () => {
-      const { prisma } = await import('../../../lib/prisma.js');
       vi.mocked(betterAuthMiddleware.requireOrganizationMembership).mockResolvedValue(undefined);
       // User has access to form-123 but NOT form-456
-      vi.mocked(prisma.form.findMany as any).mockResolvedValue([{ id: 'form-123' }]);
+      vi.mocked(formService.getAccessibleFormIds).mockResolvedValue(['form-123']);
       const hiddenResponse = { ...mockResponse, id: 'response-456', formId: 'form-456' };
       vi.mocked(responseService.getAllResponses).mockResolvedValue([mockResponse, hiddenResponse] as any);
 
@@ -522,7 +496,9 @@ describe('Responses Resolvers', () => {
         },
       };
       vi.mocked(formService.getFormById).mockResolvedValue(formWithLimits as any);
-      mockTxClient.response.count.mockResolvedValue(10);
+      vi.mocked(responseService.submitResponseWithMaxLimitCheck).mockRejectedValue(
+        new Error('Form has reached its maximum response limit')
+      );
 
       await expect(
         responsesResolvers.Mutation.submitResponse({}, { input: mockInput }, mockContext)
@@ -539,13 +515,12 @@ describe('Responses Resolvers', () => {
         },
       };
       vi.mocked(formService.getFormById).mockResolvedValue(formWithLimits as any);
-      mockTxClient.response.count.mockResolvedValue(5);
-      mockTxClient.response.create.mockResolvedValue({
+      vi.mocked(responseService.submitResponseWithMaxLimitCheck).mockResolvedValue({
         id: 'generated-response-id',
         formId: 'form-123',
         data: {},
         submittedAt: new Date(),
-      });
+      } as any);
 
       const result = await responsesResolvers.Mutation.submitResponse(
         {},
@@ -554,6 +529,10 @@ describe('Responses Resolvers', () => {
       );
 
       expect(result).toBeDefined();
+      expect(responseService.submitResponseWithMaxLimitCheck).toHaveBeenCalledWith(
+        expect.objectContaining({ formId: 'form-123' }),
+        10
+      );
     });
 
     it('should enforce time window start date', async () => {

--- a/apps/backend/src/graphql/resolvers/analytics.ts
+++ b/apps/backend/src/graphql/resolvers/analytics.ts
@@ -2,7 +2,8 @@ import { createGraphQLError, GraphQLError } from '#graphql-errors';
 import { GRAPHQL_ERROR_CODES } from '@dculus/types/graphql.js';
 import { analyticsService } from '../../services/analyticsService.js';
 import { requireAuth, requireOrganizationMembership, type BetterAuthContext } from '../../middleware/better-auth-middleware.js';
-import { prisma } from '../../lib/prisma.js';
+import { getFormById } from '../../services/formService.js';
+import { getResponseById } from '../../services/responseService.js';
 import { emitFormViewed } from '../../subscriptions/events.js';
 import { logger } from '../../lib/logger.js';
 import { checkFormAccess, PermissionLevel } from './formSharing.js';
@@ -45,10 +46,7 @@ export const analyticsResolvers = {
           (context.req?.headers?.['x-forwarded-for'] as string)?.split(',')[0];
 
         // Verify form exists and is published
-        const form = await prisma.form.findUnique({
-          where: { id: input.formId },
-          select: { id: true, isPublished: true, organizationId: true }
-        });
+        const form = await getFormById(input.formId);
 
         if (!form) {
           throw createGraphQLError('Form not found', GRAPHQL_ERROR_CODES.FORM_NOT_FOUND);
@@ -109,10 +107,7 @@ export const analyticsResolvers = {
         }
 
         // Verify form exists and is published
-        const form = await prisma.form.findUnique({
-          where: { id: input.formId },
-          select: { id: true, isPublished: true }
-        });
+        const form = await getFormById(input.formId);
 
         if (!form) {
           throw createGraphQLError('Form not found', GRAPHQL_ERROR_CODES.FORM_NOT_FOUND);
@@ -150,10 +145,7 @@ export const analyticsResolvers = {
           (context.req?.headers?.['x-forwarded-for'] as string)?.split(',')[0];
 
         // Verify form exists and is published
-        const form = await prisma.form.findUnique({
-          where: { id: input.formId },
-          select: { id: true, isPublished: true }
-        });
+        const form = await getFormById(input.formId);
 
         if (!form) {
           throw createGraphQLError('Form not found', GRAPHQL_ERROR_CODES.FORM_NOT_FOUND);
@@ -164,10 +156,7 @@ export const analyticsResolvers = {
         }
 
         // Verify response exists
-        const response = await prisma.response.findUnique({
-          where: { id: input.responseId },
-          select: { id: true, formId: true }
-        });
+        const response = await getResponseById(input.responseId);
 
         if (!response) {
           throw createGraphQLError('Response not found', GRAPHQL_ERROR_CODES.RESPONSE_NOT_FOUND);

--- a/apps/backend/src/graphql/resolvers/forms.ts
+++ b/apps/backend/src/graphql/resolvers/forms.ts
@@ -13,7 +13,9 @@ import { checkFormAccess, PermissionLevel } from './formSharing.js';
 import { generateId } from '@dculus/utils';
 import { copyFileForForm } from '../../services/fileUploadService.js';
 import { getFormSchemaFromHocuspocus } from '../../services/hocuspocus.js';
-import { prisma } from '../../lib/prisma.js';
+import { createFormFile } from '../../services/formFileService.js';
+import { getResponseCount, countAllResponses, getDashboardResponseCounts } from '../../services/responseService.js';
+import { analyticsService } from '../../services/analyticsService.js';
 import { randomUUID } from 'crypto';
 import { createGraphQLError } from '#graphql-errors';
 import { GRAPHQL_ERROR_CODES } from '@dculus/types/graphql.js';
@@ -79,9 +81,7 @@ export const formsResolvers = {
 
         // Check maximum responses limit
         if (limits.maxResponses?.enabled) {
-          const currentResponseCount = await prisma.response.count({
-            where: { formId: form.id }
-          });
+          const currentResponseCount = await countAllResponses(form.id);
 
           if (currentResponseCount >= limits.maxResponses.limit) {
             throw createGraphQLError("Form has reached its maximum response limit", GRAPHQL_ERROR_CODES.MAX_RESPONSES_REACHED);
@@ -155,7 +155,7 @@ export const formsResolvers = {
       // P3-02: Return pre-fetched _count when available (avoids N+1 on list queries).
       // Fall back to a direct COUNT query for single-form queries where _count is absent.
       if (parent._count?.responses !== undefined) return parent._count.responses;
-      return prisma.response.count({ where: { formId: parent.id, deletedAt: null } });
+      return getResponseCount(parent.id);
     },
     dashboardStats: async (parent: any) => {
       const formId = parent.id;
@@ -167,42 +167,21 @@ export const formsResolvers = {
       const twoWeeksAgo = new Date(today.getTime() - 14 * 24 * 60 * 60 * 1000);
       const monthAgo = new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000);
 
-      const [
-        responsesToday,
-        responsesThisWeek,
-        responsesThisMonth,
-        totalResponses,
-        totalViews,
-        submissionAnalytics,
-        responsesYesterday,
-        responsesLastWeek,
-        viewsThisWeek,
-        viewsLastWeek,
-      ] = await Promise.all([
-        prisma.response.count({ where: { formId, deletedAt: null, submittedAt: { gte: today } } }),
-        prisma.response.count({ where: { formId, deletedAt: null, submittedAt: { gte: weekAgo } } }),
-        prisma.response.count({ where: { formId, deletedAt: null, submittedAt: { gte: monthAgo } } }),
-        prisma.response.count({ where: { formId, deletedAt: null } }),
-        prisma.formViewAnalytics.count({ where: { formId } }),
-        // Direct formId filter — FormSubmissionAnalytics has an indexed formId column
-        prisma.formSubmissionAnalytics.findMany({
-          where: { formId },
-          select: { completionTimeSeconds: true },
-        }),
-        prisma.response.count({ where: { formId, deletedAt: null, submittedAt: { gte: yesterday, lt: today } } }),
-        prisma.response.count({ where: { formId, deletedAt: null, submittedAt: { gte: twoWeeksAgo, lt: weekAgo } } }),
-        prisma.formViewAnalytics.count({ where: { formId, viewedAt: { gte: weekAgo } } }),
-        prisma.formViewAnalytics.count({ where: { formId, viewedAt: { gte: twoWeeksAgo, lt: weekAgo } } }),
+      const [responseCounts, viewCounts, averageCompletionTime] = await Promise.all([
+        getDashboardResponseCounts(formId, { today, weekAgo, monthAgo, yesterday, twoWeeksAgo }),
+        analyticsService.getDashboardViewCounts(formId, { weekAgo, twoWeeksAgo }),
+        analyticsService.getAverageCompletionTime(formId),
       ]);
 
-      const validCompletionTimes = submissionAnalytics
-        .map(s => s.completionTimeSeconds)
-        .filter((t): t is number => t !== null && t > 0);
-
-      const averageCompletionTime =
-        validCompletionTimes.length > 0
-          ? validCompletionTimes.reduce((sum, t) => sum + t, 0) / validCompletionTimes.length
-          : null;
+      const {
+        today: responsesToday,
+        thisWeek: responsesThisWeek,
+        thisMonth: responsesThisMonth,
+        total: totalResponses,
+        yesterday: responsesYesterday,
+        lastWeek: responsesLastWeek,
+      } = responseCounts;
+      const { total: totalViews, thisWeek: viewsThisWeek, lastWeek: viewsLastWeek } = viewCounts;
 
       const responseRate = totalViews > 0 ? (totalResponses / totalViews) * 100 : 0;
 
@@ -343,17 +322,15 @@ export const formsResolvers = {
       // NOW create the FormFile record after the form exists in the database
       if (copiedFileInfo) {
         try {
-          await prisma.formFile.create({
-            data: {
-              id: randomUUID(),
-              key: copiedFileInfo.key,
-              type: 'FormBackground',
-              formId: newFormId,
-              originalName: copiedFileInfo.originalName,
-              url: copiedFileInfo.url,
-              size: copiedFileInfo.size,
-              mimeType: copiedFileInfo.mimeType,
-            }
+          await createFormFile({
+            id: randomUUID(),
+            key: copiedFileInfo.key,
+            type: 'FormBackground',
+            formId: newFormId,
+            originalName: copiedFileInfo.originalName,
+            url: copiedFileInfo.url,
+            size: copiedFileInfo.size,
+            mimeType: copiedFileInfo.mimeType,
           });
         } catch (formFileError) {
           logger.error('Error creating FormFile record:', formFileError);

--- a/apps/backend/src/graphql/resolvers/responses.ts
+++ b/apps/backend/src/graphql/resolvers/responses.ts
@@ -5,12 +5,12 @@ import {
   getResponseById,
   getResponsesByFormId,
   submitResponse,
+  submitResponseWithMaxLimitCheck,
   updateResponse,
 } from '../../services/responseService.js';
 import { Prisma } from '#prisma-client';
-import { prisma } from '../../lib/prisma.js';
 import { ResponseFilter } from '../../services/responseFilterService.js';
-import { getFormById } from '../../services/formService.js';
+import { getFormById, getAccessibleFormIds } from '../../services/formService.js';
 import {
   BetterAuthContext,
   requireAuth,
@@ -74,19 +74,7 @@ export const responsesResolvers = {
 
       // 🔒 SECURITY: Scope to forms the user can actually access (VIEWER or above).
       // Org membership alone is not sufficient — a NO_ACCESS permission must be respected.
-      const accessibleForms = await prisma.form.findMany({
-        where: {
-          organizationId,
-          OR: [
-            { createdById: userId },
-            { permissions: { some: { userId, permission: { not: PermissionLevel.NO_ACCESS } } } },
-            { sharingScope: 'ALL_ORG_MEMBERS', defaultPermission: { not: PermissionLevel.NO_ACCESS } },
-          ],
-        },
-        select: { id: true },
-      });
-
-      const accessibleFormIds = accessibleForms.map((f) => f.id);
+      const accessibleFormIds = await getAccessibleFormIds(organizationId, userId);
       const allResponses = await getAllResponses(organizationId);
       return allResponses.filter((r) => accessibleFormIds.includes(r.formId));
     },
@@ -255,43 +243,20 @@ export const responsesResolvers = {
         const limits = form.settings.submissionLimits;
 
         // Check maximum responses limit — atomic check-then-insert via a
-        // Serializable transaction so two concurrent requests cannot both pass
-        // the count check and both insert, exceeding the limit by one.
+        // Serializable transaction (responseService.submitResponseWithMaxLimitCheck)
+        // so two concurrent requests cannot both pass the count check and both
+        // insert, exceeding the limit by one.
         if (limits.maxResponses?.enabled) {
-          const maxAllowed = limits.maxResponses.limit;
-
-          const inserted = await prisma.$transaction(
-            async (tx) => {
-              const currentCount = await tx.response.count({
-                where: { formId: input.formId },
-              });
-
-              if (currentCount >= maxAllowed) {
-                throw createGraphQLError('Form has reached its maximum response limit', GRAPHQL_ERROR_CODES.MAX_RESPONSES_REACHED);
-              }
-
-              // Insert atomically within the same transaction
-              return tx.response.create({
-                data: {
-                  id: responseId,
-                  formId: input.formId,
-                  data: (input.data || {}) as Prisma.InputJsonValue,
-                  respondentUserId,
-                  respondentEmail,
-                },
-              });
+          response = await submitResponseWithMaxLimitCheck(
+            {
+              id: responseId,
+              formId: input.formId,
+              data: (input.data || {}) as Prisma.InputJsonValue,
+              respondentUserId,
+              respondentEmail,
             },
-            { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+            limits.maxResponses.limit
           );
-
-          response = {
-            id: inserted.id,
-            formId: inserted.formId,
-            data: (inserted.data as Prisma.JsonObject) || {},
-            metadata: inserted.metadata as import('@dculus/types').FormResponse['metadata'],
-            respondentEmail: inserted.respondentEmail ?? undefined,
-            submittedAt: inserted.submittedAt,
-          };
         }
 
         // Check time window limits

--- a/apps/backend/src/repositories/__tests__/analyticsRepositories.test.ts
+++ b/apps/backend/src/repositories/__tests__/analyticsRepositories.test.ts
@@ -379,4 +379,22 @@ describe('Form Submission Analytics Repository', () => {
       expect(result).toBeNull();
     });
   });
+
+  describe('getAverageCompletionTime', () => {
+    it('returns the SQL-computed average when present', async () => {
+      (mockPrisma.$queryRaw as any).mockResolvedValue([{ avg: 123.45 }]);
+
+      const result = await repository.getAverageCompletionTime('form-1');
+
+      expect(result).toBe(123.45);
+    });
+
+    it('returns null when there is no data', async () => {
+      (mockPrisma.$queryRaw as any).mockResolvedValue([{ avg: null }]);
+
+      const result = await repository.getAverageCompletionTime('form-1');
+
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/apps/backend/src/repositories/__tests__/analyticsRepositories.test.ts
+++ b/apps/backend/src/repositories/__tests__/analyticsRepositories.test.ts
@@ -6,6 +6,7 @@ const mockPrisma = {
   formViewAnalytics: {
     create: vi.fn(),
     updateMany: vi.fn(),
+    deleteMany: vi.fn(),
     count: vi.fn(),
     groupBy: vi.fn(),
     findMany: vi.fn(),
@@ -13,6 +14,7 @@ const mockPrisma = {
   formSubmissionAnalytics: {
     create: vi.fn(),
     count: vi.fn(),
+    deleteMany: vi.fn(),
     groupBy: vi.fn(),
     findMany: vi.fn(),
   },
@@ -178,6 +180,31 @@ describe('Form View Analytics Repository', () => {
       expect(result).toEqual([]);
     });
   });
+
+  describe('deleteMany', () => {
+    it('should delete many view analytics records', async () => {
+      mockPrisma.formViewAnalytics.deleteMany.mockResolvedValue({ count: 4 } as any);
+
+      const result = await repository.deleteMany({ where: { viewedAt: { lt: new Date() } } });
+
+      expect(result).toEqual({ count: 4 });
+    });
+  });
+
+  describe('getOrgDailyViewCounts', () => {
+    it('returns raw org daily view rows', async () => {
+      const rows = [{ date: new Date('2026-05-15'), views: BigInt(9) }];
+      (mockPrisma.$queryRaw as any).mockResolvedValue(rows);
+
+      const result = await repository.getOrgDailyViewCounts(
+        'org-1',
+        new Date('2026-05-01'),
+        new Date('2026-05-31')
+      );
+
+      expect(result).toEqual(rows);
+    });
+  });
 });
 
 describe('Form Submission Analytics Repository', () => {
@@ -306,6 +333,50 @@ describe('Form Submission Analytics Repository', () => {
       const timeRange = { start: new Date('2026-01-01'), end: new Date('2026-06-01') };
       const result = await repository.getDailySubmissionStats('form-1', timeRange);
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('deleteMany', () => {
+    it('should delete many submission analytics records', async () => {
+      mockPrisma.formSubmissionAnalytics.deleteMany.mockResolvedValue({ count: 6 } as any);
+
+      const result = await repository.deleteMany({ where: { submittedAt: { lt: new Date() } } });
+
+      expect(result).toEqual({ count: 6 });
+    });
+  });
+
+  describe('getOrgDailySubmissionCounts', () => {
+    it('returns raw org daily submission rows', async () => {
+      const rows = [{ date: new Date('2026-05-01'), submissions: BigInt(3) }];
+      (mockPrisma.$queryRaw as any).mockResolvedValue(rows);
+
+      const result = await repository.getOrgDailySubmissionCounts(
+        'org-1',
+        new Date('2026-05-01'),
+        new Date('2026-05-31')
+      );
+
+      expect(result).toEqual(rows);
+    });
+  });
+
+  describe('getCompletionTimePercentiles', () => {
+    it('returns the percentile row when present', async () => {
+      const row = { p50: 10, p75: 20, p90: 30, p95: 40, avg: 15, total: BigInt(100) };
+      (mockPrisma.$queryRaw as any).mockResolvedValue([row]);
+
+      const result = await repository.getCompletionTimePercentiles('form-1');
+
+      expect(result).toEqual(row);
+    });
+
+    it('returns null when no rows are returned', async () => {
+      (mockPrisma.$queryRaw as any).mockResolvedValue([]);
+
+      const result = await repository.getCompletionTimePercentiles('form-1');
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/apps/backend/src/repositories/__tests__/responseRepository.test.ts
+++ b/apps/backend/src/repositories/__tests__/responseRepository.test.ts
@@ -9,6 +9,7 @@ describe('Response Repository', () => {
       count: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
       delete: vi.fn(),
     },
     responseEditHistory: {
@@ -18,6 +19,8 @@ describe('Response Repository', () => {
     responseFieldChange: {
       create: vi.fn(),
     },
+    $queryRaw: vi.fn(),
+    $queryRawUnsafe: vi.fn(),
   };
 
   const mockContext = { prisma: mockPrisma as any };
@@ -205,6 +208,92 @@ describe('Response Repository', () => {
       expect(mockPrisma.response.findMany).toHaveBeenCalledWith({
         where: { formId: 'form-123', deletedAt: null },
         orderBy: { submittedAt: 'desc' },
+      });
+    });
+  });
+
+  describe('updateMany', () => {
+    it('should update many responses', async () => {
+      mockPrisma.response.updateMany.mockResolvedValue({ count: 3 } as any);
+
+      const result = await responseRepository.updateMany({
+        where: { formId: 'form-123' },
+        data: { deletedAt: new Date() },
+      });
+
+      expect(result).toEqual({ count: 3 });
+    });
+  });
+
+  describe('countPerFieldRaw', () => {
+    it('should return per-field counts', async () => {
+      (mockPrisma.$queryRaw as any).mockResolvedValue([
+        { field_id: 'field-1', count: BigInt(5) },
+      ]);
+
+      const result = await responseRepository.countPerFieldRaw('form-123', ['field-1', 'field-2']);
+
+      expect(result).toEqual([{ field_id: 'field-1', count: BigInt(5) }]);
+    });
+  });
+
+  describe('countReferencingAnyFieldRaw', () => {
+    it('should return a count row', async () => {
+      (mockPrisma.$queryRaw as any).mockResolvedValue([{ count: BigInt(7) }]);
+
+      const result = await responseRepository.countReferencingAnyFieldRaw('form-123', ['field-1']);
+
+      expect(result).toEqual([{ count: BigInt(7) }]);
+    });
+  });
+
+  describe('countFilteredRaw', () => {
+    it('should count via queryRawUnsafe and coerce bigint to number', async () => {
+      (mockPrisma.$queryRawUnsafe as any).mockResolvedValue([{ count: BigInt(12) }]);
+
+      const result = await responseRepository.countFilteredRaw('WHERE "formId" = $1', ['form-123']);
+
+      expect(result).toBe(12);
+      expect(mockPrisma.$queryRawUnsafe).toHaveBeenCalledWith(
+        'SELECT COUNT(*) as count FROM "response" WHERE "formId" = $1',
+        'form-123'
+      );
+    });
+  });
+
+  describe('findFilteredRaw', () => {
+    it('should query with pagination params appended', async () => {
+      const rows = [{ id: 'response-1', formId: 'form-123', data: {}, metadata: null, respondentEmail: null, submittedAt: new Date() }];
+      (mockPrisma.$queryRawUnsafe as any).mockResolvedValue(rows);
+
+      const result = await responseRepository.findFilteredRaw(
+        'WHERE "formId" = $1',
+        'ORDER BY "submittedAt" DESC',
+        ['form-123'],
+        10,
+        0
+      );
+
+      expect(result).toEqual(rows);
+      expect(mockPrisma.$queryRawUnsafe).toHaveBeenCalledWith(
+        expect.stringContaining('LIMIT $2 OFFSET $3'),
+        'form-123',
+        10,
+        0
+      );
+    });
+  });
+
+  describe('softDeleteMany', () => {
+    it('should soft-delete non-deleted responses by id', async () => {
+      mockPrisma.response.updateMany.mockResolvedValue({ count: 2 } as any);
+
+      const result = await responseRepository.softDeleteMany('form-123', ['response-1', 'response-2']);
+
+      expect(result).toEqual({ count: 2 });
+      expect(mockPrisma.response.updateMany).toHaveBeenCalledWith({
+        where: { id: { in: ['response-1', 'response-2'] }, formId: 'form-123', deletedAt: null },
+        data: { deletedAt: expect.any(Date) },
       });
     });
   });

--- a/apps/backend/src/repositories/formSubmissionAnalyticsRepository.ts
+++ b/apps/backend/src/repositories/formSubmissionAnalyticsRepository.ts
@@ -13,6 +13,10 @@ export const createFormSubmissionAnalyticsRepository = (
   const count = (args?: Prisma.FormSubmissionAnalyticsCountArgs) =>
     prisma.formSubmissionAnalytics.count(args);
 
+  const deleteMany = <T extends Prisma.FormSubmissionAnalyticsDeleteManyArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.FormSubmissionAnalyticsDeleteManyArgs>
+  ) => prisma.formSubmissionAnalytics.deleteMany(args);
+
   // Prisma's groupBy overloads require a non-optional `orderBy` in the intersection type,
   // which the declared GroupByArgs type does not satisfy — `as any` is the standard workaround.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -94,14 +98,74 @@ export const createFormSubmissionAnalyticsRepository = (
     }));
   };
 
+  // P3-04: Date instead of string, same rationale as DailySubmissionRow above.
+  type OrgDailySubmissionRow = { date: Date; submissions: bigint };
+
+  /**
+   * Daily submission counts across every form in an organization, for the
+   * given period. Joins `form` to scope by organizationId
+   * (form_submission_analytics has no organizationId column of its own).
+   */
+  const getOrgDailySubmissionCounts = (
+    organizationId: string,
+    periodStart: Date,
+    periodEnd: Date
+  ): Promise<OrgDailySubmissionRow[]> =>
+    prisma.$queryRaw<OrgDailySubmissionRow[]>`
+      SELECT
+        DATE_TRUNC('day', fsa."submittedAt") AS date,
+        COUNT(*) AS submissions
+      FROM "form_submission_analytics" fsa
+      JOIN "form" f ON f.id = fsa."formId"
+      WHERE f."organizationId" = ${organizationId}
+        AND fsa."submittedAt" >= ${periodStart}
+        AND fsa."submittedAt" <= ${periodEnd}
+      GROUP BY DATE_TRUNC('day', fsa."submittedAt")
+      ORDER BY date ASC
+    `;
+
+  /**
+   * P2-05: Completion time percentiles computed in SQL to avoid loading all
+   * rows into JS memory. PERCENTILE_CONT is a PostgreSQL ordered-set aggregate.
+   */
+  const getCompletionTimePercentiles = async (
+    formId: string
+  ): Promise<{
+    p50: number | null;
+    p75: number | null;
+    p90: number | null;
+    p95: number | null;
+    avg: number | null;
+    total: bigint;
+  } | null> => {
+    const rows = await prisma.$queryRaw<Array<{
+      p50: number | null; p75: number | null; p90: number | null; p95: number | null;
+      avg: number | null; total: bigint;
+    }>>`
+      SELECT
+        PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY "completionTimeSeconds") AS p50,
+        PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY "completionTimeSeconds") AS p75,
+        PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY "completionTimeSeconds") AS p90,
+        PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY "completionTimeSeconds") AS p95,
+        AVG("completionTimeSeconds") AS avg,
+        COUNT(*) AS total
+      FROM form_submission_analytics
+      WHERE "formId" = ${formId} AND "completionTimeSeconds" IS NOT NULL
+    `;
+    return rows[0] ?? null;
+  };
+
   return {
     create,
     count,
+    deleteMany,
     groupBy,
     findMany,
     createSubmissionEvent,
     countDistinctSessions,
     getDailySubmissionStats,
+    getOrgDailySubmissionCounts,
+    getCompletionTimePercentiles,
   };
 };
 

--- a/apps/backend/src/repositories/formSubmissionAnalyticsRepository.ts
+++ b/apps/backend/src/repositories/formSubmissionAnalyticsRepository.ts
@@ -155,6 +155,23 @@ export const createFormSubmissionAnalyticsRepository = (
     return rows[0] ?? null;
   };
 
+  /**
+   * Average completion time for a form, computed in SQL so the dashboard-stats
+   * field resolver never loads every submission row into JS memory. Excludes
+   * null and non-positive values, matching the semantics the JS-side
+   * computation historically used.
+   */
+  const getAverageCompletionTime = async (formId: string): Promise<number | null> => {
+    const rows = await prisma.$queryRaw<Array<{ avg: number | null }>>`
+      SELECT AVG("completionTimeSeconds") AS avg
+      FROM form_submission_analytics
+      WHERE "formId" = ${formId}
+        AND "completionTimeSeconds" IS NOT NULL
+        AND "completionTimeSeconds" > 0
+    `;
+    return rows[0]?.avg ?? null;
+  };
+
   return {
     create,
     count,
@@ -166,6 +183,7 @@ export const createFormSubmissionAnalyticsRepository = (
     getDailySubmissionStats,
     getOrgDailySubmissionCounts,
     getCompletionTimePercentiles,
+    getAverageCompletionTime,
   };
 };
 

--- a/apps/backend/src/repositories/formViewAnalyticsRepository.ts
+++ b/apps/backend/src/repositories/formViewAnalyticsRepository.ts
@@ -17,6 +17,10 @@ export const createFormViewAnalyticsRepository = (
   const count = (args?: Prisma.FormViewAnalyticsCountArgs) =>
     prisma.formViewAnalytics.count(args);
 
+  const deleteMany = <T extends Prisma.FormViewAnalyticsDeleteManyArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.FormViewAnalyticsDeleteManyArgs>
+  ) => prisma.formViewAnalytics.deleteMany(args);
+
   // Prisma's groupBy overloads require a non-optional `orderBy` in the intersection type,
   // which the declared GroupByArgs type does not satisfy — `as any` is the standard workaround.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -107,9 +111,36 @@ export const createFormViewAnalyticsRepository = (
     }));
   };
 
+  // P3-04: Date instead of string, same rationale as DailyViewRow above.
+  type OrgDailyViewRow = { date: Date; views: bigint };
+
+  /**
+   * Daily view counts across every form in an organization, for the given
+   * period. Joins `form` to scope by organizationId (form_view_analytics has
+   * no organizationId column of its own).
+   */
+  const getOrgDailyViewCounts = (
+    organizationId: string,
+    periodStart: Date,
+    periodEnd: Date
+  ): Promise<OrgDailyViewRow[]> =>
+    prisma.$queryRaw<OrgDailyViewRow[]>`
+      SELECT
+        DATE_TRUNC('day', fva."viewedAt") AS date,
+        COUNT(*) AS views
+      FROM "form_view_analytics" fva
+      JOIN "form" f ON f.id = fva."formId"
+      WHERE f."organizationId" = ${organizationId}
+        AND fva."viewedAt" >= ${periodStart}
+        AND fva."viewedAt" <= ${periodEnd}
+      GROUP BY DATE_TRUNC('day', fva."viewedAt")
+      ORDER BY date ASC
+    `;
+
   return {
     create,
     updateMany,
+    deleteMany,
     count,
     groupBy,
     findMany,
@@ -117,6 +148,7 @@ export const createFormViewAnalyticsRepository = (
     updateSessionMetrics,
     countDistinctSessions,
     getDailyViewStats,
+    getOrgDailyViewCounts,
   };
 };
 

--- a/apps/backend/src/repositories/responseRepository.ts
+++ b/apps/backend/src/repositories/responseRepository.ts
@@ -45,6 +45,10 @@ export const createResponseRepository = (context?: RepositoryContext) => {
     args?: Prisma.SelectSubset<T, Prisma.ResponseDeleteManyArgs>
   ) => prisma.response.deleteMany(args);
 
+  const updateMany = <T extends Prisma.ResponseUpdateManyArgs>(
+    args: Prisma.SelectSubset<T, Prisma.ResponseUpdateManyArgs>
+  ) => prisma.response.updateMany(args);
+
   const createEditHistory = <T extends Prisma.ResponseEditHistoryCreateArgs>(
     args: Prisma.SelectSubset<T, Prisma.ResponseEditHistoryCreateArgs>
   ) => prisma.responseEditHistory.create(args);
@@ -70,6 +74,102 @@ export const createResponseRepository = (context?: RepositoryContext) => {
       orderBy: { submittedAt: 'desc' },
     });
 
+  /**
+   * Per-field count of non-deleted responses holding a non-empty value for
+   * each of the given field ids. One indexed scan via LATERAL jsonb_each.
+   */
+  const countPerFieldRaw = (
+    formId: string,
+    fieldIds: string[]
+  ): Promise<Array<{ field_id: string; count: bigint }>> =>
+    prisma.$queryRaw<Array<{ field_id: string; count: bigint }>>`
+      SELECT key AS field_id, COUNT(*)::bigint AS count
+      FROM "response", LATERAL jsonb_each("data") AS entry(key, value)
+      WHERE "formId" = ${formId}
+        AND "deletedAt" IS NULL
+        AND key = ANY(${fieldIds})
+        AND value IS NOT NULL
+        AND value <> 'null'::jsonb
+        AND value <> '""'::jsonb
+      GROUP BY key
+    `;
+
+  /**
+   * Count of distinct non-deleted responses holding a non-empty value for
+   * ANY of the given field ids.
+   */
+  const countReferencingAnyFieldRaw = (
+    formId: string,
+    fieldIds: string[]
+  ): Promise<Array<{ count: bigint }>> =>
+    prisma.$queryRaw<Array<{ count: bigint }>>`
+      SELECT COUNT(*)::bigint AS count
+      FROM "response" r
+      WHERE r."formId" = ${formId}
+        AND r."deletedAt" IS NULL
+        AND EXISTS (
+          SELECT 1 FROM jsonb_each(r."data") AS entry(key, value)
+          WHERE key = ANY(${fieldIds})
+            AND value IS NOT NULL
+            AND value <> 'null'::jsonb
+            AND value <> '""'::jsonb
+        )
+    `;
+
+  /**
+   * Count of responses matching a caller-built raw WHERE clause (dynamic
+   * filter conditions constructed by responseQueryBuilder). `whereClause`
+   * must start with `WHERE "formId" = $1` — params[0] is always the formId.
+   */
+  const countFilteredRaw = async (
+    whereClause: string,
+    params: unknown[]
+  ): Promise<number> => {
+    const result = await prisma.$queryRawUnsafe<[{ count: bigint }]>(
+      `SELECT COUNT(*) as count FROM "response" ${whereClause}`,
+      ...params
+    );
+    return Number(result[0].count);
+  };
+
+  /**
+   * Page of responses matching a caller-built raw WHERE/ORDER BY clause.
+   * `limit`/`offset` are appended as the final positional params.
+   */
+  const findFilteredRaw = (
+    whereClause: string,
+    orderClause: string,
+    params: unknown[],
+    limit: number,
+    offset: number
+  ): Promise<
+    Array<{
+      id: string;
+      formId: string;
+      data: Prisma.JsonValue;
+      metadata: Prisma.JsonValue;
+      respondentEmail: string | null;
+      submittedAt: Date;
+    }>
+  > => {
+    const paginationStart = params.length + 1;
+    const selectQuery = `
+      SELECT id, "formId", data, metadata, "respondentEmail", "submittedAt"
+      FROM "response"
+      ${whereClause}
+      ${orderClause}
+      LIMIT $${paginationStart} OFFSET $${paginationStart + 1}
+    `;
+    return prisma.$queryRawUnsafe(selectQuery, ...params, limit, offset);
+  };
+
+  /** Soft-deletes (sets deletedAt) a batch of non-deleted responses for a form. */
+  const softDeleteMany = (formId: string, ids: string[]) =>
+    prisma.response.updateMany({
+      where: { id: { in: ids }, formId, deletedAt: null },
+      data: { deletedAt: new Date() },
+    });
+
   return {
     findMany,
     findUnique,
@@ -78,12 +178,18 @@ export const createResponseRepository = (context?: RepositoryContext) => {
     create,
     createMany,
     update,
+    updateMany,
     delete: remove,
     deleteMany,
     createEditHistory,
     findEditHistory,
     createFieldChange,
     listByForm,
+    countPerFieldRaw,
+    countReferencingAnyFieldRaw,
+    countFilteredRaw,
+    findFilteredRaw,
+    softDeleteMany,
   };
 };
 

--- a/apps/backend/src/services/__tests__/analyticsService.test.ts
+++ b/apps/backend/src/services/__tests__/analyticsService.test.ts
@@ -4,18 +4,10 @@ import {
   formViewAnalyticsRepository,
   formSubmissionAnalyticsRepository,
 } from '../../repositories/index.js';
-import { prisma } from '../../lib/prisma.js';
 import { logger } from '../../lib/logger.js';
 
 // Mock repositories
 vi.mock('../../repositories/index.js');
-
-// P2-05: analyticsService now calls prisma.$queryRaw for SQL percentile calculation
-vi.mock('../../lib/prisma.js', () => ({
-  prisma: {
-    $queryRaw: vi.fn(),
-  },
-}));
 
 // Mock external dependencies
 vi.mock('ua-parser-js', () => ({
@@ -530,9 +522,9 @@ describe('Analytics Service', () => {
         .mockResolvedValueOnce([{ browser: 'Chrome', _count: { browser: 1 } }] as any);
 
       // P2-05: mock the SQL percentile query result
-      vi.mocked(prisma.$queryRaw).mockResolvedValue([
-        { p50: 120, p75: 120, p90: 120, p95: 120, avg: 120, total: BigInt(1) },
-      ] as any);
+      vi.mocked(formSubmissionAnalyticsRepository.getCompletionTimePercentiles).mockResolvedValue(
+        { p50: 120, p75: 120, p90: 120, p95: 120, avg: 120, total: BigInt(1) } as any
+      );
 
       vi.mocked(formSubmissionAnalyticsRepository.findMany).mockResolvedValue([
         { completionTimeSeconds: 120 },
@@ -560,9 +552,9 @@ describe('Analytics Service', () => {
         .mockResolvedValueOnce([{ browser: 'Chrome', _count: { browser: 1 } }] as any);
 
       // P2-05: mock the SQL percentile query — avg of [60, 120, 180] = 120
-      vi.mocked(prisma.$queryRaw).mockResolvedValue([
-        { p50: 120, p75: 150, p90: 162, p95: 171, avg: 120, total: BigInt(3) },
-      ] as any);
+      vi.mocked(formSubmissionAnalyticsRepository.getCompletionTimePercentiles).mockResolvedValue(
+        { p50: 120, p75: 150, p90: 162, p95: 171, avg: 120, total: BigInt(3) } as any
+      );
 
       vi.mocked(formSubmissionAnalyticsRepository.findMany).mockResolvedValue([
         { completionTimeSeconds: 60 },
@@ -727,15 +719,14 @@ describe('Analytics Service', () => {
     const periodEnd = new Date('2026-06-30T23:59:59Z');
 
     it('returns merged daily views and submissions sorted by date', async () => {
-      (prisma.$queryRaw as any)
-        .mockResolvedValueOnce([
-          { date: new Date('2026-06-01T00:00:00Z'), views: BigInt(5) },
-          { date: new Date('2026-06-03T00:00:00Z'), views: BigInt(2) },
-        ])
-        .mockResolvedValueOnce([
-          { date: new Date('2026-06-01T00:00:00Z'), submissions: BigInt(3) },
-          { date: new Date('2026-06-04T00:00:00Z'), submissions: BigInt(1) },
-        ]);
+      vi.mocked(formViewAnalyticsRepository.getOrgDailyViewCounts).mockResolvedValue([
+        { date: new Date('2026-06-01T00:00:00Z'), views: BigInt(5) },
+        { date: new Date('2026-06-03T00:00:00Z'), views: BigInt(2) },
+      ]);
+      vi.mocked(formSubmissionAnalyticsRepository.getOrgDailySubmissionCounts).mockResolvedValue([
+        { date: new Date('2026-06-01T00:00:00Z'), submissions: BigInt(3) },
+        { date: new Date('2026-06-04T00:00:00Z'), submissions: BigInt(1) },
+      ]);
 
       const result = await analyticsService.getOrgDailyUsage(orgId, periodStart, periodEnd);
 
@@ -747,17 +738,17 @@ describe('Analytics Service', () => {
     });
 
     it('returns empty array when no data exists', async () => {
-      (prisma.$queryRaw as any)
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([]);
+      vi.mocked(formViewAnalyticsRepository.getOrgDailyViewCounts).mockResolvedValue([]);
+      vi.mocked(formSubmissionAnalyticsRepository.getOrgDailySubmissionCounts).mockResolvedValue([]);
 
       const result = await analyticsService.getOrgDailyUsage(orgId, periodStart, periodEnd);
 
       expect(result).toEqual([]);
     });
 
-    it('throws when prisma.$queryRaw fails', async () => {
-      (prisma.$queryRaw as any).mockRejectedValueOnce(new Error('DB error'));
+    it('throws when the underlying repository query fails', async () => {
+      vi.mocked(formViewAnalyticsRepository.getOrgDailyViewCounts).mockRejectedValue(new Error('DB error'));
+      vi.mocked(formSubmissionAnalyticsRepository.getOrgDailySubmissionCounts).mockResolvedValue([]);
 
       await expect(
         analyticsService.getOrgDailyUsage(orgId, periodStart, periodEnd)

--- a/apps/backend/src/services/__tests__/analyticsService.test.ts
+++ b/apps/backend/src/services/__tests__/analyticsService.test.ts
@@ -713,6 +713,40 @@ describe('Analytics Service', () => {
     });
   });
 
+  describe('getDashboardViewCounts', () => {
+    it('returns total/thisWeek/lastWeek view counts', async () => {
+      vi.mocked(formViewAnalyticsRepository.count)
+        .mockResolvedValueOnce(100)
+        .mockResolvedValueOnce(10)
+        .mockResolvedValueOnce(5);
+
+      const result = await analyticsService.getDashboardViewCounts('form-123', {
+        weekAgo: new Date('2026-05-24'),
+        twoWeeksAgo: new Date('2026-05-17'),
+      });
+
+      expect(result).toEqual({ total: 100, thisWeek: 10, lastWeek: 5 });
+    });
+  });
+
+  describe('getAverageCompletionTime', () => {
+    it('returns the SQL-computed average as a number', async () => {
+      vi.mocked(formSubmissionAnalyticsRepository.getAverageCompletionTime).mockResolvedValue(150);
+
+      const result = await analyticsService.getAverageCompletionTime('form-123');
+
+      expect(result).toBe(150);
+    });
+
+    it('returns null when there is no completion-time data', async () => {
+      vi.mocked(formSubmissionAnalyticsRepository.getAverageCompletionTime).mockResolvedValue(null);
+
+      const result = await analyticsService.getAverageCompletionTime('form-123');
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe('getOrgDailyUsage', () => {
     const orgId = 'org-abc';
     const periodStart = new Date('2026-06-01T00:00:00Z');

--- a/apps/backend/src/services/__tests__/responseFieldCounts.test.ts
+++ b/apps/backend/src/services/__tests__/responseFieldCounts.test.ts
@@ -3,21 +3,27 @@ import {
   countResponsesPerField,
   countResponsesReferencingAnyField,
 } from '../responseService.js';
-import { prisma } from '../../lib/prisma.js';
+import { responseRepository } from '../../repositories/index.js';
 
-vi.mock('../../repositories/index.js', () => ({ responseRepository: {} }));
+vi.mock('../../repositories/index.js', () => ({
+  responseRepository: {
+    countPerFieldRaw: vi.fn(),
+    countReferencingAnyFieldRaw: vi.fn(),
+  },
+  createResponseRepository: vi.fn(),
+}));
 vi.mock('../responseFilterService.js', () => ({ applyResponseFilters: vi.fn() }));
 vi.mock('../responseEditTrackingService.js', () => ({ ResponseEditTrackingService: {} }));
 vi.mock('../tagService.js', () => ({ batchLoadTagsForResponses: vi.fn() }));
 vi.mock('../../lib/prisma.js', () => ({
-  prisma: { $queryRaw: vi.fn() },
+  prisma: { $transaction: vi.fn() },
 }));
 
 describe('countResponsesPerField', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns 0 for every requested field id, then overlays query counts', async () => {
-    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([
+    vi.mocked(responseRepository.countPerFieldRaw).mockResolvedValueOnce([
       { field_id: 'f-1', count: BigInt(42) },
       { field_id: 'f-3', count: BigInt(5) },
     ] as any);
@@ -29,11 +35,11 @@ describe('countResponsesPerField', () => {
   it('short-circuits with an empty map when no field ids are given (no query)', async () => {
     const result = await countResponsesPerField('form-1', []);
     expect(result).toEqual({});
-    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+    expect(responseRepository.countPerFieldRaw).not.toHaveBeenCalled();
   });
 
   it('returns all-zero counts and logs when the query throws', async () => {
-    vi.mocked(prisma.$queryRaw).mockRejectedValueOnce(new Error('db down'));
+    vi.mocked(responseRepository.countPerFieldRaw).mockRejectedValueOnce(new Error('db down'));
     const result = await countResponsesPerField('form-1', ['f-1', 'f-2']);
     expect(result).toEqual({ 'f-1': 0, 'f-2': 0 });
   });
@@ -43,7 +49,7 @@ describe('countResponsesReferencingAnyField', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns the distinct response count from the query', async () => {
-    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ count: BigInt(7) }] as any);
+    vi.mocked(responseRepository.countReferencingAnyFieldRaw).mockResolvedValueOnce([{ count: BigInt(7) }] as any);
     const result = await countResponsesReferencingAnyField('form-1', ['f-1', 'f-2']);
     expect(result).toBe(7);
   });
@@ -51,17 +57,17 @@ describe('countResponsesReferencingAnyField', () => {
   it('returns 0 when no field ids are given (no query)', async () => {
     const result = await countResponsesReferencingAnyField('form-1', []);
     expect(result).toBe(0);
-    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+    expect(responseRepository.countReferencingAnyFieldRaw).not.toHaveBeenCalled();
   });
 
   it('returns 0 when the query returns no rows', async () => {
-    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([] as any);
+    vi.mocked(responseRepository.countReferencingAnyFieldRaw).mockResolvedValueOnce([] as any);
     const result = await countResponsesReferencingAnyField('form-1', ['f-1']);
     expect(result).toBe(0);
   });
 
   it('returns 0 and logs when the query throws', async () => {
-    vi.mocked(prisma.$queryRaw).mockRejectedValueOnce(new Error('db down'));
+    vi.mocked(responseRepository.countReferencingAnyFieldRaw).mockRejectedValueOnce(new Error('db down'));
     const result = await countResponsesReferencingAnyField('form-1', ['f-1']);
     expect(result).toBe(0);
   });

--- a/apps/backend/src/services/__tests__/responseService.test.ts
+++ b/apps/backend/src/services/__tests__/responseService.test.ts
@@ -8,12 +8,11 @@ import {
   updateResponse,
   deleteResponse,
 } from '../responseService.js';
-import { responseRepository } from '../../repositories/index.js';
+import { responseRepository, createResponseRepository } from '../../repositories/index.js';
 import { logger } from '../../lib/logger.js';
 
 import { applyResponseFilters } from '../responseFilterService.js';
 import { ResponseEditTrackingService } from '../responseEditTrackingService.js';
-import { prisma } from '../../lib/prisma.js';
 import { emitResponseEdited } from '../../plugins/core/events.js';
 
 // Mock dependencies
@@ -68,6 +67,10 @@ describe('Response Service', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Transaction-scoped repository used inside updateResponse's prisma.$transaction (P2-02)
+    vi.mocked(createResponseRepository).mockReturnValue({
+      update: mockTxClient.response.update,
+    } as any);
   });
 
   afterEach(() => {
@@ -209,12 +212,10 @@ describe('Response Service', () => {
 
     it('should apply filters when provided', async () => {
       const mockResponses = [mockResponse];
-      
-      // Mock Prisma calls for database-level filtering
-      vi.mocked(prisma.$queryRawUnsafe).mockResolvedValueOnce([{ count: BigInt(1) }] as any);
-      vi.mocked(prisma.$queryRawUnsafe).mockResolvedValueOnce(mockResponses as any);
-      vi.mocked(prisma.response.count).mockResolvedValue(1);
-      vi.mocked(prisma.response.findMany).mockResolvedValue(mockResponses as any);
+
+      // Mock repository calls for database-level filtering
+      vi.mocked(responseRepository.countFilteredRaw).mockResolvedValueOnce(1);
+      vi.mocked(responseRepository.findFilteredRaw).mockResolvedValueOnce(mockResponses as any);
       // Mock memory filtering fallback in case database filtering fails
       vi.mocked(applyResponseFilters).mockReturnValue(mockResponses as any);
 

--- a/apps/backend/src/services/__tests__/responseService.test.ts
+++ b/apps/backend/src/services/__tests__/responseService.test.ts
@@ -5,6 +5,7 @@ import {
   getResponsesByFormId,
   getAllResponsesByFormId,
   submitResponse,
+  submitResponseWithMaxLimitCheck,
   updateResponse,
   deleteResponse,
 } from '../responseService.js';
@@ -18,10 +19,13 @@ import { emitResponseEdited } from '../../plugins/core/events.js';
 // Mock dependencies
 vi.mock('../../repositories/index.js');
 vi.mock('../responseFilterService.js');
-// Minimal mock Prisma transaction client used by updateResponse (P2-02)
+// Minimal mock Prisma transaction client used by updateResponse (P2-02) and
+// submitResponseWithMaxLimitCheck's Serializable max-responses transaction
 const mockTxClient = {
   response: {
     update: vi.fn(),
+    count: vi.fn(),
+    create: vi.fn(),
   },
 };
 
@@ -68,8 +72,11 @@ describe('Response Service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Transaction-scoped repository used inside updateResponse's prisma.$transaction (P2-02)
+    // and submitResponseWithMaxLimitCheck's Serializable transaction
     vi.mocked(createResponseRepository).mockReturnValue({
       update: mockTxClient.response.update,
+      count: mockTxClient.response.count,
+      create: mockTxClient.response.create,
     } as any);
   });
 
@@ -328,6 +335,59 @@ describe('Response Service', () => {
       const result = await submitResponse(invalidResponse);
 
       expect(result).toBeDefined();
+    });
+  });
+
+  describe('submitResponseWithMaxLimitCheck', () => {
+    const responseData = {
+      id: 'response-123',
+      formId: 'form-123',
+      data: { field1: 'value1' },
+      respondentUserId: null,
+      respondentEmail: null,
+    };
+
+    it('rejects when the current count has already reached the limit', async () => {
+      mockTxClient.response.count.mockResolvedValue(10);
+
+      await expect(
+        submitResponseWithMaxLimitCheck(responseData, 10)
+      ).rejects.toThrow('Form has reached its maximum response limit');
+
+      expect(mockTxClient.response.create).not.toHaveBeenCalled();
+    });
+
+    it('inserts and returns the mapped FormResponse when under the limit', async () => {
+      mockTxClient.response.count.mockResolvedValue(5);
+      mockTxClient.response.create.mockResolvedValue({
+        ...mockResponse,
+        id: 'response-123',
+        formId: 'form-123',
+        data: { field1: 'value1' },
+        metadata: null,
+        respondentEmail: undefined,
+        submittedAt: new Date('2024-01-01'),
+      });
+
+      const result = await submitResponseWithMaxLimitCheck(responseData, 10);
+
+      expect(mockTxClient.response.count).toHaveBeenCalledWith({
+        where: { formId: 'form-123' },
+      });
+      expect(mockTxClient.response.create).toHaveBeenCalledWith({
+        data: {
+          id: 'response-123',
+          formId: 'form-123',
+          data: { field1: 'value1' },
+          respondentUserId: null,
+          respondentEmail: null,
+        },
+      });
+      expect(result).toMatchObject({
+        id: 'response-123',
+        formId: 'form-123',
+        data: { field1: 'value1' },
+      });
     });
   });
 

--- a/apps/backend/src/services/analyticsService.ts
+++ b/apps/backend/src/services/analyticsService.ts
@@ -5,7 +5,6 @@ import { createRequire } from 'module';
 import { existsSync } from 'fs';
 import { Reader } from '@maxmind/geoip2-node';
 import { logger } from '../lib/logger.js';
-import { prisma } from '../lib/prisma.js';
 import {
   formViewAnalyticsRepository,
   formSubmissionAnalyticsRepository,
@@ -402,6 +401,42 @@ const createCompletionTimeDistribution = (completionTimes: number[]) => {
   }).filter(range => range.count > 0); // Only return ranges with data
 };
 
+/**
+ * Bucketed view counts for the `Form.dashboardStats` field resolver. All
+ * three counts are independent and safe to run concurrently.
+ */
+const getDashboardViewCounts = async (
+  formId: string,
+  ranges: { weekAgo: Date; twoWeeksAgo: Date }
+): Promise<{ total: number; thisWeek: number; lastWeek: number }> => {
+  const [total, thisWeek, lastWeek] = await Promise.all([
+    formViewAnalyticsRepository.count({ where: { formId } }),
+    formViewAnalyticsRepository.count({ where: { formId, viewedAt: { gte: ranges.weekAgo } } }),
+    formViewAnalyticsRepository.count({ where: { formId, viewedAt: { gte: ranges.twoWeeksAgo, lt: ranges.weekAgo } } }),
+  ]);
+  return { total, thisWeek, lastWeek };
+};
+
+/**
+ * Average completion time across a form's submission analytics, ignoring
+ * null and non-positive values. Used by the `Form.dashboardStats` field
+ * resolver.
+ */
+const getAverageCompletionTime = async (formId: string): Promise<number | null> => {
+  const submissionAnalytics = await formSubmissionAnalyticsRepository.findMany({
+    where: { formId },
+    select: { completionTimeSeconds: true },
+  });
+
+  const validCompletionTimes = submissionAnalytics
+    .map((s) => s.completionTimeSeconds)
+    .filter((t): t is number => t !== null && t > 0);
+
+  return validCompletionTimes.length > 0
+    ? validCompletionTimes.reduce((sum, t) => sum + t, 0) / validCompletionTimes.length
+    : null;
+};
+
 // Database query functions
 const getFormAnalytics = async (formId: string, timeRange?: { start: Date; end: Date }) => {
   try {
@@ -538,10 +573,6 @@ const getFormAnalytics = async (formId: string, timeRange?: { start: Date; end: 
   }
 };
 
-// Org daily usage types
-type OrgDailyViewRow = { date: Date; views: bigint };
-type OrgDailySubmissionRow = { date: Date; submissions: bigint };
-
 /**
  * Get organization's daily views and submissions for a given time period.
  * Returns merged data sorted by date in ascending order.
@@ -553,30 +584,8 @@ const getOrgDailyUsage = async (
 ): Promise<Array<{ date: string; views: number; submissions: number }>> => {
   try {
     const [viewRows, submissionRows] = await Promise.all([
-      prisma.$queryRaw<OrgDailyViewRow[]>`
-        SELECT
-          DATE_TRUNC('day', fva."viewedAt") AS date,
-          COUNT(*) AS views
-        FROM "form_view_analytics" fva
-        JOIN "form" f ON f.id = fva."formId"
-        WHERE f."organizationId" = ${organizationId}
-          AND fva."viewedAt" >= ${periodStart}
-          AND fva."viewedAt" <= ${periodEnd}
-        GROUP BY DATE_TRUNC('day', fva."viewedAt")
-        ORDER BY date ASC
-      `,
-      prisma.$queryRaw<OrgDailySubmissionRow[]>`
-        SELECT
-          DATE_TRUNC('day', fsa."submittedAt") AS date,
-          COUNT(*) AS submissions
-        FROM "form_submission_analytics" fsa
-        JOIN "form" f ON f.id = fsa."formId"
-        WHERE f."organizationId" = ${organizationId}
-          AND fsa."submittedAt" >= ${periodStart}
-          AND fsa."submittedAt" <= ${periodEnd}
-        GROUP BY DATE_TRUNC('day', fsa."submittedAt")
-        ORDER BY date ASC
-      `,
+      formViewAnalyticsRepository.getOrgDailyViewCounts(organizationId, periodStart, periodEnd),
+      formSubmissionAnalyticsRepository.getOrgDailySubmissionCounts(organizationId, periodStart, periodEnd),
     ]);
 
     const merged = new Map<string, { views: number; submissions: number }>();
@@ -625,8 +634,8 @@ export const cleanupOldAnalytics = async (daysToRetain = 365): Promise<void> => 
   cutoff.setDate(cutoff.getDate() - daysToRetain);
 
   const [viewsDeleted, submissionsDeleted] = await Promise.all([
-    prisma.formViewAnalytics.deleteMany({ where: { viewedAt: { lt: cutoff } } }),
-    prisma.formSubmissionAnalytics.deleteMany({ where: { submittedAt: { lt: cutoff } } }),
+    formViewAnalyticsRepository.deleteMany({ where: { viewedAt: { lt: cutoff } } }),
+    formSubmissionAnalyticsRepository.deleteMany({ where: { submittedAt: { lt: cutoff } } }),
   ]);
 
   logger.info(
@@ -707,20 +716,7 @@ const getFormSubmissionAnalytics = async (formId: string, timeRange?: { start: D
 
       // P2-05: Completion time percentiles computed in SQL to avoid loading all rows
       // into JS memory. PERCENTILE_CONT is a PostgreSQL ordered-set aggregate.
-      prisma.$queryRaw<Array<{
-        p50: number | null; p75: number | null; p90: number | null; p95: number | null;
-        avg: number | null; total: bigint;
-      }>>`
-        SELECT
-          PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY "completionTimeSeconds") AS p50,
-          PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY "completionTimeSeconds") AS p75,
-          PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY "completionTimeSeconds") AS p90,
-          PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY "completionTimeSeconds") AS p95,
-          AVG("completionTimeSeconds") AS avg,
-          COUNT(*) AS total
-        FROM form_submission_analytics
-        WHERE "formId" = ${formId} AND "completionTimeSeconds" IS NOT NULL
-      `,
+      formSubmissionAnalyticsRepository.getCompletionTimePercentiles(formId),
 
       // Distribution still needs individual values — cap at 10,000 rows to avoid
       // loading unbounded data into memory for large forms.
@@ -787,7 +783,7 @@ const getFormSubmissionAnalytics = async (formId: string, timeRange?: { start: D
     }
     
     // P2-05: Use SQL-computed percentiles — no JS-side sort over all rows needed
-    const sqlPercentiles = completionTimePercentilesRaw[0] ?? null;
+    const sqlPercentiles = completionTimePercentilesRaw ?? null;
     const averageCompletionTime = sqlPercentiles?.avg != null ? Number(sqlPercentiles.avg) : null;
     const completionTimePercentiles = sqlPercentiles
       ? {
@@ -831,6 +827,8 @@ const analyticsService = {
   getFormAnalytics,
   getFormSubmissionAnalytics,
   getOrgDailyUsage,
+  getDashboardViewCounts,
+  getAverageCompletionTime,
   initialize: initializeService
 };
 

--- a/apps/backend/src/services/analyticsService.ts
+++ b/apps/backend/src/services/analyticsService.ts
@@ -419,22 +419,13 @@ const getDashboardViewCounts = async (
 
 /**
  * Average completion time across a form's submission analytics, ignoring
- * null and non-positive values. Used by the `Form.dashboardStats` field
- * resolver.
+ * null and non-positive values. Computed in SQL (not loaded into JS memory)
+ * so this stays cheap on the frequently-hit `Form.dashboardStats` field
+ * resolver even for forms with large submission volumes.
  */
 const getAverageCompletionTime = async (formId: string): Promise<number | null> => {
-  const submissionAnalytics = await formSubmissionAnalyticsRepository.findMany({
-    where: { formId },
-    select: { completionTimeSeconds: true },
-  });
-
-  const validCompletionTimes = submissionAnalytics
-    .map((s) => s.completionTimeSeconds)
-    .filter((t): t is number => t !== null && t > 0);
-
-  return validCompletionTimes.length > 0
-    ? validCompletionTimes.reduce((sum, t) => sum + t, 0) / validCompletionTimes.length
-    : null;
+  const avg = await formSubmissionAnalyticsRepository.getAverageCompletionTime(formId);
+  return avg != null ? Number(avg) : null;
 };
 
 // Database query functions

--- a/apps/backend/src/services/responseService.ts
+++ b/apps/backend/src/services/responseService.ts
@@ -1,15 +1,18 @@
 import { FormResponse } from '@dculus/types';
+import { GRAPHQL_ERROR_CODES } from '@dculus/types/graphql.js';
+import { createGraphQLError } from '#graphql-errors';
 import { ResponseFilter, applyResponseFilters } from './responseFilterService.js';
 import {
   buildRawSQLCondition,
   canFilterAtDatabase
 } from './responseQueryBuilder.js';
 import { batchLoadTagsForResponses } from './tagService.js';
-import { responseRepository } from '../repositories/index.js';
+import { responseRepository, createResponseRepository } from '../repositories/index.js';
+import { withPrisma } from '../repositories/baseRepository.js';
 import { logger } from '../lib/logger.js';
 import { prisma } from '../lib/prisma.js';
 import { emitResponseEdited } from '../plugins/core/events.js';
-import type { Prisma } from '#prisma-client';
+import { Prisma } from '#prisma-client';
 
 
 /**
@@ -66,17 +69,7 @@ export const countResponsesPerField = async (
 
   try {
     // One indexed scan over the form's live responses; count per requested key.
-    const rows = await prisma.$queryRaw<Array<{ field_id: string; count: bigint }>>`
-      SELECT key AS field_id, COUNT(*)::bigint AS count
-      FROM "response", LATERAL jsonb_each("data") AS entry(key, value)
-      WHERE "formId" = ${formId}
-        AND "deletedAt" IS NULL
-        AND key = ANY(${fieldIds})
-        AND value IS NOT NULL
-        AND value <> 'null'::jsonb
-        AND value <> '""'::jsonb
-      GROUP BY key
-    `;
+    const rows = await responseRepository.countPerFieldRaw(formId, fieldIds);
     for (const row of rows) {
       result[row.field_id] = Number(row.count);
     }
@@ -96,24 +89,50 @@ export const countResponsesReferencingAnyField = async (
 ): Promise<number> => {
   if (fieldIds.length === 0) return 0;
   try {
-    const rows = await prisma.$queryRaw<Array<{ count: bigint }>>`
-      SELECT COUNT(*)::bigint AS count
-      FROM "response" r
-      WHERE r."formId" = ${formId}
-        AND r."deletedAt" IS NULL
-        AND EXISTS (
-          SELECT 1 FROM jsonb_each(r."data") AS entry(key, value)
-          WHERE key = ANY(${fieldIds})
-            AND value IS NOT NULL
-            AND value <> 'null'::jsonb
-            AND value <> '""'::jsonb
-        )
-    `;
+    const rows = await responseRepository.countReferencingAnyFieldRaw(formId, fieldIds);
     return rows.length > 0 ? Number(rows[0].count) : 0;
   } catch (error) {
     logger.error('Error counting responses referencing fields:', error);
     return 0;
   }
+};
+
+/** Non-deleted response count for a form. Used by the `Form.responseCount` field resolver. */
+export const getResponseCount = async (formId: string): Promise<number> =>
+  responseRepository.count({ where: { formId, deletedAt: null } });
+
+/**
+ * Total response count for a form, including soft-deleted rows. Used for the
+ * maximum-responses submission-limit check, which is intentionally based on
+ * every response ever recorded (not just currently-visible ones).
+ */
+export const countAllResponses = async (formId: string): Promise<number> =>
+  responseRepository.count({ where: { formId } });
+
+/**
+ * Bucketed non-deleted response counts for the `Form.dashboardStats` field
+ * resolver. All six counts are independent and safe to run concurrently.
+ */
+export const getDashboardResponseCounts = async (
+  formId: string,
+  ranges: { today: Date; weekAgo: Date; monthAgo: Date; yesterday: Date; twoWeeksAgo: Date }
+): Promise<{
+  today: number;
+  thisWeek: number;
+  thisMonth: number;
+  total: number;
+  yesterday: number;
+  lastWeek: number;
+}> => {
+  const [today, thisWeek, thisMonth, total, yesterday, lastWeek] = await Promise.all([
+    responseRepository.count({ where: { formId, deletedAt: null, submittedAt: { gte: ranges.today } } }),
+    responseRepository.count({ where: { formId, deletedAt: null, submittedAt: { gte: ranges.weekAgo } } }),
+    responseRepository.count({ where: { formId, deletedAt: null, submittedAt: { gte: ranges.monthAgo } } }),
+    responseRepository.count({ where: { formId, deletedAt: null } }),
+    responseRepository.count({ where: { formId, deletedAt: null, submittedAt: { gte: ranges.yesterday, lt: ranges.today } } }),
+    responseRepository.count({ where: { formId, deletedAt: null, submittedAt: { gte: ranges.twoWeeksAgo, lt: ranges.weekAgo } } }),
+  ]);
+  return { today, thisWeek, thisMonth, total, yesterday, lastWeek };
 };
 
 export const getResponseById = async (id: string): Promise<FormResponse | null> => {
@@ -220,9 +239,7 @@ export async function getResponsesByFormId(
 
 
       // Count total matching documents
-      const countQuery = `SELECT COUNT(*) as count FROM "response" ${whereClause}`;
-      const countResult = await prisma.$queryRawUnsafe<[{ count: bigint }]>(countQuery, ...params);
-      total = Number(countResult[0].count);
+      total = await responseRepository.countFilteredRaw(whereClause, params);
 
       // Build ORDER BY clause
       const orderClause = validSortBy === 'submittedAt'
@@ -230,23 +247,13 @@ export async function getResponsesByFormId(
         : `ORDER BY "id" ${validSortOrder.toUpperCase()}`; // Fallback to id sorting
 
       // Query with pagination and sorting — LIMIT/OFFSET passed as positional params
-      const paginationStart = params.length + 1;
-      const selectQuery = `
-        SELECT id, "formId", data, metadata, "respondentEmail", "submittedAt"
-        FROM "response"
-        ${whereClause}
-        ${orderClause}
-        LIMIT $${paginationStart} OFFSET $${paginationStart + 1}
-      `;
-
-      const dbResponses = await prisma.$queryRawUnsafe<Array<{
-        id: string;
-        formId: string;
-        data: Prisma.JsonValue;
-        metadata: Prisma.JsonValue;
-        respondentEmail: string | null;
-        submittedAt: Date;
-      }>>(selectQuery, ...params, validLimit, skip);
+      const dbResponses = await responseRepository.findFilteredRaw(
+        whereClause,
+        orderClause,
+        params,
+        validLimit,
+        skip
+      );
 
       // Convert to FormResponse format
       responses = dbResponses.map((doc) => ({
@@ -423,6 +430,58 @@ export const submitResponse = async (responseData: Partial<FormResponse>): Promi
   };
 };
 
+/**
+ * Atomic check-then-insert for a form's maximum-responses submission limit.
+ * Uses a Serializable transaction so two concurrent submissions cannot both
+ * pass the count check and both insert, exceeding the limit by one — do not
+ * weaken the isolation level or split the count/insert across transactions.
+ */
+export const submitResponseWithMaxLimitCheck = async (
+  responseData: {
+    id: string;
+    formId: string;
+    data: Prisma.InputJsonValue;
+    respondentUserId: string | null;
+    respondentEmail: string | null;
+  },
+  maxAllowed: number
+): Promise<FormResponse> => {
+  const inserted = await prisma.$transaction(
+    async (tx) => {
+      const txRepo = createResponseRepository(withPrisma(tx as any));
+
+      const currentCount = await txRepo.count({
+        where: { formId: responseData.formId },
+      });
+
+      if (currentCount >= maxAllowed) {
+        throw createGraphQLError('Form has reached its maximum response limit', GRAPHQL_ERROR_CODES.MAX_RESPONSES_REACHED);
+      }
+
+      // Insert atomically within the same transaction
+      return txRepo.create({
+        data: {
+          id: responseData.id,
+          formId: responseData.formId,
+          data: responseData.data,
+          respondentUserId: responseData.respondentUserId,
+          respondentEmail: responseData.respondentEmail,
+        },
+      });
+    },
+    { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+  );
+
+  return {
+    id: inserted.id,
+    formId: inserted.formId,
+    data: (inserted.data as Prisma.JsonObject) || {},
+    metadata: inserted.metadata as FormResponse['metadata'],
+    respondentEmail: inserted.respondentEmail ?? undefined,
+    submittedAt: inserted.submittedAt,
+  };
+};
+
 export const updateResponse = async (
   responseId: string,
   data: Prisma.JsonObject,
@@ -459,8 +518,12 @@ export const updateResponse = async (
       // transaction so a failure in recordEdit never leaves an untracked edit,
       // and a failure in the response update never creates an orphaned audit record.
       const updatedResponse = await prisma.$transaction(async (tx) => {
+        // Transaction-scoped repository so the response update and edit
+        // history recording share the same Prisma transaction client.
+        const txRepo = createResponseRepository(withPrisma(tx as any));
+
         // 1. Update the response row inside the transaction
-        const updated = await tx.response.update({
+        const updated = await txRepo.update({
           where: { id: responseId },
           data: { data: data as Prisma.InputJsonValue },
         });
@@ -559,10 +622,7 @@ export const deleteResponse = async (id: string): Promise<boolean> => {
 
 export const deleteResponses = async (formId: string, ids: string[]): Promise<boolean> => {
   try {
-    await prisma.response.updateMany({
-      where: { id: { in: ids }, formId, deletedAt: null },
-      data: { deletedAt: new Date() },
-    });
+    await responseRepository.softDeleteMany(formId, ids);
     return true;
   } catch (error) {
     logger.error('Error bulk-deleting responses:', error);


### PR DESCRIPTION
## Summary
Closes #257 (part of epic #245). Depends on #246 (Story 12), already merged.

- Extended `responseRepository` with domain methods for the raw SQL previously inline in `responseService.ts`: `countPerFieldRaw`, `countReferencingAnyFieldRaw`, `countFilteredRaw`/`findFilteredRaw` (the filtered list/count pair), and `softDeleteMany`/`updateMany`.
- Extended `formViewAnalyticsRepository`/`formSubmissionAnalyticsRepository` with `getOrgDailyViewCounts`/`getOrgDailySubmissionCounts`, `getCompletionTimePercentiles`, and `deleteMany`.
- Routed `responseService.ts` and `analyticsService.ts` entirely through these repositories — including refactoring the edit-tracking `prisma.$transaction` to the standard `createResponseRepository(withPrisma(tx))` pattern.
- Added `responseService.submitResponseWithMaxLimitCheck`, moving the Serializable max-responses check-then-insert transaction out of the `responses.ts` resolver and into the service layer (resolvers should never touch prisma directly), while preserving the exact isolation level and atomicity.
- Cleaned up `forms.ts`, `analytics.ts`, and `responses.ts` resolvers to route through `formService`/`responseService`/`analyticsService` instead of calling `prisma.*` directly (including swapping a leftover `prisma.formFile.create` in `forms.ts` for the existing `formFileService.createFormFile`).
- Added repository test coverage for every new method; updated resolver/service unit tests whose mocks assumed direct Prisma access.

## Test plan
- [x] `pnpm --filter backend exec tsc --noEmit` passes
- [x] `pnpm test:unit` passes (2986/2986)
- [x] `grep -n "prisma\." apps/backend/src/services/responseService.ts apps/backend/src/services/analyticsService.ts apps/backend/src/graphql/resolvers/forms.ts apps/backend/src/graphql/resolvers/analytics.ts apps/backend/src/graphql/resolvers/responses.ts` shows only the two expected `prisma.$transaction` transaction roots in `responseService.ts` (matching the canonical `formService.ts` pattern) — zero elsewhere
- [ ] `pnpm test:integration` — not run: Docker isn't available in this environment. An existing scenario (`test/integration/features/form-responses.feature:25`, "Submission limit prevents additional responses") already covers the max-responses transaction and should be verified in CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved analytics dashboards with more consistent view, submission, and completion-time metrics.
  * Strengthened response filtering, counts, pagination, and bulk deletion workflows.
  * Enforced maximum response limits more reliably during submissions.
  * Improved resilience so analytics or tracking failures do not interrupt successful form activity.

* **Tests**
  * Expanded coverage for analytics, response limits, filtering, reporting, and error-handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->