### PR TITLE
Story 05: PDF Generation — pdfGeneratorRepository

### DIFF
--- a/apps/backend/src/repositories/__tests__/pdfGeneratorRepository.test.ts
+++ b/apps/backend/src/repositories/__tests__/pdfGeneratorRepository.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createPdfGeneratorRepository } from '../pdfGeneratorRepository.js';
+
+const prismaMock = vi.hoisted(() => ({
+  pdfGenerator: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    count: vi.fn().mockResolvedValue(0),
+  },
+  pdfGenerationRun: {
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+  },
+  pdfGenerationResult: {
+    upsert: vi.fn().mockResolvedValue({}),
+    findUnique: vi.fn().mockResolvedValue(null),
+    findMany: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('../baseRepository.js', () => ({
+  resolvePrisma: () => prismaMock,
+}));
+
+describe('pdfGeneratorRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.pdfGenerator.findMany.mockResolvedValue([]);
+    prismaMock.pdfGenerator.findUnique.mockResolvedValue(null);
+    prismaMock.pdfGenerator.create.mockResolvedValue({});
+    prismaMock.pdfGenerator.update.mockResolvedValue({});
+    prismaMock.pdfGenerator.delete.mockResolvedValue({});
+    prismaMock.pdfGenerator.count.mockResolvedValue(0);
+    prismaMock.pdfGenerationRun.findFirst.mockResolvedValue(null);
+    prismaMock.pdfGenerationRun.findUnique.mockResolvedValue(null);
+    prismaMock.pdfGenerationRun.create.mockResolvedValue({});
+    prismaMock.pdfGenerationRun.update.mockResolvedValue({});
+    prismaMock.pdfGenerationResult.upsert.mockResolvedValue({});
+    prismaMock.pdfGenerationResult.findUnique.mockResolvedValue(null);
+    prismaMock.pdfGenerationResult.findMany.mockResolvedValue([]);
+  });
+
+  it('proxies basic prisma delegate methods for PdfGenerator', async () => {
+    const repo = createPdfGeneratorRepository();
+    const args = { where: { id: 'generator-1' } };
+
+    await repo.findMany(args as any);
+    await repo.findUnique(args as any);
+    await repo.create({ data: { id: 'generator-1' } } as any);
+    await repo.update({ where: { id: 'generator-1' }, data: { name: 'New' } } as any);
+    await repo.delete({ where: { id: 'generator-1' } } as any);
+    await repo.count(args as any);
+
+    expect(prismaMock.pdfGenerator.findMany).toHaveBeenCalledWith(args);
+    expect(prismaMock.pdfGenerator.findUnique).toHaveBeenCalledWith(args);
+    expect(prismaMock.pdfGenerator.create).toHaveBeenCalled();
+    expect(prismaMock.pdfGenerator.update).toHaveBeenCalled();
+    expect(prismaMock.pdfGenerator.delete).toHaveBeenCalled();
+    expect(prismaMock.pdfGenerator.count).toHaveBeenCalledWith(args);
+  });
+
+  describe('PdfGenerator domain helpers', () => {
+    it('findById looks up by id only', async () => {
+      const repo = createPdfGeneratorRepository();
+      await repo.findById('generator-1');
+      expect(prismaMock.pdfGenerator.findUnique).toHaveBeenCalledWith({ where: { id: 'generator-1' } });
+    });
+
+    it('findByIdWithTemplate includes the template relation', async () => {
+      const repo = createPdfGeneratorRepository();
+      await repo.findByIdWithTemplate('generator-1');
+      expect(prismaMock.pdfGenerator.findUnique).toHaveBeenCalledWith({
+        where: { id: 'generator-1' },
+        include: { template: true },
+      });
+    });
+
+    it('listByForm orders by createdAt desc', async () => {
+      const repo = createPdfGeneratorRepository();
+      await repo.listByForm('form-1');
+      expect(prismaMock.pdfGenerator.findMany).toHaveBeenCalledWith({
+        where: { formId: 'form-1' },
+        orderBy: { createdAt: 'desc' },
+      });
+    });
+
+    it('countByForm scopes to formId', async () => {
+      const repo = createPdfGeneratorRepository();
+      await repo.countByForm('form-1');
+      expect(prismaMock.pdfGenerator.count).toHaveBeenCalledWith({ where: { formId: 'form-1' } });
+    });
+
+    it('createGenerator / updateGenerator / deleteGenerator delegate correctly', async () => {
+      const repo = createPdfGeneratorRepository();
+      await repo.createGenerator({ id: 'generator-1' } as any);
+      await repo.updateGenerator('generator-1', { name: 'Renamed' } as any);
+      await repo.deleteGenerator('generator-1');
+
+      expect(prismaMock.pdfGenerator.create).toHaveBeenCalledWith({ data: { id: 'generator-1' } });
+      expect(prismaMock.pdfGenerator.update).toHaveBeenCalledWith({
+        where: { id: 'generator-1' },
+        data: { name: 'Renamed' },
+      });
+      expect(prismaMock.pdfGenerator.delete).toHaveBeenCalledWith({ where: { id: 'generator-1' } });
+    });
+  });
+
+  describe('PdfGenerationRun domain helpers', () => {
+    it('findRunById looks up by id only', async () => {
+      const repo = createPdfGeneratorRepository();
+      await repo.findRunById('run-1');
+      expect(prismaMock.pdfGenerationRun.findUnique).toHaveBeenCalledWith({ where: { id: 'run-1' } });
+    });
+
+    it('findActiveRun scopes to running/cancelling statuses', async () => {
+      const repo = createPdfGeneratorRepository();
+      await repo.findActiveRun('generator-1');
+      expect(prismaMock.pdfGenerationRun.findFirst).toHaveBeenCalledWith({
+        where: { generatorId: 'generator-1', status: { in: ['running', 'cancelling'] } },
+      });
+    });
+
+    it('findLatestRun orders by startedAt desc', async () => {
+      const repo = createPdfGeneratorRepository();
+      await repo.findLatestRun('generator-1');
+      expect(prismaMock.pdfGenerationRun.findFirst).toHaveBeenCalledWith({
+        where: { generatorId: 'generator-1' },
+        orderBy: { startedAt: 'desc' },
+      });
+    });
+
+    it('createRun delegates correctly', async () => {
+      const repo = createPdfGeneratorRepository();
+      await repo.createRun({ id: 'run-1' } as any);
+      expect(prismaMock.pdfGenerationRun.create).toHaveBeenCalledWith({ data: { id: 'run-1' } });
+    });
+
+    it('updateRunStatus updates the run by id with arbitrary status-transition data', async () => {
+      const repo = createPdfGeneratorRepository();
+      await repo.updateRunStatus('run-1', { status: 'completed', completedAt: expect.any(Date) } as any);
+      expect(prismaMock.pdfGenerationRun.update).toHaveBeenCalledWith({
+        where: { id: 'run-1' },
+        data: { status: 'completed', completedAt: expect.any(Date) },
+      });
+    });
+  });
+
+  describe('PdfGenerationResult domain helpers', () => {
+    it('upsertResult upserts on the generatorId_responseId compound key', async () => {
+      const repo = createPdfGeneratorRepository();
+      await repo.upsertResult('generator-1', 'response-1', {
+        create: { id: 'result-1', generatorId: 'generator-1', responseId: 'response-1', status: 'success' } as any,
+        update: { status: 'success' } as any,
+      });
+
+      expect(prismaMock.pdfGenerationResult.upsert).toHaveBeenCalledWith({
+        where: { generatorId_responseId: { generatorId: 'generator-1', responseId: 'response-1' } },
+        create: { id: 'result-1', generatorId: 'generator-1', responseId: 'response-1', status: 'success' },
+        update: { status: 'success' },
+      });
+    });
+
+    it('findResult looks up by the compound key', async () => {
+      const repo = createPdfGeneratorRepository();
+      await repo.findResult('generator-1', 'response-1');
+      expect(prismaMock.pdfGenerationResult.findUnique).toHaveBeenCalledWith({
+        where: { generatorId_responseId: { generatorId: 'generator-1', responseId: 'response-1' } },
+      });
+    });
+
+    it('listResultsByGenerator orders by generatedAt desc', async () => {
+      const repo = createPdfGeneratorRepository();
+      await repo.listResultsByGenerator('generator-1');
+      expect(prismaMock.pdfGenerationResult.findMany).toHaveBeenCalledWith({
+        where: { generatorId: 'generator-1' },
+        orderBy: { generatedAt: 'desc' },
+      });
+    });
+
+    it('listSuccessfulResultResponseIdsByGenerator selects only responseId', async () => {
+      const repo = createPdfGeneratorRepository();
+      await repo.listSuccessfulResultResponseIdsByGenerator('generator-1');
+      expect(prismaMock.pdfGenerationResult.findMany).toHaveBeenCalledWith({
+        where: { generatorId: 'generator-1', status: 'success' },
+        select: { responseId: true },
+      });
+    });
+
+    it('listDownloadableResultsByGenerator scopes to success + non-null fileKey', async () => {
+      const repo = createPdfGeneratorRepository();
+      await repo.listDownloadableResultsByGenerator('generator-1');
+      expect(prismaMock.pdfGenerationResult.findMany).toHaveBeenCalledWith({
+        where: { generatorId: 'generator-1', status: 'success', fileKey: { not: null } },
+      });
+    });
+
+    it('listSuccessfulResultsByResponse scopes to responseId + success', async () => {
+      const repo = createPdfGeneratorRepository();
+      await repo.listSuccessfulResultsByResponse('response-1');
+      expect(prismaMock.pdfGenerationResult.findMany).toHaveBeenCalledWith({
+        where: { responseId: 'response-1', status: 'success' },
+      });
+    });
+  });
+});

