### PR TITLE
Story 10: Form Sharing — formPermissionRepository + formSharingService, wire formSharing.ts

### DIFF
--- a/apps/backend/src/graphql/resolvers/formSharing.ts
+++ b/apps/backend/src/graphql/resolvers/formSharing.ts
@@ -1,12 +1,18 @@
 import { BetterAuthContext, requireAuth, requireOrganizationMembership } from '../../middleware/better-auth-middleware.js';
 import * as formSharingService from '../../services/formSharingService.js';
+import { checkFormAccess } from '../../services/formSharingService.js';
+import type { Permission, Scope } from '../../services/formSharingService.js';
 
 // Re-exported for backward compatibility — other resolvers/services import these
 // directly from this file (e.g. formService.ts's checkFormAccess-based permission
 // checks). The implementations now live in formSharingService.ts.
-export const { PermissionLevel, SharingScope, PERMISSION_HIERARCHY, checkFormAccess } = formSharingService;
-export type Permission = formSharingService.Permission;
-export type Scope = formSharingService.Scope;
+export {
+  PermissionLevel,
+  SharingScope,
+  PERMISSION_HIERARCHY,
+  checkFormAccess,
+} from '../../services/formSharingService.js';
+export type { Permission, Scope } from '../../services/formSharingService.js';
 
 export const formSharingResolvers = {
   Query: {

--- a/apps/backend/src/graphql/resolvers/formSharing.ts
+++ b/apps/backend/src/graphql/resolvers/formSharing.ts
@@ -1,122 +1,19 @@
-import { prisma } from '../../lib/prisma.js';
 import { BetterAuthContext, requireAuth, requireOrganizationMembership } from '../../middleware/better-auth-middleware.js';
-import { randomUUID } from 'crypto';
-import { createGraphQLError } from '#graphql-errors';
-import { GRAPHQL_ERROR_CODES } from '@dculus/types/graphql.js';
-import { audit } from '../../lib/audit.js';
+import * as formSharingService from '../../services/formSharingService.js';
 
-// Permission levels mapping
-export const PermissionLevel = {
-  OWNER: 'OWNER',
-  EDITOR: 'EDITOR',
-  VIEWER: 'VIEWER',
-  NO_ACCESS: 'NO_ACCESS'
-} as const;
-
-// Sharing scopes mapping
-export const SharingScope = {
-  PRIVATE: 'PRIVATE',
-  SPECIFIC_MEMBERS: 'SPECIFIC_MEMBERS',
-  ALL_ORG_MEMBERS: 'ALL_ORG_MEMBERS'
-} as const;
-
-type Permission = typeof PermissionLevel[keyof typeof PermissionLevel];
-type Scope = typeof SharingScope[keyof typeof SharingScope];
-
-// Helper function to check if user has permission to access form
-export const checkFormAccess = async (userId: string, formId: string, requiredPermission: Permission = PermissionLevel.VIEWER) => {
-  const form = await prisma.form.findFirst({
-    where: { id: formId, deletedAt: null },
-    include: {
-      createdBy: true,
-      permissions: {
-        include: {
-          user: true,
-          grantedBy: true
-        }
-      },
-      organization: {
-        include: {
-          members: {
-            where: { userId },
-            include: { user: true }
-          }
-        }
-      }
-    }
-  });
-
-  if (!form) {
-    throw createGraphQLError('Form not found', GRAPHQL_ERROR_CODES.FORM_NOT_FOUND);
-  }
-
-  // 🔒 SECURITY: Check organization membership FIRST (before owner check)
-  // This ensures even form owners must be organization members to access forms
-  const userMembership = form.organization.members.find(member => member.userId === userId);
-  if (!userMembership) {
-    // User is not a member of this organization - deny access even if they're the owner
-    return { hasAccess: false, permission: PermissionLevel.NO_ACCESS, form };
-  }
-
-  // Check if user is the form owner (only reachable if user is org member)
-  if (form.createdById === userId) {
-    return { hasAccess: true, permission: PermissionLevel.OWNER, form };
-  }
-
-  // Check explicit permissions
-  const explicitPermission = form.permissions.find(p => p.userId === userId);
-  if (explicitPermission) {
-    const hasRequiredAccess = checkPermissionLevel(explicitPermission.permission as Permission, requiredPermission);
-    return {
-      hasAccess: hasRequiredAccess,
-      permission: explicitPermission.permission as Permission,
-      form
-    };
-  }
-
-  // Check sharing scope for organization members
-  if (form.sharingScope === SharingScope.ALL_ORG_MEMBERS) {
-    const hasRequiredAccess = checkPermissionLevel(form.defaultPermission as Permission, requiredPermission);
-    return {
-      hasAccess: hasRequiredAccess,
-      permission: form.defaultPermission as Permission,
-      form
-    };
-  }
-
-  // Default: no access
-  return { hasAccess: false, permission: PermissionLevel.NO_ACCESS, form };
-};
-
-export const PERMISSION_HIERARCHY: Record<string, number> = {
-  [PermissionLevel.NO_ACCESS]: 0,
-  [PermissionLevel.VIEWER]: 1,
-  [PermissionLevel.EDITOR]: 2,
-  [PermissionLevel.OWNER]: 3,
-};
-
-const checkPermissionLevel = (userPermission: Permission, requiredPermission: Permission): boolean =>
-  (PERMISSION_HIERARCHY[userPermission] ?? 0) >= (PERMISSION_HIERARCHY[requiredPermission] ?? 0);
+// Re-exported for backward compatibility — other resolvers/services import these
+// directly from this file (e.g. formService.ts's checkFormAccess-based permission
+// checks). The implementations now live in formSharingService.ts.
+export const { PermissionLevel, SharingScope, PERMISSION_HIERARCHY, checkFormAccess } = formSharingService;
+export type Permission = formSharingService.Permission;
+export type Scope = formSharingService.Scope;
 
 export const formSharingResolvers = {
   Query: {
     formPermissions: async (_: any, { formId }: { formId: string }, context: { auth: BetterAuthContext }) => {
       requireAuth(context.auth);
 
-      // Check if user has access to manage permissions (must be owner)
-      const accessCheck = await checkFormAccess(context.auth.user!.id, formId, PermissionLevel.OWNER);
-      if (!accessCheck.hasAccess) {
-        throw createGraphQLError('Access denied: Insufficient permissions', GRAPHQL_ERROR_CODES.NO_ACCESS);
-      }
-
-      return await prisma.formPermission.findMany({
-        where: { formId },
-        include: {
-          user: true,
-          grantedBy: true
-        },
-        orderBy: { grantedAt: 'desc' }
-      });
+      return formSharingService.getFormPermissions(context.auth.user!.id, formId);
     },
 
 
@@ -142,126 +39,14 @@ export const formSharingResolvers = {
       // 🔒 SECURITY: Verify user is a member of the target organization
       await requireOrganizationMembership(context.auth, organizationId);
 
-      const userId = context.auth.user!.id;
-
-      // Validate pagination parameters
-      const currentPage = Math.max(1, page);
-      const pageLimit = Math.min(Math.max(1, limit), 100); // Max 100 items per page
-      const skip = (currentPage - 1) * pageLimit;
-
-      const sharedAccessConditions = [
-        {
-          permissions: {
-            some: {
-              userId,
-              permission: { not: PermissionLevel.NO_ACCESS }
-            }
-          }
-        },
-        {
-          sharingScope: SharingScope.ALL_ORG_MEMBERS,
-          defaultPermission: { not: PermissionLevel.NO_ACCESS }
-        }
-      ];
-
-      const searchTerm = filters?.search?.trim();
-      const searchFilter = searchTerm
-        ? {
-          OR: [
-            { title: { contains: searchTerm, mode: 'insensitive' } },
-            { description: { contains: searchTerm, mode: 'insensitive' } }
-          ]
-        }
-        : null;
-
-      let whereCondition: any;
-
-      switch (category) {
-        case 'OWNER': {
-          whereCondition = {
-            organizationId,
-            createdById: userId,
-            ...(searchFilter ? { AND: [searchFilter] } : {})
-          };
-          break;
-        }
-        case 'SHARED': {
-          whereCondition = {
-            organizationId,
-            createdById: { not: userId },
-            AND: [
-              { OR: sharedAccessConditions },
-              ...(searchFilter ? [searchFilter] : [])
-            ]
-          };
-          break;
-        }
-        case 'ALL': {
-          const ownerClause = searchFilter
-            ? {
-              createdById: userId,
-              AND: [searchFilter]
-            }
-            : { createdById: userId };
-
-          const sharedClause = {
-            createdById: { not: userId },
-            AND: [
-              { OR: sharedAccessConditions },
-              ...(searchFilter ? [searchFilter] : [])
-            ]
-          };
-
-          whereCondition = {
-            organizationId,
-            OR: [ownerClause, sharedClause]
-          };
-          break;
-        }
-        default: {
-          throw createGraphQLError(`Invalid category: ${category}. Must be OWNER, SHARED, or ALL`, GRAPHQL_ERROR_CODES.BAD_USER_INPUT);
-        }
-      }
-
-      whereCondition = { ...whereCondition, deletedAt: null };
-
-      // Get total count for pagination
-      const totalCount = await prisma.form.count({
-        where: whereCondition
+      return formSharingService.listForms({
+        organizationId,
+        category,
+        userId: context.auth.user!.id,
+        page,
+        limit,
+        filters,
       });
-
-      // Get paginated forms — include _count.responses for N+1-free responseCount resolution (P3-02)
-      const forms = await prisma.form.findMany({
-        where: whereCondition,
-        include: {
-          organization: true,
-          createdBy: true,
-          permissions: {
-            include: {
-              user: true,
-              grantedBy: true
-            }
-          },
-          _count: {
-            select: { responses: true }
-          }
-        },
-        orderBy: { updatedAt: 'desc' },
-        skip,
-        take: pageLimit
-      });
-
-      const totalPages = Math.ceil(totalCount / pageLimit);
-
-      return {
-        forms,
-        totalCount,
-        page: currentPage,
-        limit: pageLimit,
-        totalPages,
-        hasNextPage: currentPage < totalPages,
-        hasPreviousPage: currentPage > 1
-      };
     },
 
     organizationMembers: async (_: any, { organizationId }: { organizationId: string }, context: { auth: BetterAuthContext }) => {
@@ -269,13 +54,7 @@ export const formSharingResolvers = {
       await requireOrganizationMembership(context.auth, organizationId);
 
       // User is verified member - return organization members
-      const members = await prisma.member.findMany({
-        where: { organizationId },
-        include: { user: true },
-        orderBy: { user: { name: 'asc' } }
-      });
-
-      return members.map(member => member.user);
+      return formSharingService.listOrganizationMembersForSharing(organizationId);
     }
   },
 
@@ -286,106 +65,8 @@ export const formSharingResolvers = {
       context: { auth: BetterAuthContext }
     ) => {
       requireAuth(context.auth);
-      const userId = context.auth.user!.id;
 
-      // Check if user has permission to share the form (must be owner)
-      const accessCheck = await checkFormAccess(userId, input.formId, PermissionLevel.OWNER);
-      if (!accessCheck.hasAccess) {
-        throw createGraphQLError('Access denied: Insufficient permissions to share this form', GRAPHQL_ERROR_CODES.NO_ACCESS);
-      }
-
-      // Update form sharing settings
-      const updatedForm = await prisma.form.update({
-        where: { id: input.formId },
-        data: {
-          sharingScope: input.sharingScope,
-          defaultPermission: input.defaultPermission || PermissionLevel.VIEWER
-        }
-      });
-
-      // Handle user-specific permissions
-      if (input.userPermissions && input.userPermissions.length > 0) {
-        const userIds = input.userPermissions.map(up => up.userId);
-
-        // 🔒 SECURITY: Verify all target users are members of the form's organization
-        const orgMembers = await prisma.member.findMany({
-          where: {
-            organizationId: accessCheck.form.organizationId,
-            userId: { in: userIds }
-          },
-          select: { userId: true }
-        });
-
-        const validUserIds = new Set(orgMembers.map(m => m.userId));
-        const invalidUsers = userIds.filter(id => !validUserIds.has(id));
-
-        if (invalidUsers.length > 0) {
-          throw createGraphQLError(
-            `Cannot grant permissions to users outside organization: ${invalidUsers.join(', ')}`,
-            GRAPHQL_ERROR_CODES.NO_ACCESS
-          );
-        }
-
-        // Prevent callers from granting themselves a higher role than they currently hold
-        const callerCurrentPermission = accessCheck.permission;
-        const selfEscalation = input.userPermissions.find(
-          up =>
-            up.userId === userId &&
-            (PERMISSION_HIERARCHY[up.permission] ?? 0) > (PERMISSION_HIERARCHY[callerCurrentPermission] ?? 0)
-        );
-        if (selfEscalation) {
-          throw createGraphQLError(
-            'Cannot grant yourself a higher permission level than you currently hold',
-            GRAPHQL_ERROR_CODES.NO_ACCESS
-          );
-        }
-
-        // Remove existing permissions for these users
-        await prisma.formPermission.deleteMany({
-          where: {
-            formId: input.formId,
-            userId: { in: userIds }
-          }
-        });
-
-        // Add new permissions
-        const permissionsToCreate = input.userPermissions
-          .filter(up => up.permission !== PermissionLevel.NO_ACCESS)
-          .map(up => ({
-            id: randomUUID(),
-            formId: input.formId,
-            userId: up.userId,
-            permission: up.permission,
-            grantedById: userId
-          }));
-
-        if (permissionsToCreate.length > 0) {
-          await prisma.formPermission.createMany({
-            data: permissionsToCreate
-          });
-        }
-      }
-
-      // Return the updated sharing settings
-      const permissions = await prisma.formPermission.findMany({
-        where: { formId: input.formId },
-        include: {
-          user: true,
-          grantedBy: true
-        }
-      });
-
-      await audit('permission.granted', 'FormPermission', input.formId, userId, {
-        sharingScope: input.sharingScope,
-        defaultPermission: input.defaultPermission,
-        userPermissions: input.userPermissions,
-      });
-
-      return {
-        sharingScope: updatedForm.sharingScope,
-        defaultPermission: updatedForm.defaultPermission,
-        permissions
-      };
+      return formSharingService.shareForm(context.auth.user!.id, input);
     },
 
     updateFormPermission: async (
@@ -394,88 +75,8 @@ export const formSharingResolvers = {
       context: { auth: BetterAuthContext }
     ) => {
       requireAuth(context.auth);
-      const grantedById = context.auth.user!.id;
 
-      // Check if user has permission to manage permissions (must be owner)
-      const accessCheck = await checkFormAccess(grantedById, input.formId, PermissionLevel.OWNER);
-      if (!accessCheck.hasAccess) {
-        throw createGraphQLError('Access denied: Insufficient permissions', GRAPHQL_ERROR_CODES.NO_ACCESS);
-      }
-
-      // 🔒 SECURITY: Verify target user is a member of the form's organization
-      const isMember = await prisma.member.findFirst({
-        where: {
-          organizationId: accessCheck.form.organizationId,
-          userId: input.userId
-        }
-      });
-
-      if (!isMember) {
-        throw createGraphQLError('Cannot grant permissions to users outside organization', GRAPHQL_ERROR_CODES.NO_ACCESS);
-      }
-
-      // Prevent users from changing owner permissions
-      if (accessCheck.form.createdById === input.userId) {
-        throw createGraphQLError('Cannot change permissions for form owner', GRAPHQL_ERROR_CODES.NO_ACCESS);
-      }
-
-      // Remove access if permission is NO_ACCESS
-      if (input.permission === PermissionLevel.NO_ACCESS) {
-        await prisma.formPermission.deleteMany({
-          where: {
-            formId: input.formId,
-            userId: input.userId
-          }
-        });
-
-        await audit('permission.granted', 'FormPermission', input.formId, grantedById, {
-          targetUserId: input.userId,
-          permission: PermissionLevel.NO_ACCESS,
-        });
-
-        return {
-          id: '',
-          formId: input.formId,
-          userId: input.userId,
-          permission: PermissionLevel.NO_ACCESS,
-          grantedAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-          user: null,
-          grantedBy: null
-        };
-      }
-
-      // Upsert permission
-      const permission = await prisma.formPermission.upsert({
-        where: {
-          formId_userId: {
-            formId: input.formId,
-            userId: input.userId
-          }
-        },
-        update: {
-          permission: input.permission,
-          grantedById
-        },
-        create: {
-          id: randomUUID(),
-          formId: input.formId,
-          userId: input.userId,
-          permission: input.permission,
-          grantedById
-        },
-        include: {
-          user: true,
-          grantedBy: true
-        }
-      });
-
-      await audit('permission.granted', 'FormPermission', input.formId, grantedById, {
-        targetUserId: input.userId,
-        permission: input.permission,
-      });
-
-      return permission;
+      return formSharingService.updateFormPermission(context.auth.user!.id, input);
     },
 
     removeFormAccess: async (
@@ -484,47 +85,14 @@ export const formSharingResolvers = {
       context: { auth: BetterAuthContext }
     ) => {
       requireAuth(context.auth);
-      const grantedById = context.auth.user!.id;
 
-      // Check if user has permission to manage permissions (must be owner)
-      const accessCheck = await checkFormAccess(grantedById, formId, PermissionLevel.OWNER);
-      if (!accessCheck.hasAccess) {
-        throw createGraphQLError('Access denied: Insufficient permissions', GRAPHQL_ERROR_CODES.NO_ACCESS);
-      }
-
-      // Prevent removing access from form owner
-      if (accessCheck.form.createdById === userId) {
-        throw createGraphQLError('Cannot remove access from form owner', GRAPHQL_ERROR_CODES.NO_ACCESS);
-      }
-
-      const result = await prisma.formPermission.deleteMany({
-        where: {
-          formId,
-          userId
-        }
-      });
-
-      if (result.count > 0) {
-        await audit('permission.granted', 'FormPermission', formId, grantedById, {
-          targetUserId: userId,
-          permission: PermissionLevel.NO_ACCESS,
-        });
-      }
-
-      return result.count > 0;
+      return formSharingService.removeFormAccess(context.auth.user!.id, formId, userId);
     }
   },
 
   Form: {
     permissions: async (parent: any) => {
-      return await prisma.formPermission.findMany({
-        where: { formId: parent.id },
-        include: {
-          user: true,
-          grantedBy: true
-        },
-        orderBy: { grantedAt: 'desc' }
-      });
+      return formSharingService.listFormPermissions(parent.id);
     },
 
     userPermission: async (parent: any, _args: any, context: { auth: BetterAuthContext }) => {

--- a/apps/backend/src/repositories/__tests__/formPermissionRepository.test.ts
+++ b/apps/backend/src/repositories/__tests__/formPermissionRepository.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createFormPermissionRepository } from '../formPermissionRepository.js';
+
+const prismaMock = vi.hoisted(() => ({
+  formPermission: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    count: vi.fn().mockResolvedValue(0),
+    upsert: vi.fn().mockResolvedValue({}),
+    createMany: vi.fn().mockResolvedValue({ count: 0 }),
+    deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+  },
+}));
+
+vi.mock('../baseRepository.js', () => ({
+  resolvePrisma: () => prismaMock,
+}));
+
+describe('formPermissionRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.formPermission.findMany.mockResolvedValue([]);
+    prismaMock.formPermission.findUnique.mockResolvedValue(null);
+    prismaMock.formPermission.create.mockResolvedValue({});
+    prismaMock.formPermission.update.mockResolvedValue({});
+    prismaMock.formPermission.delete.mockResolvedValue({});
+    prismaMock.formPermission.count.mockResolvedValue(0);
+    prismaMock.formPermission.upsert.mockResolvedValue({});
+    prismaMock.formPermission.createMany.mockResolvedValue({ count: 0 });
+    prismaMock.formPermission.deleteMany.mockResolvedValue({ count: 0 });
+  });
+
+  it('should proxy generic delegate methods', async () => {
+    const repo = createFormPermissionRepository();
+    const args = { where: { id: 'perm-1' } };
+
+    await repo.findMany(args);
+    await repo.findUnique(args as any);
+    await repo.create({ data: { formId: 'form-1' } } as any);
+    await repo.update({ where: { id: 'perm-1' }, data: { permission: 'EDITOR' } } as any);
+    await repo.delete({ where: { id: 'perm-1' } } as any);
+    await repo.count(args as any);
+    await repo.upsert({ where: { id: 'perm-1' }, update: {}, create: {} } as any);
+    await repo.createMany({ data: [] } as any);
+    await repo.deleteMany({ where: { formId: 'form-1' } } as any);
+
+    expect(prismaMock.formPermission.findMany).toHaveBeenCalledWith(args);
+    expect(prismaMock.formPermission.findUnique).toHaveBeenCalledWith(args);
+    expect(prismaMock.formPermission.create).toHaveBeenCalled();
+    expect(prismaMock.formPermission.update).toHaveBeenCalled();
+    expect(prismaMock.formPermission.delete).toHaveBeenCalled();
+    expect(prismaMock.formPermission.count).toHaveBeenCalledWith(args);
+    expect(prismaMock.formPermission.upsert).toHaveBeenCalled();
+    expect(prismaMock.formPermission.createMany).toHaveBeenCalledWith({ data: [] });
+    expect(prismaMock.formPermission.deleteMany).toHaveBeenCalledWith({ where: { formId: 'form-1' } });
+  });
+
+  describe('findByForm', () => {
+    it('returns every grant for a form, newest first, with grantee + granter loaded', async () => {
+      const repo = createFormPermissionRepository();
+      const mockPermissions = [{ id: 'perm-1', formId: 'form-1' }];
+      prismaMock.formPermission.findMany.mockResolvedValueOnce(mockPermissions);
+
+      const result = await repo.findByForm('form-1');
+
+      expect(prismaMock.formPermission.findMany).toHaveBeenCalledWith({
+        where: { formId: 'form-1' },
+        include: { user: true, grantedBy: true },
+        orderBy: { grantedAt: 'desc' },
+      });
+      expect(result).toEqual(mockPermissions);
+    });
+  });
+
+  describe('removeManyForUsers', () => {
+    it('deletes permissions for a form scoped to a set of users', async () => {
+      const repo = createFormPermissionRepository();
+
+      await repo.removeManyForUsers('form-1', ['user-1', 'user-2']);
+
+      expect(prismaMock.formPermission.deleteMany).toHaveBeenCalledWith({
+        where: { formId: 'form-1', userId: { in: ['user-1', 'user-2'] } },
+      });
+    });
+  });
+
+  describe('removeForUser', () => {
+    it('deletes a single user permission on a form', async () => {
+      const repo = createFormPermissionRepository();
+
+      await repo.removeForUser('form-1', 'user-1');
+
+      expect(prismaMock.formPermission.deleteMany).toHaveBeenCalledWith({
+        where: { formId: 'form-1', userId: 'user-1' },
+      });
+    });
+  });
+
+  describe('createManyForUsers', () => {
+    it('bulk-creates permission grants', async () => {
+      const repo = createFormPermissionRepository();
+      const data = [
+        { id: 'perm-1', formId: 'form-1', userId: 'user-1', permission: 'EDITOR', grantedById: 'owner-1' },
+      ];
+
+      await repo.createManyForUsers(data as any);
+
+      expect(prismaMock.formPermission.createMany).toHaveBeenCalledWith({ data });
+    });
+  });
+
+  describe('upsertForUser', () => {
+    it('updates an existing grant with the same shape used to create it', async () => {
+      const repo = createFormPermissionRepository();
+      const upserted = { id: 'perm-1', formId: 'form-1', userId: 'user-1', permission: 'EDITOR' };
+      prismaMock.formPermission.upsert.mockResolvedValueOnce(upserted);
+
+      const result = await repo.upsertForUser('form-1', 'user-1', 'EDITOR', 'owner-1');
+
+      expect(prismaMock.formPermission.upsert).toHaveBeenCalledWith({
+        where: { formId_userId: { formId: 'form-1', userId: 'user-1' } },
+        update: { permission: 'EDITOR', grantedById: 'owner-1' },
+        create: expect.objectContaining({
+          formId: 'form-1',
+          userId: 'user-1',
+          permission: 'EDITOR',
+          grantedById: 'owner-1',
+        }),
+        include: { user: true, grantedBy: true },
+      });
+      expect(result).toEqual(upserted);
+    });
+  });
+});

--- a/apps/backend/src/repositories/__tests__/formRepository.test.ts
+++ b/apps/backend/src/repositories/__tests__/formRepository.test.ts
@@ -94,6 +94,35 @@ describe('formRepository', () => {
     expect(prismaMock.formFile.create).toHaveBeenCalledWith({ data: { formId: 'form-1', key: 'file' } });
   });
 
+  describe('findByIdWithAccessContext', () => {
+    it('queries with createdBy, permission grants, and the caller-scoped membership row', async () => {
+      const repo = createFormRepository();
+      const mockForm = { id: 'form-1', organization: { members: [] } };
+      prismaMock.form.findFirst.mockResolvedValueOnce(mockForm as any);
+
+      const result = await repo.findByIdWithAccessContext('form-1', 'user-1');
+
+      expect(prismaMock.form.findFirst).toHaveBeenCalledWith({
+        where: { id: 'form-1', deletedAt: null },
+        include: {
+          createdBy: true,
+          permissions: {
+            include: { user: true, grantedBy: true },
+          },
+          organization: {
+            include: {
+              members: {
+                where: { userId: 'user-1' },
+                include: { user: true },
+              },
+            },
+          },
+        },
+      });
+      expect(result).toEqual(mockForm);
+    });
+  });
+
   describe('listAccessibleByOrganization', () => {
     it('queries with the created/permission/sharing-scope OR clause and id-only select', async () => {
       const repo = createFormRepository();

--- a/apps/backend/src/repositories/__tests__/formRepository.test.ts
+++ b/apps/backend/src/repositories/__tests__/formRepository.test.ts
@@ -95,7 +95,7 @@ describe('formRepository', () => {
   });
 
   describe('findByIdWithAccessContext', () => {
-    it('queries with createdBy, permission grants, and the caller-scoped membership row', async () => {
+    it('queries with createdBy, the caller-scoped permission grant, and the caller-scoped membership row', async () => {
       const repo = createFormRepository();
       const mockForm = { id: 'form-1', organization: { members: [] } };
       prismaMock.form.findFirst.mockResolvedValueOnce(mockForm as any);
@@ -107,6 +107,7 @@ describe('formRepository', () => {
         include: {
           createdBy: true,
           permissions: {
+            where: { userId: 'user-1' },
             include: { user: true, grantedBy: true },
           },
           organization: {

--- a/apps/backend/src/repositories/formPermissionRepository.ts
+++ b/apps/backend/src/repositories/formPermissionRepository.ts
@@ -1,0 +1,117 @@
+import type { Prisma } from '#prisma-client';
+import { randomUUID } from 'crypto';
+import { resolvePrisma, type RepositoryContext } from './baseRepository.js';
+
+/**
+ * Factory for all FormPermission (form sharing) related data access.
+ */
+export const createFormPermissionRepository = (context?: RepositoryContext) => {
+  const prisma = resolvePrisma(context);
+
+  /** --- Generic delegate passthroughs (keep API flexibility) --- */
+  const findMany = <T extends Prisma.FormPermissionFindManyArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.FormPermissionFindManyArgs>
+  ) => prisma.formPermission.findMany(args);
+
+  const findUnique = <T extends Prisma.FormPermissionFindUniqueArgs>(
+    args: Prisma.SelectSubset<T, Prisma.FormPermissionFindUniqueArgs>
+  ) => prisma.formPermission.findUnique(args);
+
+  const create = <T extends Prisma.FormPermissionCreateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.FormPermissionCreateArgs>
+  ) => prisma.formPermission.create(args);
+
+  const update = <T extends Prisma.FormPermissionUpdateArgs>(
+    args: Prisma.SelectSubset<T, Prisma.FormPermissionUpdateArgs>
+  ) => prisma.formPermission.update(args);
+
+  const remove = <T extends Prisma.FormPermissionDeleteArgs>(
+    args: Prisma.SelectSubset<T, Prisma.FormPermissionDeleteArgs>
+  ) => prisma.formPermission.delete(args);
+
+  const count = <T extends Prisma.FormPermissionCountArgs>(
+    args?: Prisma.SelectSubset<T, Prisma.FormPermissionCountArgs>
+  ) => prisma.formPermission.count(args);
+
+  const upsert = <T extends Prisma.FormPermissionUpsertArgs>(
+    args: Prisma.SelectSubset<T, Prisma.FormPermissionUpsertArgs>
+  ) => prisma.formPermission.upsert(args);
+
+  const createMany = <T extends Prisma.FormPermissionCreateManyArgs>(
+    args: Prisma.SelectSubset<T, Prisma.FormPermissionCreateManyArgs>
+  ) => prisma.formPermission.createMany(args);
+
+  const deleteMany = <T extends Prisma.FormPermissionDeleteManyArgs>(
+    args: Prisma.SelectSubset<T, Prisma.FormPermissionDeleteManyArgs>
+  ) => prisma.formPermission.deleteMany(args);
+
+  /** --- Domain-oriented helpers for common access patterns --- */
+
+  /**
+   * Every permission grant on a form, newest first, with grantee + granter loaded.
+   * Used both by the `formPermissions` query and the `Form.permissions` field resolver.
+   */
+  const findByForm = async (formId: string) =>
+    prisma.formPermission.findMany({
+      where: { formId },
+      include: { user: true, grantedBy: true },
+      orderBy: { grantedAt: 'desc' },
+    });
+
+  /** Bulk-revoke permissions for a set of users on a form (pre-write cleanup in `shareForm`). */
+  const removeManyForUsers = async (formId: string, userIds: string[]) =>
+    prisma.formPermission.deleteMany({ where: { formId, userId: { in: userIds } } });
+
+  /** Revoke a single user's permission on a form. */
+  const removeForUser = async (formId: string, userId: string) =>
+    prisma.formPermission.deleteMany({ where: { formId, userId } });
+
+  /** Bulk-create permission grants (skips NO_ACCESS entries — callers filter those out). */
+  const createManyForUsers = async (
+    data: Prisma.FormPermissionCreateManyInput[]
+  ) => prisma.formPermission.createMany({ data });
+
+  /** Grant or update a single user's permission on a form. */
+  const upsertForUser = async (
+    formId: string,
+    userId: string,
+    permission: string,
+    grantedById: string
+  ) =>
+    prisma.formPermission.upsert({
+      where: { formId_userId: { formId, userId } },
+      update: { permission, grantedById },
+      create: {
+        id: randomUUID(),
+        formId,
+        userId,
+        permission,
+        grantedById,
+      },
+      include: { user: true, grantedBy: true },
+    });
+
+  return {
+    // Generic operations (used when custom queries are needed)
+    findMany,
+    findUnique,
+    create,
+    update,
+    delete: remove,
+    count,
+    upsert,
+    createMany,
+    deleteMany,
+
+    // Domain helpers (preferred for service layer)
+    findByForm,
+    removeManyForUsers,
+    removeForUser,
+    createManyForUsers,
+    upsertForUser,
+  };
+};
+
+export type FormPermissionRepository = ReturnType<typeof createFormPermissionRepository>;
+
+export const formPermissionRepository = createFormPermissionRepository();

--- a/apps/backend/src/repositories/formRepository.ts
+++ b/apps/backend/src/repositories/formRepository.ts
@@ -82,6 +82,33 @@ export const createFormRepository = (context?: RepositoryContext) => {
     });
 
   /**
+   * Form + the relations `checkFormAccess` needs to resolve a user's effective
+   * permission: creator, every permission grant (with grantee/granter), and
+   * the caller's own membership row in the form's organization.
+   */
+  const findByIdWithAccessContext = async (id: string, userId: string) =>
+    prisma.form.findFirst({
+      where: { id, deletedAt: null },
+      include: {
+        createdBy: true,
+        permissions: {
+          include: {
+            user: true,
+            grantedBy: true,
+          },
+        },
+        organization: {
+          include: {
+            members: {
+              where: { userId },
+              include: { user: true },
+            },
+          },
+        },
+      },
+    });
+
+  /**
    * Forms within an organization that a user can actually see: forms they
    * created, forms with an explicit non-NO_ACCESS permission grant, or forms
    * shared org-wide (ALL_ORG_MEMBERS) with a non-NO_ACCESS default permission.
@@ -176,6 +203,7 @@ export const createFormRepository = (context?: RepositoryContext) => {
     listByOrganization,
     findById,
     findByShortUrl,
+    findByIdWithAccessContext,
     listAccessibleByOrganization,
     createForm,
     updateForm,

--- a/apps/backend/src/repositories/formRepository.ts
+++ b/apps/backend/src/repositories/formRepository.ts
@@ -83,8 +83,8 @@ export const createFormRepository = (context?: RepositoryContext) => {
 
   /**
    * Form + the relations `checkFormAccess` needs to resolve a user's effective
-   * permission: creator, every permission grant (with grantee/granter), and
-   * the caller's own membership row in the form's organization.
+   * permission: creator, the caller's own explicit permission grant (if any),
+   * and the caller's own membership row in the form's organization.
    */
   const findByIdWithAccessContext = async (id: string, userId: string) =>
     prisma.form.findFirst({
@@ -92,6 +92,7 @@ export const createFormRepository = (context?: RepositoryContext) => {
       include: {
         createdBy: true,
         permissions: {
+          where: { userId },
           include: {
             user: true,
             grantedBy: true,

--- a/apps/backend/src/repositories/index.ts
+++ b/apps/backend/src/repositories/index.ts
@@ -1,5 +1,6 @@
 export * from './baseRepository.js';
 export * from './formRepository.js';
+export * from './formPermissionRepository.js';
 export * from './formFileRepository.js';
 export * from './subscriptionRepository.js';
 export * from './organizationRepository.js';

--- a/apps/backend/src/services/formSharingService.ts
+++ b/apps/backend/src/services/formSharingService.ts
@@ -1,0 +1,450 @@
+import { randomUUID } from 'crypto';
+import { createGraphQLError } from '#graphql-errors';
+import { GRAPHQL_ERROR_CODES } from '@dculus/types/graphql.js';
+import { formRepository } from '../repositories/formRepository.js';
+import { formPermissionRepository } from '../repositories/formPermissionRepository.js';
+import { memberRepository } from '../repositories/memberRepository.js';
+import { audit } from '../lib/audit.js';
+
+// Permission levels mapping
+export const PermissionLevel = {
+  OWNER: 'OWNER',
+  EDITOR: 'EDITOR',
+  VIEWER: 'VIEWER',
+  NO_ACCESS: 'NO_ACCESS',
+} as const;
+
+// Sharing scopes mapping
+export const SharingScope = {
+  PRIVATE: 'PRIVATE',
+  SPECIFIC_MEMBERS: 'SPECIFIC_MEMBERS',
+  ALL_ORG_MEMBERS: 'ALL_ORG_MEMBERS',
+} as const;
+
+export type Permission = (typeof PermissionLevel)[keyof typeof PermissionLevel];
+export type Scope = (typeof SharingScope)[keyof typeof SharingScope];
+
+export const PERMISSION_HIERARCHY: Record<string, number> = {
+  [PermissionLevel.NO_ACCESS]: 0,
+  [PermissionLevel.VIEWER]: 1,
+  [PermissionLevel.EDITOR]: 2,
+  [PermissionLevel.OWNER]: 3,
+};
+
+const checkPermissionLevel = (
+  userPermission: Permission,
+  requiredPermission: Permission
+): boolean =>
+  (PERMISSION_HIERARCHY[userPermission] ?? 0) >=
+  (PERMISSION_HIERARCHY[requiredPermission] ?? 0);
+
+/**
+ * Resolve a user's effective permission on a form: organization membership is
+ * checked first (even form owners lose access if they leave the org), then
+ * ownership, then explicit `FormPermission` grants, then the form's
+ * `ALL_ORG_MEMBERS` default sharing scope.
+ */
+export const checkFormAccess = async (
+  userId: string,
+  formId: string,
+  requiredPermission: Permission = PermissionLevel.VIEWER
+) => {
+  const form = await formRepository.findByIdWithAccessContext(formId, userId);
+
+  if (!form) {
+    throw createGraphQLError('Form not found', GRAPHQL_ERROR_CODES.FORM_NOT_FOUND);
+  }
+
+  // 🔒 SECURITY: Check organization membership FIRST (before owner check)
+  // This ensures even form owners must be organization members to access forms
+  const userMembership = form.organization.members.find(
+    (member: any) => member.userId === userId
+  );
+  if (!userMembership) {
+    // User is not a member of this organization - deny access even if they're the owner
+    return { hasAccess: false, permission: PermissionLevel.NO_ACCESS, form };
+  }
+
+  // Check if user is the form owner (only reachable if user is org member)
+  if (form.createdById === userId) {
+    return { hasAccess: true, permission: PermissionLevel.OWNER, form };
+  }
+
+  // Check explicit permissions
+  const explicitPermission = form.permissions.find((p: any) => p.userId === userId);
+  if (explicitPermission) {
+    const hasRequiredAccess = checkPermissionLevel(
+      explicitPermission.permission as Permission,
+      requiredPermission
+    );
+    return {
+      hasAccess: hasRequiredAccess,
+      permission: explicitPermission.permission as Permission,
+      form,
+    };
+  }
+
+  // Check sharing scope for organization members
+  if (form.sharingScope === SharingScope.ALL_ORG_MEMBERS) {
+    const hasRequiredAccess = checkPermissionLevel(
+      form.defaultPermission as Permission,
+      requiredPermission
+    );
+    return {
+      hasAccess: hasRequiredAccess,
+      permission: form.defaultPermission as Permission,
+      form,
+    };
+  }
+
+  // Default: no access
+  return { hasAccess: false, permission: PermissionLevel.NO_ACCESS, form };
+};
+
+/** Every permission grant on a form — no access check (used by the `Form.permissions` field resolver). */
+export const listFormPermissions = (formId: string) =>
+  formPermissionRepository.findByForm(formId);
+
+/** Owner-only listing of a form's permission grants, for the `formPermissions` query. */
+export const getFormPermissions = async (userId: string, formId: string) => {
+  const accessCheck = await checkFormAccess(userId, formId, PermissionLevel.OWNER);
+  if (!accessCheck.hasAccess) {
+    throw createGraphQLError('Access denied: Insufficient permissions', GRAPHQL_ERROR_CODES.NO_ACCESS);
+  }
+
+  return listFormPermissions(formId);
+};
+
+export const listForms = async (params: {
+  organizationId: string;
+  category: string;
+  userId: string;
+  page?: number;
+  limit?: number;
+  filters?: { search?: string };
+}) => {
+  const { organizationId, category, userId, page = 1, limit = 10, filters } = params;
+
+  // Validate pagination parameters
+  const currentPage = Math.max(1, page);
+  const pageLimit = Math.min(Math.max(1, limit), 100); // Max 100 items per page
+  const skip = (currentPage - 1) * pageLimit;
+
+  const sharedAccessConditions = [
+    {
+      permissions: {
+        some: {
+          userId,
+          permission: { not: PermissionLevel.NO_ACCESS },
+        },
+      },
+    },
+    {
+      sharingScope: SharingScope.ALL_ORG_MEMBERS,
+      defaultPermission: { not: PermissionLevel.NO_ACCESS },
+    },
+  ];
+
+  const searchTerm = filters?.search?.trim();
+  const searchFilter = searchTerm
+    ? {
+        OR: [
+          { title: { contains: searchTerm, mode: 'insensitive' } },
+          { description: { contains: searchTerm, mode: 'insensitive' } },
+        ],
+      }
+    : null;
+
+  let whereCondition: any;
+
+  switch (category) {
+    case 'OWNER': {
+      whereCondition = {
+        organizationId,
+        createdById: userId,
+        ...(searchFilter ? { AND: [searchFilter] } : {}),
+      };
+      break;
+    }
+    case 'SHARED': {
+      whereCondition = {
+        organizationId,
+        createdById: { not: userId },
+        AND: [{ OR: sharedAccessConditions }, ...(searchFilter ? [searchFilter] : [])],
+      };
+      break;
+    }
+    case 'ALL': {
+      const ownerClause = searchFilter
+        ? {
+            createdById: userId,
+            AND: [searchFilter],
+          }
+        : { createdById: userId };
+
+      const sharedClause = {
+        createdById: { not: userId },
+        AND: [{ OR: sharedAccessConditions }, ...(searchFilter ? [searchFilter] : [])],
+      };
+
+      whereCondition = {
+        organizationId,
+        OR: [ownerClause, sharedClause],
+      };
+      break;
+    }
+    default: {
+      throw createGraphQLError(
+        `Invalid category: ${category}. Must be OWNER, SHARED, or ALL`,
+        GRAPHQL_ERROR_CODES.BAD_USER_INPUT
+      );
+    }
+  }
+
+  whereCondition = { ...whereCondition, deletedAt: null };
+
+  // Get total count for pagination
+  const totalCount = await formRepository.count({
+    where: whereCondition,
+  });
+
+  // Get paginated forms — include _count.responses for N+1-free responseCount resolution (P3-02)
+  const forms = await formRepository.findMany({
+    where: whereCondition,
+    include: {
+      organization: true,
+      createdBy: true,
+      permissions: {
+        include: {
+          user: true,
+          grantedBy: true,
+        },
+      },
+      _count: {
+        select: { responses: true },
+      },
+    },
+    orderBy: { updatedAt: 'desc' },
+    skip,
+    take: pageLimit,
+  });
+
+  const totalPages = Math.ceil(totalCount / pageLimit);
+
+  return {
+    forms,
+    totalCount,
+    page: currentPage,
+    limit: pageLimit,
+    totalPages,
+    hasNextPage: currentPage < totalPages,
+    hasPreviousPage: currentPage > 1,
+  };
+};
+
+export const listOrganizationMembersForSharing = async (organizationId: string) => {
+  const members = await memberRepository.findMany({
+    where: { organizationId },
+    include: { user: true },
+    orderBy: { user: { name: 'asc' } },
+  });
+
+  return members.map((member: any) => member.user);
+};
+
+export const shareForm = async (
+  userId: string,
+  input: {
+    formId: string;
+    sharingScope: Scope;
+    defaultPermission?: Permission;
+    userPermissions?: Array<{ userId: string; permission: Permission }>;
+  }
+) => {
+  // Check if user has permission to share the form (must be owner)
+  const accessCheck = await checkFormAccess(userId, input.formId, PermissionLevel.OWNER);
+  if (!accessCheck.hasAccess) {
+    throw createGraphQLError(
+      'Access denied: Insufficient permissions to share this form',
+      GRAPHQL_ERROR_CODES.NO_ACCESS
+    );
+  }
+
+  // Update form sharing settings
+  const updatedForm = await formRepository.update({
+    where: { id: input.formId },
+    data: {
+      sharingScope: input.sharingScope,
+      defaultPermission: input.defaultPermission || PermissionLevel.VIEWER,
+    },
+  });
+
+  // Handle user-specific permissions
+  if (input.userPermissions && input.userPermissions.length > 0) {
+    const userIds = input.userPermissions.map((up) => up.userId);
+
+    // 🔒 SECURITY: Verify all target users are members of the form's organization
+    const orgMembers = await memberRepository.findMany({
+      where: {
+        organizationId: accessCheck.form.organizationId,
+        userId: { in: userIds },
+      },
+      select: { userId: true },
+    });
+
+    const validUserIds = new Set(orgMembers.map((m: any) => m.userId));
+    const invalidUsers = userIds.filter((id) => !validUserIds.has(id));
+
+    if (invalidUsers.length > 0) {
+      throw createGraphQLError(
+        `Cannot grant permissions to users outside organization: ${invalidUsers.join(', ')}`,
+        GRAPHQL_ERROR_CODES.NO_ACCESS
+      );
+    }
+
+    // Prevent callers from granting themselves a higher role than they currently hold
+    const callerCurrentPermission = accessCheck.permission;
+    const selfEscalation = input.userPermissions.find(
+      (up) =>
+        up.userId === userId &&
+        (PERMISSION_HIERARCHY[up.permission] ?? 0) > (PERMISSION_HIERARCHY[callerCurrentPermission] ?? 0)
+    );
+    if (selfEscalation) {
+      throw createGraphQLError(
+        'Cannot grant yourself a higher permission level than you currently hold',
+        GRAPHQL_ERROR_CODES.NO_ACCESS
+      );
+    }
+
+    // Remove existing permissions for these users
+    await formPermissionRepository.removeManyForUsers(input.formId, userIds);
+
+    // Add new permissions
+    const permissionsToCreate = input.userPermissions
+      .filter((up) => up.permission !== PermissionLevel.NO_ACCESS)
+      .map((up) => ({
+        id: randomUUID(),
+        formId: input.formId,
+        userId: up.userId,
+        permission: up.permission,
+        grantedById: userId,
+      }));
+
+    if (permissionsToCreate.length > 0) {
+      await formPermissionRepository.createManyForUsers(permissionsToCreate);
+    }
+  }
+
+  // Return the updated sharing settings
+  const permissions = await formPermissionRepository.findMany({
+    where: { formId: input.formId },
+    include: {
+      user: true,
+      grantedBy: true,
+    },
+  });
+
+  await audit('permission.granted', 'FormPermission', input.formId, userId, {
+    sharingScope: input.sharingScope,
+    defaultPermission: input.defaultPermission,
+    userPermissions: input.userPermissions,
+  });
+
+  return {
+    sharingScope: updatedForm.sharingScope,
+    defaultPermission: updatedForm.defaultPermission,
+    permissions,
+  };
+};
+
+export const updateFormPermission = async (
+  grantedById: string,
+  input: { formId: string; userId: string; permission: Permission }
+) => {
+  // Check if user has permission to manage permissions (must be owner)
+  const accessCheck = await checkFormAccess(grantedById, input.formId, PermissionLevel.OWNER);
+  if (!accessCheck.hasAccess) {
+    throw createGraphQLError('Access denied: Insufficient permissions', GRAPHQL_ERROR_CODES.NO_ACCESS);
+  }
+
+  // 🔒 SECURITY: Verify target user is a member of the form's organization
+  const isMember = await memberRepository.findFirst({
+    where: {
+      organizationId: accessCheck.form.organizationId,
+      userId: input.userId,
+    },
+  });
+
+  if (!isMember) {
+    throw createGraphQLError('Cannot grant permissions to users outside organization', GRAPHQL_ERROR_CODES.NO_ACCESS);
+  }
+
+  // Prevent users from changing owner permissions
+  if (accessCheck.form.createdById === input.userId) {
+    throw createGraphQLError('Cannot change permissions for form owner', GRAPHQL_ERROR_CODES.NO_ACCESS);
+  }
+
+  // Remove access if permission is NO_ACCESS
+  if (input.permission === PermissionLevel.NO_ACCESS) {
+    await formPermissionRepository.removeForUser(input.formId, input.userId);
+
+    await audit('permission.granted', 'FormPermission', input.formId, grantedById, {
+      targetUserId: input.userId,
+      permission: PermissionLevel.NO_ACCESS,
+    });
+
+    return {
+      id: '',
+      formId: input.formId,
+      userId: input.userId,
+      permission: PermissionLevel.NO_ACCESS,
+      grantedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      user: null,
+      grantedBy: null,
+    };
+  }
+
+  // Upsert permission
+  const permission = await formPermissionRepository.upsertForUser(
+    input.formId,
+    input.userId,
+    input.permission,
+    grantedById
+  );
+
+  await audit('permission.granted', 'FormPermission', input.formId, grantedById, {
+    targetUserId: input.userId,
+    permission: input.permission,
+  });
+
+  return permission;
+};
+
+export const removeFormAccess = async (
+  grantedById: string,
+  formId: string,
+  userId: string
+) => {
+  // Check if user has permission to manage permissions (must be owner)
+  const accessCheck = await checkFormAccess(grantedById, formId, PermissionLevel.OWNER);
+  if (!accessCheck.hasAccess) {
+    throw createGraphQLError('Access denied: Insufficient permissions', GRAPHQL_ERROR_CODES.NO_ACCESS);
+  }
+
+  // Prevent removing access from form owner
+  if (accessCheck.form.createdById === userId) {
+    throw createGraphQLError('Cannot remove access from form owner', GRAPHQL_ERROR_CODES.NO_ACCESS);
+  }
+
+  const result = await formPermissionRepository.removeForUser(formId, userId);
+
+  if (result.count > 0) {
+    await audit('permission.granted', 'FormPermission', formId, grantedById, {
+      targetUserId: userId,
+      permission: PermissionLevel.NO_ACCESS,
+    });
+  }
+
+  return result.count > 0;
+};


### PR DESCRIPTION
## Summary

- Part of Epic #245 (Backend — Repository Pattern Rollout). Closes #259.
- Adds `formPermissionRepository` covering all `FormPermission` data access (generic CRUD + domain helpers: `findByForm`, `removeManyForUsers`, `removeForUser`, `createManyForUsers`, `upsertForUser`), registered in `repositories/index.ts`.
- Adds `formSharingService` owning `checkFormAccess`, `PermissionLevel`, `SharingScope`, `PERMISSION_HIERARCHY`, and all sharing business logic (`listForms`, `shareForm`, `updateFormPermission`, `removeFormAccess`, etc.), built on `formRepository` (+ new `findByIdWithAccessContext` helper), `formPermissionRepository`, and `memberRepository`.
- `graphql/resolvers/formSharing.ts` now has zero direct `prisma.*` calls — routes entirely through `formSharingService` while keeping every existing `requireAuth`/`requireOrganizationMembership`/permission-level guard exactly as-is.
- `checkFormAccess`/`PermissionLevel`/`SharingScope`/`PERMISSION_HIERARCHY` stay re-exported from `formSharing.ts`, so the ~15 other resolvers/services that import them (`formService`, `hocuspocus`, `fileUpload`, `analytics`, `tags`, etc.) needed **zero** changes.
- No behavior change — existing `formSharing.test.ts` passes unmodified.

## Test plan

- [x] `pnpm --filter backend exec tsc --noEmit` passes
- [x] `pnpm --filter backend test` — 117 files / 3045 tests pass, including unmodified `formSharing.test.ts`
- [x] New `apps/backend/src/repositories/__tests__/formPermissionRepository.test.ts` (mocked Prisma)
- [x] New `findByIdWithAccessContext` test case in `formRepository.test.ts`
- [x] `grep -n "prisma\." apps/backend/src/graphql/resolvers/formSharing.ts` → zero matches
- [x] Manually verified via `pnpm dev` against the shared dev DB: opened the Share dialog on a real form, switched sharing scope to "All organization members" and back to "Private" — both saved successfully with no backend errors, exercising `checkFormAccess`, `formPermissions`, `organizationMembers`, and `shareForm` end-to-end
- [x] pre-push hook (backend/form-viewer tests + form-app/form-viewer/admin-app builds) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Sharing & Permissions**
  * Improved form-sharing access controls and permission handling.
  * Added support for listing forms, shared members, and effective access levels.
  * Sharing updates, permission changes, and access removal now provide more consistent results.
  * Added safeguards for organization membership, owner protection, and preventing unauthorized permission escalation.

* **Reliability**
  * Improved consistency of form access and sharing operations across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->