### PR TITLE
Native Quiz: strip grading from formSchemaPublic

### DIFF
--- a/apps/backend/src/graphql/resolvers/__tests__/forms.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/forms.test.ts
@@ -453,6 +453,157 @@ describe('Forms Resolvers', () => {
     });
   });
 
+  describe('Form: formSchemaPublic', () => {
+    const buildSchema = () => ({
+      pages: [
+        {
+          id: 'page-1',
+          title: 'Page 1',
+          fields: [
+            {
+              id: 'field-1',
+              type: 'radio_field',
+              label: 'Q1',
+              grading: {
+                mode: 'exact',
+                pointValue: 10,
+                acceptedAnswers: ['Paris'],
+              },
+            },
+            {
+              id: 'field-2',
+              type: 'text_input_field',
+              label: 'Q2',
+              // no grading on this field
+            },
+            {
+              id: 'field-3',
+              type: 'checkbox_field',
+              label: 'Q3 (deleted)',
+              deleted: true,
+              grading: {
+                mode: 'set',
+                pointValue: 5,
+                acceptedAnswers: ['a', 'b'],
+              },
+            },
+          ],
+        },
+        {
+          id: 'page-2',
+          title: 'Page 2',
+          fields: [
+            {
+              id: 'field-4',
+              type: 'number_field',
+              label: 'Q4',
+              grading: {
+                mode: 'numeric',
+                pointValue: 7,
+                acceptedAnswers: ['42'],
+                numeric: { tolerance: 0.5 },
+              },
+            },
+          ],
+        },
+      ],
+      layout: { theme: 'light' },
+    });
+
+    it('filters out deleted fields', async () => {
+      vi.mocked(hocuspocusService.getFormSchemaFromHocuspocus).mockResolvedValue(buildSchema());
+
+      const result = await formsResolvers.Form.formSchemaPublic(mockForm, {}, mockContext);
+
+      const fieldIds = result.pages.flatMap((p: any) => p.fields.map((f: any) => f.id));
+      expect(fieldIds).toEqual(['field-1', 'field-2', 'field-4']);
+    });
+
+    it('strips grading from every field so the answer key never reaches the serialized payload', async () => {
+      vi.mocked(hocuspocusService.getFormSchemaFromHocuspocus).mockResolvedValue(buildSchema());
+
+      const result = await formsResolvers.Form.formSchemaPublic(mockForm, {}, mockContext);
+      const serialized = JSON.stringify(result);
+
+      expect(serialized).not.toContain('grading');
+      expect(serialized).not.toContain('acceptedAnswers');
+      expect(serialized).not.toContain('pointValue');
+
+      // Sanity: the fields themselves (and non-grading data) survived the strip.
+      expect(serialized).toContain('field-1');
+      expect(serialized).toContain('field-4');
+    });
+
+    it('does not mutate the schema returned by getFormSchemaFromHocuspocus', async () => {
+      const schema = buildSchema();
+      vi.mocked(hocuspocusService.getFormSchemaFromHocuspocus).mockResolvedValue(schema);
+
+      await formsResolvers.Form.formSchemaPublic(mockForm, {}, mockContext);
+      // Call again on the SAME underlying object — if the first call mutated
+      // it in place, grading would already be gone here.
+      await formsResolvers.Form.formSchemaPublic(mockForm, {}, mockContext);
+
+      expect(schema.pages[0].fields[0]).toHaveProperty('grading');
+      expect((schema.pages[0].fields[0] as any).grading.acceptedAnswers).toEqual(['Paris']);
+      expect(schema.pages[1].fields[0]).toHaveProperty('grading');
+    });
+
+    it('leaves the authenticated formSchema resolver untouched — grading still returned', async () => {
+      const schema = buildSchema();
+      vi.mocked(hocuspocusService.getFormSchemaFromHocuspocus).mockResolvedValue(schema);
+
+      const result = await formsResolvers.Form.formSchema(mockForm);
+
+      expect(JSON.stringify(result)).toContain('grading');
+      expect(result.pages[0].fields[0].grading.acceptedAnswers).toEqual(['Paris']);
+    });
+
+    it('produces a byte-identical payload to before when a form has no grading anywhere', async () => {
+      const noGradingSchema = {
+        pages: [
+          {
+            id: 'page-1',
+            title: 'Page 1',
+            fields: [
+              { id: 'field-1', type: 'text_input_field', label: 'Q1' },
+              { id: 'field-2', type: 'text_input_field', label: 'Q2', deleted: true },
+            ],
+          },
+        ],
+        layout: { theme: 'light' },
+      };
+      vi.mocked(hocuspocusService.getFormSchemaFromHocuspocus).mockResolvedValue(noGradingSchema);
+
+      const result = await formsResolvers.Form.formSchemaPublic(mockForm, {}, mockContext);
+
+      // Same shape the pre-Story-04 resolver would have produced: only the
+      // deleted-field filter applied, nothing else changed.
+      expect(result).toEqual({
+        pages: [
+          {
+            id: 'page-1',
+            title: 'Page 1',
+            fields: [{ id: 'field-1', type: 'text_input_field', label: 'Q1' }],
+          },
+        ],
+        layout: { theme: 'light' },
+      });
+    });
+
+    it('returns null when access control gates the form', async () => {
+      const gatedForm = {
+        ...mockForm,
+        settings: JSON.stringify({ accessControl: { enabled: true, requireSignIn: true } }),
+      };
+      const unauthenticatedContext = { auth: { user: null, session: null, isAuthenticated: false } };
+
+      const result = await formsResolvers.Form.formSchemaPublic(gatedForm, {}, unauthenticatedContext as any);
+
+      expect(result).toBeNull();
+      expect(hocuspocusService.getFormSchemaFromHocuspocus).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Form: settings', () => {
     it('should parse and return JSON settings', () => {
       const settings = { theme: 'dark', spacing: 'compact' };

--- a/apps/backend/src/graphql/resolvers/forms.ts
+++ b/apps/backend/src/graphql/resolvers/forms.ts
@@ -123,6 +123,26 @@ export const formsResolvers = {
       // Fall back to the DB column when Hocuspocus is unavailable (e.g. pool pressure timeout)
       return schema ?? parent.formSchema ?? null;
     },
+    // This is the ONLY resolver the public form-viewer renders from
+    // (apps/form-viewer/src/pages/FormViewer.tsx) — it is reachable by any
+    // respondent, unauthenticated, before they submit anything. Every field's
+    // optional `grading` (Native Quiz answer key: acceptedAnswers, pointValue,
+    // etc. — see packages/types/src/quiz.ts) is stripped unconditionally
+    // below, regardless of whether quiz mode is on, because leaking it here
+    // would hand out the answer key to every respondent ahead of submission.
+    // `Form.formSchema` (above) is the builder-only counterpart and keeps
+    // `grading` intact for authors.
+    //
+    // The other two surfaces that read form structure are already safe and
+    // need no stripping:
+    //   - The Hocuspocus Y.doc (services/hocuspocus.ts) is builder-only —
+    //     form-viewer never opens a Y.js connection; only the authenticated
+    //     builder does, via CollaborationManager, which sends a bearer token
+    //     (apps/form-app/src/store/collaboration/CollaborationManager.ts).
+    //   - `Form.settings` (below) is a typed GraphQL object (see
+    //     `type FormSettings` in schema.ts), so a client only ever receives
+    //     the subfields it explicitly selects in its query — there is no
+    //     JSON blob to accidentally over-expose a new settings key through.
     formSchemaPublic: async (parent: any, _args: any, context: { auth: BetterAuthContext }) => {
       // Withhold form structure while access control isn't satisfied — this
       // is what lets `formByShortUrl` return a gate-able Form instead of a
@@ -137,7 +157,14 @@ export const formsResolvers = {
         ...raw,
         pages: raw.pages.map((page: any) => ({
           ...page,
-          fields: (page.fields || []).filter((f: any) => !f.deleted),
+          fields: (page.fields || [])
+            .filter((f: any) => !f.deleted)
+            .map((f: any) => {
+              if (!('grading' in f)) return f;
+              const fieldWithoutGrading = { ...f };
+              delete fieldWithoutGrading.grading;
+              return fieldWithoutGrading;
+            }),
         })),
       };
     },


### PR DESCRIPTION
Closes #293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Public form views now consistently hide quiz grading and answer-key information.
  - Deleted fields are excluded from public form schemas.
  - Access-restricted forms correctly return no schema to unauthorized viewers.
  - Existing schemas without grading data retain their previous behavior.

- **Tests**
  - Added coverage for public and authenticated form schema access, data filtering, and source-schema immutability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->