--- a/apps/backend/src/repositories/index.ts
+++ b/apps/backend/src/repositories/index.ts
@@ -17,3 +17,4 @@ export * from './pluginRepository.js';
 export * from './invitationRepository.js';
 export * from './tagRepository.js';
 export * from './pdfTemplateRepository.js';
+export * from './pdfGeneratorRepository.js';

--- a/apps/backend/src/repositories/pdfGeneratorRepository.ts
+++ b/apps/backend/src/repositories/pdfGeneratorRepository.ts
@@ -1,0 +1,166 @@
+import type { Prisma } from '#prisma-client';
+import { resolvePrisma, type RepositoryContext } from './baseRepository.js';
+
+const ACTIVE_RUN_STATUSES = ['running', 'cancelling'] as const;
+
+/**
+ * Factory for PdfGenerator / PdfGenerationRun / PdfGenerationResult data
+ * access — the three models are always used together across
+ * pdfGenerationJobService, pdfGeneratorService and pdfGeneratorZipService.
+ */
+export const createPdfGeneratorRepository = (context?: RepositoryContext) => {
+  const prisma = resolvePrisma(context);
+
+  /** --- Generic delegate passthroughs (PdfGenerator) --- */
+  const findMany = <T extends Prisma.PdfGeneratorFindManyArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.PdfGeneratorFindManyArgs>
+  ) => prisma.pdfGenerator.findMany(args);
+
+  const findUnique = <T extends Prisma.PdfGeneratorFindUniqueArgs>(
+    args: Prisma.SelectSubset<T, Prisma.PdfGeneratorFindUniqueArgs>
+  ) => prisma.pdfGenerator.findUnique(args);
+
+  const create = <T extends Prisma.PdfGeneratorCreateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.PdfGeneratorCreateArgs>
+  ) => prisma.pdfGenerator.create(args);
+
+  const update = <T extends Prisma.PdfGeneratorUpdateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.PdfGeneratorUpdateArgs>
+  ) => prisma.pdfGenerator.update(args);
+
+  const remove = <T extends Prisma.PdfGeneratorDeleteArgs>(
+    args: Prisma.SelectSubset<T, Prisma.PdfGeneratorDeleteArgs>
+  ) => prisma.pdfGenerator.delete(args);
+
+  const count = <T extends Prisma.PdfGeneratorCountArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.PdfGeneratorCountArgs>
+  ) => prisma.pdfGenerator.count(args);
+
+  /** --- Domain helpers: PdfGenerator --- */
+  const findById = async (id: string) => prisma.pdfGenerator.findUnique({ where: { id } });
+
+  const findByIdWithTemplate = async (id: string) =>
+    prisma.pdfGenerator.findUnique({ where: { id }, include: { template: true } });
+
+  const listByForm = async (formId: string) =>
+    prisma.pdfGenerator.findMany({ where: { formId }, orderBy: { createdAt: 'desc' } });
+
+  const countByForm = async (formId: string) => prisma.pdfGenerator.count({ where: { formId } });
+
+  const createGenerator = async (data: Prisma.PdfGeneratorCreateArgs['data']) =>
+    prisma.pdfGenerator.create({ data });
+
+  const updateGenerator = async (id: string, data: Prisma.PdfGeneratorUpdateArgs['data']) =>
+    prisma.pdfGenerator.update({ where: { id }, data });
+
+  const deleteGenerator = async (id: string) => prisma.pdfGenerator.delete({ where: { id } });
+
+  /** --- Domain helpers: PdfGenerationRun --- */
+  const findRunById = async (id: string) => prisma.pdfGenerationRun.findUnique({ where: { id } });
+
+  const findActiveRun = async (generatorId: string) =>
+    prisma.pdfGenerationRun.findFirst({
+      where: { generatorId, status: { in: [...ACTIVE_RUN_STATUSES] } },
+    });
+
+  const findLatestRun = async (generatorId: string) =>
+    prisma.pdfGenerationRun.findFirst({
+      where: { generatorId },
+      orderBy: { startedAt: 'desc' },
+    });
+
+  const createRun = async (data: Prisma.PdfGenerationRunCreateArgs['data']) =>
+    prisma.pdfGenerationRun.create({ data });
+
+  /**
+   * Every run mutation past creation is a status transition (running ->
+   * cancelling -> cancelled/completed/failed, plus per-response progress
+   * counters) — one helper for all of pdfGenerationJobService's
+   * `pdfGenerationRun.update` call sites.
+   */
+  const updateRunStatus = async (
+    runId: string,
+    data: Prisma.PdfGenerationRunUpdateArgs['data']
+  ) => prisma.pdfGenerationRun.update({ where: { id: runId }, data });
+
+  /** --- Domain helpers: PdfGenerationResult --- */
+  const upsertResult = async (
+    generatorId: string,
+    responseId: string,
+    data: {
+      create: Prisma.PdfGenerationResultCreateArgs['data'];
+      update: Prisma.PdfGenerationResultUpdateArgs['data'];
+    }
+  ) =>
+    prisma.pdfGenerationResult.upsert({
+      where: { generatorId_responseId: { generatorId, responseId } },
+      create: data.create,
+      update: data.update,
+    });
+
+  const findResult = async (generatorId: string, responseId: string) =>
+    prisma.pdfGenerationResult.findUnique({
+      where: { generatorId_responseId: { generatorId, responseId } },
+    });
+
+  const listResultsByGenerator = async (generatorId: string) =>
+    prisma.pdfGenerationResult.findMany({
+      where: { generatorId },
+      orderBy: { generatedAt: 'desc' },
+    });
+
+  /** Response ids only, for counting successful results without pulling full rows. */
+  const listSuccessfulResultResponseIdsByGenerator = async (generatorId: string) =>
+    prisma.pdfGenerationResult.findMany({
+      where: { generatorId, status: 'success' },
+      select: { responseId: true },
+    });
+
+  const listDownloadableResultsByGenerator = async (generatorId: string) =>
+    prisma.pdfGenerationResult.findMany({
+      where: { generatorId, status: 'success', fileKey: { not: null } },
+    });
+
+  const listSuccessfulResultsByResponse = async (responseId: string) =>
+    prisma.pdfGenerationResult.findMany({
+      where: { responseId, status: 'success' },
+    });
+
+  return {
+    // Generic operations (PdfGenerator)
+    findMany,
+    findUnique,
+    create,
+    update,
+    delete: remove,
+    count,
+
+    // Domain helpers (PdfGenerator)
+    findById,
+    findByIdWithTemplate,
+    listByForm,
+    countByForm,
+    createGenerator,
+    updateGenerator,
+    deleteGenerator,
+
+    // Domain helpers (PdfGenerationRun)
+    findRunById,
+    findActiveRun,
+    findLatestRun,
+    createRun,
+    updateRunStatus,
+
+    // Domain helpers (PdfGenerationResult)
+    upsertResult,
+    findResult,
+    listResultsByGenerator,
+    listSuccessfulResultResponseIdsByGenerator,
+    listDownloadableResultsByGenerator,
+    listSuccessfulResultsByResponse,
+  };
+};
+
+export type PdfGeneratorRepository = ReturnType<typeof createPdfGeneratorRepository>;
+
+export const pdfGeneratorRepository = createPdfGeneratorRepository();

--- a/apps/backend/src/services/pdfGenerationJobService.ts
+++ b/apps/backend/src/services/pdfGenerationJobService.ts
@@ -3,8 +3,8 @@ import { deserializeFormSchema } from '@dculus/types';
 import { generateId } from '@dculus/utils';
 import { createGraphQLError } from '#graphql-errors';
 import { GRAPHQL_ERROR_CODES } from '@dculus/types/graphql.js';
-import { prisma } from '../lib/prisma.js';
 import { logger } from '../lib/logger.js';
+import { pdfGeneratorRepository, formRepository, responseRepository } from '../repositories/index.js';
 import {
   hydrateTemplate,
   getPdfFonts,
@@ -38,15 +38,12 @@ export const wait = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
 async function loadGeneratorContext(generatorId: string) {
-  const generator = await prisma.pdfGenerator.findUnique({
-    where: { id: generatorId },
-    include: { template: true },
-  });
+  const generator = await pdfGeneratorRepository.findByIdWithTemplate(generatorId);
   if (!generator) {
     throw createGraphQLError('PDF generator not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
   }
 
-  const form = await prisma.form.findUnique({
+  const form = await formRepository.findUnique({
     where: { id: generator.formId },
     select: { formSchema: true },
   });
@@ -91,8 +88,7 @@ async function generateAndPersistResult(params: {
   const substitutionValues = buildSubstitutionValues(deserializedSchema, responseData);
   const filename = buildGeneratorFilename(filenameFieldId, substitutionValues, templateName, responseId);
 
-  await prisma.pdfGenerationResult.upsert({
-    where: { generatorId_responseId: { generatorId, responseId } },
+  await pdfGeneratorRepository.upsertResult(generatorId, responseId, {
     create: { id: generateId(), generatorId, responseId, status: 'success', fileKey, filename },
     update: { status: 'success', fileKey, filename, errorMessage: null, generatedAt: new Date() },
   });
@@ -102,8 +98,7 @@ async function generateAndPersistResult(params: {
 
 async function recordFailure(generatorId: string, responseId: string, error: unknown): Promise<void> {
   const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-  await prisma.pdfGenerationResult.upsert({
-    where: { generatorId_responseId: { generatorId, responseId } },
+  await pdfGeneratorRepository.upsertResult(generatorId, responseId, {
     create: { id: generateId(), generatorId, responseId, status: 'failed', errorMessage },
     update: { status: 'failed', errorMessage, generatedAt: new Date() },
   });
@@ -113,7 +108,7 @@ export const startPdfGenerationRun = async (
   generatorId: string,
   trigger: 'manual' | 'auto' = 'manual'
 ) => {
-  const generator = await prisma.pdfGenerator.findUnique({ where: { id: generatorId } });
+  const generator = await pdfGeneratorRepository.findById(generatorId);
   if (!generator) {
     throw createGraphQLError('PDF generator not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
   }
@@ -124,9 +119,7 @@ export const startPdfGenerationRun = async (
     );
   }
 
-  const activeRun = await prisma.pdfGenerationRun.findFirst({
-    where: { generatorId, status: { in: ['running', 'cancelling'] } },
-  });
+  const activeRun = await pdfGeneratorRepository.findActiveRun(generatorId);
   if (activeRun) {
     throw createGraphQLError(
       'A run is already in progress for this PDF generator',
@@ -134,7 +127,7 @@ export const startPdfGenerationRun = async (
     );
   }
 
-  const totalResponseCount = await prisma.response.count({
+  const totalResponseCount = await responseRepository.count({
     where: { formId: generator.formId, deletedAt: null },
   });
   if (totalResponseCount > MAX_RESPONSES_PER_RUN) {
@@ -150,14 +143,12 @@ export const startPdfGenerationRun = async (
     generator.filterLogic as 'AND' | 'OR'
   );
 
-  const run = await prisma.pdfGenerationRun.create({
-    data: {
-      id: generateId(),
-      generatorId,
-      trigger,
-      status: 'running',
-      totalCount: matchingResponses.length,
-    },
+  const run = await pdfGeneratorRepository.createRun({
+    id: generateId(),
+    generatorId,
+    trigger,
+    status: 'running',
+    totalCount: matchingResponses.length,
   });
 
   void runPdfGenerationLoop(run.id, generatorId, matchingResponses);
@@ -180,16 +171,16 @@ export const runPdfGenerationLoop = async (
     let failed = 0;
 
     for (let i = 0; i < responses.length; i += BATCH_SIZE) {
-      const run = await prisma.pdfGenerationRun.findUnique({ where: { id: runId } });
+      const run = await pdfGeneratorRepository.findRunById(runId);
       // The run row can vanish mid-loop (e.g. its generator was deleted,
       // cascading the delete) — nothing to update in that case, and
       // attempting one would throw "record not found" from inside a
       // fire-and-forget void call, surfacing as an unhandled rejection.
       if (!run) return;
       if (run.status === 'cancelling') {
-        await prisma.pdfGenerationRun.update({
-          where: { id: runId },
-          data: { status: 'cancelled', completedAt: new Date() },
+        await pdfGeneratorRepository.updateRunStatus(runId, {
+          status: 'cancelled',
+          completedAt: new Date(),
         });
         return;
       }
@@ -219,18 +210,19 @@ export const runPdfGenerationLoop = async (
         // Updated after every response (not just every batch) so a slow batch
         // never lets updatedAt go stale enough to trip stalled-run detection
         // while the loop is still healthy — see getLatestPdfGenerationRun.
-        await prisma.pdfGenerationRun.update({
-          where: { id: runId },
-          data: { processedCount: processed, succeededCount: succeeded, failedCount: failed },
+        await pdfGeneratorRepository.updateRunStatus(runId, {
+          processedCount: processed,
+          succeededCount: succeeded,
+          failedCount: failed,
         });
       }
 
       await wait(BATCH_DELAY_MS);
     }
 
-    await prisma.pdfGenerationRun.update({
-      where: { id: runId },
-      data: { status: 'completed', completedAt: new Date() },
+    await pdfGeneratorRepository.updateRunStatus(runId, {
+      status: 'completed',
+      completedAt: new Date(),
     });
   } catch (error: any) {
     logger.error(`[PDF Generator] Run ${runId} failed`, error);
@@ -238,13 +230,10 @@ export const runPdfGenerationLoop = async (
     // run row is already gone (e.g. its generator was deleted concurrently),
     // this update would itself throw and escape as an unhandled rejection.
     try {
-      await prisma.pdfGenerationRun.update({
-        where: { id: runId },
-        data: {
-          status: 'failed',
-          errorMessage: error.message || 'Unknown error',
-          completedAt: new Date(),
-        },
+      await pdfGeneratorRepository.updateRunStatus(runId, {
+        status: 'failed',
+        errorMessage: error.message || 'Unknown error',
+        completedAt: new Date(),
       });
     } catch (updateError) {
       logger.error(`[PDF Generator] Could not mark run ${runId} as failed:`, updateError);
@@ -253,7 +242,7 @@ export const runPdfGenerationLoop = async (
 };
 
 export const getPdfGenerationRun = async (runId: string) => {
-  return prisma.pdfGenerationRun.findUnique({ where: { id: runId } });
+  return pdfGeneratorRepository.findRunById(runId);
 };
 
 export const cancelPdfGenerationRun = async (runId: string) => {
@@ -265,14 +254,11 @@ export const cancelPdfGenerationRun = async (runId: string) => {
     return run;
   }
 
-  return prisma.pdfGenerationRun.update({ where: { id: runId }, data: { status: 'cancelling' } });
+  return pdfGeneratorRepository.updateRunStatus(runId, { status: 'cancelling' });
 };
 
 export const getLatestPdfGenerationRun = async (generatorId: string) => {
-  const run = await prisma.pdfGenerationRun.findFirst({
-    where: { generatorId },
-    orderBy: { startedAt: 'desc' },
-  });
+  const run = await pdfGeneratorRepository.findLatestRun(generatorId);
   if (!run) return null;
 
   // Also cover 'cancelling': if the process restarts between
@@ -283,14 +269,11 @@ export const getLatestPdfGenerationRun = async (generatorId: string) => {
   if (run.status === 'running' || run.status === 'cancelling') {
     const staleMs = Date.now() - run.updatedAt.getTime();
     if (staleMs > STALLED_THRESHOLD_MS) {
-      return prisma.pdfGenerationRun.update({
-        where: { id: run.id },
-        data: {
-          status: 'failed',
-          errorMessage:
-            'Run appears stalled, possibly due to a server restart. Click Run again to retry.',
-          completedAt: new Date(),
-        },
+      return pdfGeneratorRepository.updateRunStatus(run.id, {
+        status: 'failed',
+        errorMessage:
+          'Run appears stalled, possibly due to a server restart. Click Run again to retry.',
+        completedAt: new Date(),
       });
     }
   }
@@ -312,7 +295,7 @@ export const generateSinglePdfForGenerator = async (
 ): Promise<{ fileKey: string; filename: string }> => {
   const { generator, deserializedSchema } = await loadGeneratorContext(generatorId);
 
-  const response = await prisma.response.findUnique({ where: { id: responseId } });
+  const response = await responseRepository.findUnique({ where: { id: responseId } });
   if (!response || response.deletedAt || response.formId !== generator.formId) {
     throw createGraphQLError('Response not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
   }
@@ -340,9 +323,7 @@ export const generateSinglePdfForGenerator = async (
  * runs outside any request/response cycle.
  */
 export const regeneratePdfsForResponse = async (responseId: string): Promise<void> => {
-  const results = await prisma.pdfGenerationResult.findMany({
-    where: { responseId, status: 'success' },
-  });
+  const results = await pdfGeneratorRepository.listSuccessfulResultsByResponse(responseId);
 
   for (const result of results) {
     try {

--- a/apps/backend/src/services/pdfGeneratorService.ts
+++ b/apps/backend/src/services/pdfGeneratorService.ts
@@ -1,8 +1,12 @@
 import { generateId } from '@dculus/utils';
 import { createGraphQLError } from '#graphql-errors';
 import { GRAPHQL_ERROR_CODES } from '@dculus/types/graphql.js';
-import { prisma } from '../lib/prisma.js';
 import { logger } from '../lib/logger.js';
+import {
+  pdfGeneratorRepository,
+  pdfTemplateRepository,
+  responseRepository,
+} from '../repositories/index.js';
 import { ResponseFilter, applyResponseFilters } from './responseFilterService.js';
 import { getAllResponsesByFormId } from './responseService.js';
 import { deleteGeneratedPdfsForGenerator } from './pdfGeneratorStorage.js';
@@ -36,34 +40,32 @@ const normalizeOptionalString = (value: string | null | undefined): string | nul
   value === '' ? null : value;
 
 export const createPdfGenerator = async (input: PdfGeneratorInput) => {
-  const template = await prisma.pdfTemplate.findUnique({ where: { id: input.templateId } });
+  const template = await pdfTemplateRepository.findById(input.templateId);
   if (!template || template.formId !== input.formId) {
     throw createGraphQLError('PDF template not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
   }
 
-  return prisma.pdfGenerator.create({
-    data: {
-      id: generateId(),
-      formId: input.formId,
-      templateId: input.templateId,
-      name: input.name,
-      columnName: normalizeOptionalString(input.columnName) ?? null,
-      filenameFieldId: normalizeOptionalString(input.filenameFieldId) ?? null,
-      filters: input.filters as any,
-      filterLogic: input.filterLogic ?? 'AND',
-      autoRunOnSubmit: input.autoRunOnSubmit ?? false,
-    },
+  return pdfGeneratorRepository.createGenerator({
+    id: generateId(),
+    formId: input.formId,
+    templateId: input.templateId,
+    name: input.name,
+    columnName: normalizeOptionalString(input.columnName) ?? null,
+    filenameFieldId: normalizeOptionalString(input.filenameFieldId) ?? null,
+    filters: input.filters as any,
+    filterLogic: input.filterLogic ?? 'AND',
+    autoRunOnSubmit: input.autoRunOnSubmit ?? false,
   });
 };
 
 export const updatePdfGenerator = async (id: string, input: PdfGeneratorUpdateInput) => {
-  const generator = await prisma.pdfGenerator.findUnique({ where: { id } });
+  const generator = await pdfGeneratorRepository.findById(id);
   if (!generator) {
     throw createGraphQLError('PDF generator not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
   }
 
   if (input.templateId) {
-    const template = await prisma.pdfTemplate.findUnique({ where: { id: input.templateId } });
+    const template = await pdfTemplateRepository.findById(input.templateId);
     if (!template || template.formId !== generator.formId) {
       throw createGraphQLError('PDF template not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
     }
@@ -83,30 +85,27 @@ export const updatePdfGenerator = async (id: string, input: PdfGeneratorUpdateIn
     );
   }
 
-  return prisma.pdfGenerator.update({
-    where: { id },
-    data: {
-      ...(input.templateId !== undefined ? { templateId: input.templateId } : {}),
-      ...(input.name !== undefined ? { name: input.name } : {}),
-      ...(input.columnName !== undefined ? { columnName: normalizeOptionalString(input.columnName) } : {}),
-      ...(input.filenameFieldId !== undefined
-        ? { filenameFieldId: normalizeOptionalString(input.filenameFieldId) }
-        : {}),
-      ...(input.filters !== undefined ? { filters: input.filters as any } : {}),
-      ...(input.filterLogic !== undefined ? { filterLogic: input.filterLogic } : {}),
-      ...(input.autoRunOnSubmit !== undefined ? { autoRunOnSubmit: input.autoRunOnSubmit } : {}),
-      ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
-    },
+  return pdfGeneratorRepository.updateGenerator(id, {
+    ...(input.templateId !== undefined ? { templateId: input.templateId } : {}),
+    ...(input.name !== undefined ? { name: input.name } : {}),
+    ...(input.columnName !== undefined ? { columnName: normalizeOptionalString(input.columnName) } : {}),
+    ...(input.filenameFieldId !== undefined
+      ? { filenameFieldId: normalizeOptionalString(input.filenameFieldId) }
+      : {}),
+    ...(input.filters !== undefined ? { filters: input.filters as any } : {}),
+    ...(input.filterLogic !== undefined ? { filterLogic: input.filterLogic } : {}),
+    ...(input.autoRunOnSubmit !== undefined ? { autoRunOnSubmit: input.autoRunOnSubmit } : {}),
+    ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
   });
 };
 
 export const deletePdfGenerator = async (id: string): Promise<boolean> => {
-  const generator = await prisma.pdfGenerator.findUnique({ where: { id } });
+  const generator = await pdfGeneratorRepository.findById(id);
   if (!generator) {
     throw createGraphQLError('PDF generator not found', GRAPHQL_ERROR_CODES.NOT_FOUND);
   }
 
-  await prisma.pdfGenerator.delete({ where: { id } });
+  await pdfGeneratorRepository.deleteGenerator(id);
 
   try {
     await deleteGeneratedPdfsForGenerator(generator.formId, generator.id);
@@ -118,19 +117,19 @@ export const deletePdfGenerator = async (id: string): Promise<boolean> => {
 };
 
 export const listPdfGenerators = async (formId: string) => {
-  return prisma.pdfGenerator.findMany({ where: { formId }, orderBy: { createdAt: 'desc' } });
+  return pdfGeneratorRepository.listByForm(formId);
 };
 
 export const getPdfGenerator = async (id: string) => {
-  return prisma.pdfGenerator.findUnique({ where: { id } });
+  return pdfGeneratorRepository.findById(id);
 };
 
 export const countPdfGenerators = async (formId: string): Promise<number> => {
-  return prisma.pdfGenerator.count({ where: { formId } });
+  return pdfGeneratorRepository.countByForm(formId);
 };
 
 export const getPdfTemplateById = async (templateId: string) => {
-  return prisma.pdfTemplate.findUnique({ where: { id: templateId } });
+  return pdfTemplateRepository.findById(templateId);
 };
 
 // Single-result lookup, the results list, and the ZIP-availability count all
@@ -139,9 +138,7 @@ export const getPdfTemplateById = async (templateId: string) => {
 // generated must disappear from every one of these, not just the list view.
 
 export const getPdfGenerationResult = async (generatorId: string, responseId: string) => {
-  const result = await prisma.pdfGenerationResult.findUnique({
-    where: { generatorId_responseId: { generatorId, responseId } },
-  });
+  const result = await pdfGeneratorRepository.findResult(generatorId, responseId);
   if (!result) return null;
   const [live] = await filterResultsToLiveResponses([result]);
   return live ?? null;
@@ -152,18 +149,12 @@ export const getPdfGenerationResult = async (generatorId: string, responseId: st
  * the source for the "View results" modal.
  */
 export const listPdfGenerationResults = async (generatorId: string) => {
-  const results = await prisma.pdfGenerationResult.findMany({
-    where: { generatorId },
-    orderBy: { generatedAt: 'desc' },
-  });
+  const results = await pdfGeneratorRepository.listResultsByGenerator(generatorId);
   return filterResultsToLiveResponses(results);
 };
 
 export const countSuccessfulResults = async (generatorId: string): Promise<number> => {
-  const results = await prisma.pdfGenerationResult.findMany({
-    where: { generatorId, status: 'success' },
-    select: { responseId: true },
-  });
+  const results = await pdfGeneratorRepository.listSuccessfulResultResponseIdsByGenerator(generatorId);
   const live = await filterResultsToLiveResponses(results);
   return live.length;
 };
@@ -209,7 +200,7 @@ export const filterResultsToLiveResponses = async <T extends { responseId: strin
   results: T[]
 ): Promise<T[]> => {
   if (results.length === 0) return results;
-  const liveResponses = await prisma.response.findMany({
+  const liveResponses = await responseRepository.findMany({
     where: { id: { in: results.map((r) => r.responseId) }, deletedAt: null },
     select: { id: true },
   });

--- a/apps/backend/src/services/pdfGeneratorZipService.ts
+++ b/apps/backend/src/services/pdfGeneratorZipService.ts
@@ -1,6 +1,6 @@
 import JSZip from 'jszip';
-import { prisma } from '../lib/prisma.js';
 import { logger } from '../lib/logger.js';
+import { pdfGeneratorRepository } from '../repositories/index.js';
 import { downloadFileBuffer } from './fileUploadService.js';
 import { filterResultsToLiveResponses } from './pdfGeneratorService.js';
 
@@ -12,9 +12,7 @@ import { filterResultsToLiveResponses } from './pdfGeneratorService.js';
  * every run (manual or auto) — no run-scoping needed.
  */
 export async function buildZipForGenerator(generatorId: string): Promise<Buffer> {
-  const allResults = await prisma.pdfGenerationResult.findMany({
-    where: { generatorId, status: 'success', fileKey: { not: null } },
-  });
+  const allResults = await pdfGeneratorRepository.listDownloadableResultsByGenerator(generatorId);
   // Exclude soft-deleted responses' PDFs — see filterResultsToLiveResponses.
   const results = await filterResultsToLiveResponses(allResults);
 


### PR DESCRIPTION
## Summary
- Add `pdfGeneratorRepository` covering `PdfGenerator`, `PdfGenerationRun`, and `PdfGenerationResult` (per repository-pattern conventions in #245)
- Route `pdfGenerationJobService.ts`, `pdfGeneratorService.ts`, and `pdfGeneratorZipService.ts` through the new repository plus the existing `formRepository`/`responseRepository`/`pdfTemplateRepository`
- Collapse the repeated `pdfGenerationRun.update` status-transition call sites in `pdfGenerationJobService.ts` into a single `updateRunStatus(runId, data)` helper
- `pdfGenerators.ts` resolver required no changes — already fully service-driven

Closes #251 (Story 05, part of Epic #245).

## Test plan
- [x] `pnpm --filter backend exec tsc --noEmit` passes
- [x] `pnpm test:unit` passes (113 test files / 2998 tests)
- [x] `apps/backend/src/repositories/__tests__/pdfGeneratorRepository.test.ts` added (mocked Prisma)
- [x] `grep -n "prisma\."` on the three owned service files returns zero results
- [x] No PDF-generator `.feature` integration tests exist in the repo to re-run
- [x] Pre-push hooks (backend/form-viewer tests + form-app/form-viewer/admin-app builds) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)