### PR TITLE
Native Quiz: Y.js plumbing for field grading

### DIFF
--- a/apps/form-app/src/store/collaboration/CollaborationManager.ts
+++ b/apps/form-app/src/store/collaboration/CollaborationManager.ts
@@ -4,11 +4,13 @@ import { getBearerToken } from '../../lib/auth-client';
 import {
   ConditionalRule,
   deserializeFormField,
+  FieldGrading,
   FieldType,
   FormField,
   FormLayout,
   FormPage,
   sanitizeConditions,
+  sanitizeFieldGrading,
 } from '@dculus/types';
 import * as Y from 'yjs';
 import { DEFAULT_LAYOUT } from '../helpers/defaultLayout';
@@ -34,6 +36,47 @@ export type FieldData = {
   maxFiles?: number;
   defaultCountry?: string;
   deleted?: boolean;
+  grading?: FieldGrading;
+};
+
+// Converts a nested Y.Map (e.g. `grading.text`/`grading.numeric`/`grading.set`) into a
+// plain object, leaving primitives untouched. Only used for grading's small,
+// flat sub-option-objects — not a general Y-type deep-unwrap.
+const yMapToPlainObject = (value: any): any => {
+  if (!(value instanceof Y.Map)) return value;
+  const plain: Record<string, any> = {};
+  value.forEach((v, k) => {
+    plain[k] = v;
+  });
+  return plain;
+};
+
+// Reads the `grading` Y.Map (built by createYJSFieldMap) back into a plain
+// FieldGrading object, then re-validates it through sanitizeFieldGrading so
+// downstream code only ever sees well-formed grading — mirrors the same
+// trust-boundary treatment applied to conditions/quiz settings elsewhere.
+// Returns undefined (never {}) when the field has no grading.
+const extractGrading = (fieldMap: Y.Map<any>): FieldGrading | undefined => {
+  const gradingYMap = fieldMap.get('grading');
+  if (!(gradingYMap instanceof Y.Map)) return undefined;
+
+  const plain: Record<string, any> = {};
+  gradingYMap.forEach((value, key) => {
+    if (key === 'acceptedAnswers') {
+      plain[key] = value instanceof Y.Array ? value.toArray() : value;
+    } else if (key === 'optionFeedback') {
+      const arr = value instanceof Y.Array ? value.toArray() : value;
+      plain[key] = Array.isArray(arr)
+        ? arr.map((entry) => yMapToPlainObject(entry))
+        : arr;
+    } else if (key === 'text' || key === 'numeric' || key === 'set') {
+      plain[key] = yMapToPlainObject(value);
+    } else {
+      plain[key] = value;
+    }
+  });
+
+  return sanitizeFieldGrading(plain);
 };
 
 export const extractFieldData = (fieldMap: Y.Map<any>): FieldData => {
@@ -94,6 +137,7 @@ export const extractFieldData = (fieldMap: Y.Map<any>): FieldData => {
     maxFiles: fieldMap.get('maxFiles'),
     defaultCountry: fieldMap.get('defaultCountry') || undefined,
     deleted: fieldMap.get('deleted') || undefined,
+    grading: extractGrading(fieldMap),
   };
 
   if (fieldType === FieldType.RICH_TEXT_FIELD) {

--- a/apps/form-app/src/store/helpers/__tests__/fieldHelpers.grading.test.ts
+++ b/apps/form-app/src/store/helpers/__tests__/fieldHelpers.grading.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Y.js round-trip coverage for field `grading` (#294 — Story 05 of the Native
+ * Quiz epic, #289). `grading` is a nested object containing arrays
+ * (`acceptedAnswers`, `optionFeedback`) and mode-specific sub-objects
+ * (`text`/`numeric`/`set`), so it needs the same explicit Y.Array/Y.Map
+ * treatment `createYJSFieldMap` already gives `options`/`allowedMimeTypes`/
+ * `validation`. This suite exercises the two ends of that plumbing directly:
+ * createYJSFieldMap (plain FieldData -> Y.Map) and extractFieldData
+ * (Y.Map -> plain FieldData).
+ *
+ * setupTests.ts globally mocks '@dculus/types' with a small subset of field
+ * classes for component tests — opt back into the real implementation here
+ * (same pattern as selectionSlice.test.ts's `jest.unmock('zustand')`) since
+ * these tests need the full type system, including the grading sanitizers
+ * and every field class createFormField can construct. CollaborationManager
+ * also pulls in lib/config (import.meta.env, Vite-only) and lib/auth-client
+ * transitively — stub both since this suite never opens a real connection.
+ */
+jest.unmock('@dculus/types');
+jest.mock('../../../lib/config', () => ({ getWebSocketUrl: () => '' }));
+jest.mock('../../../lib/auth-client', () => ({ getBearerToken: () => '' }));
+
+import * as Y from 'yjs';
+import { FieldGrading, FieldType, FillableFormField } from '@dculus/types';
+import {
+  createFormField,
+  createYJSFieldMap,
+  serializeFieldToYMap,
+} from '../fieldHelpers';
+import { extractFieldData, FieldData } from '../../collaboration/CollaborationManager';
+
+const baseFieldData = (
+  overrides: Partial<FieldData> = {}
+): FieldData => ({
+  id: 'f1',
+  type: FieldType.RADIO_FIELD,
+  label: 'Question',
+  required: false,
+  placeholder: '',
+  defaultValue: '',
+  prefix: '',
+  hint: '',
+  options: ['Option A', 'Option B', 'Option C'],
+  ...overrides,
+});
+
+// Yjs types must be integrated into a Y.Doc before they can be read back
+// (AbstractType throws "Invalid access" otherwise) — mirror how production
+// code always inserts a freshly-built fieldMap into a Y.Array that already
+// belongs to a doc (fieldsArray.push([fieldMap])) before reading from it.
+const attachToDoc = <T extends Y.AbstractType<any>>(type: T): T => {
+  const doc = new Y.Doc();
+  doc.getMap('root').set('field', type);
+  return type;
+};
+
+const roundTrip = (fieldData: FieldData): FieldData => {
+  const map = attachToDoc(createYJSFieldMap(fieldData));
+  return extractFieldData(map);
+};
+
+describe('grading round-trip through createYJSFieldMap / extractFieldData', () => {
+  test('exact mode with optionFeedback, messages and shuffleOptions round-trips deeply-equal', () => {
+    const grading: FieldGrading = {
+      mode: 'exact',
+      pointValue: 5,
+      acceptedAnswers: ['Option A'],
+      whenCorrect: 'Nice work!',
+      whenIncorrect: 'Not quite.',
+      general: 'This tests basic recall.',
+      optionFeedback: [
+        { option: 'Option A', feedback: 'Correct — well done.' },
+        { option: 'Option B', feedback: 'Close, but not it.' },
+      ],
+      shuffleOptions: true,
+    };
+
+    const result = roundTrip(baseFieldData({ grading }));
+    expect(result.grading).toEqual(grading);
+  });
+
+  test('set mode with wrongSelectionPenalty round-trips deeply-equal', () => {
+    const grading: FieldGrading = {
+      mode: 'set',
+      pointValue: 10,
+      acceptedAnswers: ['Option A', 'Option C'],
+      set: { scoring: 'partial', wrongSelectionPenalty: 0.5 },
+    };
+
+    const result = roundTrip(
+      baseFieldData({ type: FieldType.CHECKBOX_FIELD, grading })
+    );
+    expect(result.grading).toEqual(grading);
+  });
+
+  test('text mode with match options round-trips deeply-equal', () => {
+    const grading: FieldGrading = {
+      mode: 'text',
+      pointValue: 3,
+      acceptedAnswers: ['Paris', 'paris, france'],
+      text: {
+        caseSensitive: false,
+        trimWhitespace: true,
+        collapseWhitespace: true,
+        ignorePunctuation: true,
+        regex: false,
+      },
+    };
+
+    const result = roundTrip(
+      baseFieldData({ type: FieldType.TEXT_INPUT_FIELD, options: undefined, grading })
+    );
+    expect(result.grading).toEqual(grading);
+  });
+
+  test('numeric mode with tolerance/min/max round-trips deeply-equal', () => {
+    const grading: FieldGrading = {
+      mode: 'numeric',
+      pointValue: 2,
+      acceptedAnswers: ['42'],
+      numeric: { tolerance: 0.5, tolerancePercent: 5, min: 0, max: 100 },
+    };
+
+    const result = roundTrip(
+      baseFieldData({ type: FieldType.NUMBER_FIELD, options: undefined, grading })
+    );
+    expect(result.grading).toEqual(grading);
+  });
+
+  test('manual mode with an empty answer key round-trips deeply-equal', () => {
+    const grading: FieldGrading = {
+      mode: 'manual',
+      pointValue: 5,
+      acceptedAnswers: [],
+    };
+
+    const result = roundTrip(
+      baseFieldData({ type: FieldType.TEXT_AREA_FIELD, options: undefined, grading })
+    );
+    expect(result.grading).toEqual(grading);
+  });
+
+  test('a field with no grading round-trips to grading === undefined', () => {
+    const result = roundTrip(baseFieldData());
+    expect(result.grading).toBeUndefined();
+  });
+
+  test('a field with no grading produces a Y.Map with NO grading key at all', () => {
+    const map = attachToDoc(createYJSFieldMap(baseFieldData()));
+    expect(map.has('grading')).toBe(false);
+  });
+
+  test('a field with grading produces a Y.Map whose grading key is a Y.Map (not a plain object)', () => {
+    const grading: FieldGrading = { mode: 'exact', pointValue: 1, acceptedAnswers: ['A'] };
+    const map = attachToDoc(createYJSFieldMap(baseFieldData({ grading })));
+    expect(map.get('grading')).toBeInstanceOf(Y.Map);
+    expect(map.get('grading').get('acceptedAnswers')).toBeInstanceOf(Y.Array);
+  });
+});
+
+describe('createFormField assigns grading after construction', () => {
+  test('grading is attached to the constructed instance when provided', () => {
+    const grading: FieldGrading = { mode: 'exact', pointValue: 1, acceptedAnswers: ['A'] };
+    const field = createFormField(FieldType.RADIO_FIELD, {
+      label: 'Q1',
+      options: ['A', 'B'],
+      grading,
+    }) as FillableFormField;
+
+    expect(field.grading).toEqual(grading);
+  });
+
+  test('grading is left undefined when not provided', () => {
+    const field = createFormField(FieldType.RADIO_FIELD, {
+      label: 'Q1',
+      options: ['A', 'B'],
+    }) as FillableFormField;
+
+    expect(field.grading).toBeUndefined();
+  });
+
+  test('grading is never assigned to non-fillable fields (rich text)', () => {
+    const field = createFormField(FieldType.RICH_TEXT_FIELD, {
+      content: '<p>hi</p>',
+    } as any);
+
+    expect((field as any).grading).toBeUndefined();
+  });
+});
+
+describe('serializeFieldToYMap carries grading from a FillableFormField instance', () => {
+  test('an instance with grading serializes to a Y.Map with a populated grading key', () => {
+    const grading: FieldGrading = {
+      mode: 'set',
+      pointValue: 8,
+      acceptedAnswers: ['A', 'B'],
+      set: { scoring: 'all' },
+    };
+    const field = createFormField(FieldType.CHECKBOX_FIELD, {
+      label: 'Pick two',
+      options: ['A', 'B', 'C'],
+      grading,
+    }) as FillableFormField;
+
+    const map = attachToDoc(serializeFieldToYMap(field));
+    const extracted = extractFieldData(map);
+    expect(extracted.grading).toEqual(grading);
+  });
+
+  test('an instance without grading serializes to a Y.Map with no grading key', () => {
+    const field = createFormField(FieldType.CHECKBOX_FIELD, {
+      label: 'Pick two',
+      options: ['A', 'B', 'C'],
+    }) as FillableFormField;
+
+    const map = attachToDoc(serializeFieldToYMap(field));
+    expect(map.has('grading')).toBe(false);
+  });
+});

--- a/apps/form-app/src/store/helpers/fieldHelpers.ts
+++ b/apps/form-app/src/store/helpers/fieldHelpers.ts
@@ -23,6 +23,7 @@ import {
   FillableFormFieldValidation,
   TextFieldValidation,
   CheckboxFieldValidation,
+  FieldGrading,
 } from '@dculus/types';
 import { generateRandomString } from '@dculus/utils';
 import { FieldData } from '../collaboration/CollaborationManager';
@@ -95,6 +96,35 @@ export const createFormField = (
   const hint = fieldData.hint || '';
   const placeholder = fieldData.placeholder || '';
 
+  const field = createFormFieldInstance(fieldType, fieldId, fieldData, {
+    label,
+    defaultValue,
+    prefix,
+    hint,
+    placeholder,
+  });
+
+  // `grading` is deliberately not a constructor parameter (see
+  // FillableFormField.grading) — assign after construction instead.
+  if (fieldData.grading && field instanceof FillableFormField) {
+    field.grading = fieldData.grading;
+  }
+
+  return field;
+};
+
+const createFormFieldInstance = (
+  fieldType: FieldType,
+  fieldId: string,
+  fieldData: Partial<FieldData>,
+  { label, defaultValue, prefix, hint, placeholder }: {
+    label: string;
+    defaultValue: string;
+    prefix: string;
+    hint: string;
+    placeholder: string;
+  }
+): FormField => {
   switch (fieldType) {
     case FieldType.TEXT_INPUT_FIELD: {
       const textValidation = new TextFieldValidation(
@@ -286,6 +316,70 @@ export const createFormField = (
 };
 
 /**
+ * Build the `grading` Y.Map for a field, giving `acceptedAnswers` and
+ * `optionFeedback` the same explicit Y.Array treatment as `options` /
+ * `allowedMimeTypes` above, and the mode-specific option objects
+ * (`text`/`numeric`/`set`) their own nested Y.Map — mirrors `validation`.
+ * Only called when `fieldData.grading` is present; callers skip this
+ * entirely otherwise so a non-quiz field's Y.Map has no `grading` key at all.
+ */
+const createGradingYMap = (grading: FieldGrading): Y.Map<any> => {
+  const gradingMap = new Y.Map();
+
+  gradingMap.set('mode', grading.mode);
+  gradingMap.set('pointValue', grading.pointValue);
+
+  const acceptedAnswersArray = new Y.Array();
+  (grading.acceptedAnswers || []).forEach((answer) =>
+    acceptedAnswersArray.push([answer])
+  );
+  gradingMap.set('acceptedAnswers', acceptedAnswersArray);
+
+  if (grading.text) {
+    const textMap = new Y.Map();
+    Object.entries(grading.text).forEach(([key, value]) => {
+      if (value !== undefined) textMap.set(key, value);
+    });
+    gradingMap.set('text', textMap);
+  }
+  if (grading.numeric) {
+    const numericMap = new Y.Map();
+    Object.entries(grading.numeric).forEach(([key, value]) => {
+      if (value !== undefined) numericMap.set(key, value);
+    });
+    gradingMap.set('numeric', numericMap);
+  }
+  if (grading.set) {
+    const setMap = new Y.Map();
+    Object.entries(grading.set).forEach(([key, value]) => {
+      if (value !== undefined) setMap.set(key, value);
+    });
+    gradingMap.set('set', setMap);
+  }
+
+  if (grading.whenCorrect !== undefined) gradingMap.set('whenCorrect', grading.whenCorrect);
+  if (grading.whenIncorrect !== undefined) gradingMap.set('whenIncorrect', grading.whenIncorrect);
+  if (grading.general !== undefined) gradingMap.set('general', grading.general);
+
+  if (grading.optionFeedback) {
+    const optionFeedbackArray = new Y.Array();
+    grading.optionFeedback.forEach((entry) => {
+      const entryMap = new Y.Map();
+      entryMap.set('option', entry.option);
+      entryMap.set('feedback', entry.feedback);
+      optionFeedbackArray.push([entryMap]);
+    });
+    gradingMap.set('optionFeedback', optionFeedbackArray);
+  }
+
+  if (grading.shuffleOptions !== undefined) {
+    gradingMap.set('shuffleOptions', grading.shuffleOptions);
+  }
+
+  return gradingMap;
+};
+
+/**
  * Create a YJS Map from field data
  */
 export const createYJSFieldMap = (fieldData: FieldData): Y.Map<any> => {
@@ -302,6 +396,8 @@ export const createYJSFieldMap = (fieldData: FieldData): Y.Map<any> => {
       const mimeArray = new Y.Array();
       value.forEach((mime: string) => mimeArray.push([mime]));
       fieldMap.set('allowedMimeTypes', mimeArray);
+    } else if (key === 'grading' && value) {
+      fieldMap.set('grading', createGradingYMap(value as FieldGrading));
     } else if (value !== undefined) {
       fieldMap.set(key, value);
     }
@@ -388,6 +484,7 @@ export const serializeFieldToYMap = (field: FormField): Y.Map<any> => {
     allowedMimeTypes: (fillableField as FileUploadField).allowedMimeTypes,
     maxFileSizeMb: (fillableField as FileUploadField).maxFileSizeMb,
     maxFiles: (fillableField as FileUploadField).maxFiles,
+    grading: fillableField.grading,
     defaultCountry: (fillableField as PhoneNumberField).defaultCountry,
   };
 

--- a/apps/form-app/src/store/slices/__tests__/gradingRoundTrip.test.ts
+++ b/apps/form-app/src/store/slices/__tests__/gradingRoundTrip.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Verifies `grading` survives the five field/page operations that round-trip
+ * through createYJSFieldMap / extractFieldData (#294 — Story 05 of the
+ * Native Quiz epic, #289): duplicate field, copy field to another page,
+ * reorder, duplicate page, and change field type. A silent drop here means a
+ * user loses their answer key by doing any of these, so each test asserts
+ * the grading data survives byte-for-byte (or is deliberately dropped, for
+ * the type-change-to-an-incompatible-type case).
+ *
+ * setupTests.ts globally mocks '@dculus/types' and 'zustand' for component
+ * tests — opt back into both real implementations here (same pattern as
+ * automationBuilderSlice.test.ts / selectionSlice.test.ts) since these slices
+ * need the real field classes, grading sanitizers, and a working zustand
+ * `create`. CollaborationManager also pulls in lib/config (import.meta.env,
+ * Vite-only) and lib/auth-client transitively — stub both, this suite never
+ * opens a real connection.
+ */
+jest.unmock('@dculus/types');
+jest.unmock('zustand');
+jest.mock('../../../lib/config', () => ({ getWebSocketUrl: () => '' }));
+jest.mock('../../../lib/auth-client', () => ({ getBearerToken: () => '' }));
+
+import * as Y from 'yjs';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { create } = require('zustand') as typeof import('zustand');
+import { FieldGrading, FieldType } from '@dculus/types';
+import { createYJSFieldMap } from '../../helpers/fieldHelpers';
+import { extractFieldData, FieldData } from '../../collaboration/CollaborationManager';
+import { createFieldsSlice } from '../fieldsSlice';
+import { createPagesSlice } from '../pagesSlice';
+
+const EXACT_GRADING: FieldGrading = {
+  mode: 'exact',
+  pointValue: 5,
+  acceptedAnswers: ['Option A'],
+  optionFeedback: [{ option: 'Option A', feedback: 'Correct!' }],
+};
+
+type Harness = {
+  ydoc: Y.Doc;
+  store: ReturnType<typeof buildStore>;
+  getPageFields: (pageId: string) => FieldData[];
+};
+
+const buildStore = (ydoc: Y.Doc) =>
+  create<any>()((set, get) => ({
+    _getYDoc: () => ydoc,
+    _isYJSReady: () => true,
+    ...createFieldsSlice(set, get),
+    ...createPagesSlice(set, get),
+  }));
+
+// Seeds a Y.Doc with `formSchema.pages[pageIndex].fields` built the same way
+// production code builds them (createYJSFieldMap pushed into a real Y.Array
+// inside a real Y.Doc), so extractFieldData's "must be attached to a doc"
+// requirement is satisfied exactly like at runtime.
+const seedDoc = (
+  pages: Array<{ id: string; fields: FieldData[] }>
+): Harness => {
+  const ydoc = new Y.Doc();
+  const formSchemaMap = ydoc.getMap('formSchema');
+  const pagesArray = new Y.Array<Y.Map<any>>();
+  formSchemaMap.set('pages', pagesArray);
+
+  pages.forEach((page, index) => {
+    const pageMap = new Y.Map();
+    pageMap.set('id', page.id);
+    pageMap.set('title', `Page ${index + 1}`);
+    pageMap.set('order', index);
+    const fieldsArray = new Y.Array<Y.Map<any>>();
+    page.fields.forEach((fieldData) => {
+      fieldsArray.push([createYJSFieldMap(fieldData)]);
+    });
+    pageMap.set('fields', fieldsArray);
+    pagesArray.push([pageMap]);
+  });
+
+  const store = buildStore(ydoc);
+
+  const getPageFields = (pageId: string): FieldData[] => {
+    const pageMap = pagesArray
+      .toArray()
+      .find((p) => p.get('id') === pageId);
+    if (!pageMap) return [];
+    const fieldsArray = pageMap.get('fields') as Y.Array<Y.Map<any>>;
+    return fieldsArray
+      .toArray()
+      .filter((fieldMap) => !fieldMap.get('deleted'))
+      .map((fieldMap) => extractFieldData(fieldMap));
+  };
+
+  return { ydoc, store, getPageFields };
+};
+
+const radioField = (id: string, grading?: FieldGrading): FieldData => ({
+  id,
+  type: FieldType.RADIO_FIELD,
+  label: 'Q1',
+  required: false,
+  placeholder: '',
+  defaultValue: '',
+  prefix: '',
+  hint: '',
+  options: ['Option A', 'Option B'],
+  grading,
+});
+
+describe('duplicateField carries grading', () => {
+  test('the duplicate has deeply-equal grading under a new id', () => {
+    const { store, getPageFields } = seedDoc([
+      { id: 'page-1', fields: [radioField('f1', EXACT_GRADING)] },
+    ]);
+
+    store.getState().duplicateField('page-1', 'f1');
+
+    const fields = getPageFields('page-1');
+    expect(fields).toHaveLength(2);
+    const [original, duplicate] = fields;
+    expect(original.grading).toEqual(EXACT_GRADING);
+    expect(duplicate.id).not.toBe('f1');
+    expect(duplicate.label).toBe('Q1 (Copy)');
+    expect(duplicate.grading).toEqual(EXACT_GRADING);
+  });
+
+  test('a field without grading duplicates with grading still undefined', () => {
+    const { store, getPageFields } = seedDoc([
+      { id: 'page-1', fields: [radioField('f1')] },
+    ]);
+
+    store.getState().duplicateField('page-1', 'f1');
+
+    const fields = getPageFields('page-1');
+    expect(fields.every((f) => f.grading === undefined)).toBe(true);
+  });
+});
+
+describe('copyFieldToPage carries grading', () => {
+  test('the copy on the target page has deeply-equal grading', () => {
+    const { store, getPageFields } = seedDoc([
+      { id: 'page-1', fields: [radioField('f1', EXACT_GRADING)] },
+      { id: 'page-2', fields: [] },
+    ]);
+
+    store.getState().copyFieldToPage('page-1', 'page-2', 'f1');
+
+    const sourceFields = getPageFields('page-1');
+    const targetFields = getPageFields('page-2');
+    expect(sourceFields[0].grading).toEqual(EXACT_GRADING);
+    expect(targetFields).toHaveLength(1);
+    expect(targetFields[0].id).not.toBe('f1');
+    expect(targetFields[0].grading).toEqual(EXACT_GRADING);
+  });
+});
+
+describe('reorderFields preserves each field\'s own grading', () => {
+  test('grading stays attached to the field that owns it, not the slot', () => {
+    const { store, getPageFields } = seedDoc([
+      {
+        id: 'page-1',
+        fields: [radioField('f1', EXACT_GRADING), radioField('f2')],
+      },
+    ]);
+
+    store.getState().reorderFields('page-1', 0, 1);
+
+    const fields = getPageFields('page-1');
+    expect(fields.map((f) => f.id)).toEqual(['f2', 'f1']);
+    const graded = fields.find((f) => f.id === 'f1');
+    const ungraded = fields.find((f) => f.id === 'f2');
+    expect(graded?.grading).toEqual(EXACT_GRADING);
+    expect(ungraded?.grading).toBeUndefined();
+  });
+});
+
+describe('duplicatePage carries grading on every duplicated field', () => {
+  test('the duplicated page\'s field has deeply-equal grading under new page/field ids', () => {
+    const { store, ydoc } = seedDoc([
+      { id: 'page-1', fields: [radioField('f1', EXACT_GRADING)] },
+    ]);
+
+    store.getState().duplicatePage('page-1');
+
+    const pagesArray = ydoc.getMap('formSchema').get('pages') as Y.Array<Y.Map<any>>;
+    expect(pagesArray.length).toBe(2);
+    const duplicatedPageMap = pagesArray.get(1);
+    expect(duplicatedPageMap.get('id')).not.toBe('page-1');
+
+    const duplicatedFieldsArray = duplicatedPageMap.get('fields') as Y.Array<Y.Map<any>>;
+    const duplicatedField = extractFieldData(duplicatedFieldsArray.get(0));
+    expect(duplicatedField.id).not.toBe('f1');
+    expect(duplicatedField.grading).toEqual(EXACT_GRADING);
+  });
+});
+
+describe('convertFieldType and grading compatibility', () => {
+  test('keeps grading between compatible types (radio_field -> select_field, both "exact")', () => {
+    const { store, getPageFields } = seedDoc([
+      { id: 'page-1', fields: [radioField('f1', EXACT_GRADING)] },
+    ]);
+
+    store.getState().convertFieldType('page-1', 'f1', FieldType.SELECT_FIELD);
+
+    const fields = getPageFields('page-1');
+    expect(fields).toHaveLength(1);
+    expect(fields[0].type).toBe(FieldType.SELECT_FIELD);
+    expect(fields[0].id).not.toBe('f1'); // convertFieldType always mints a new id
+    expect(fields[0].grading).toEqual(EXACT_GRADING);
+  });
+
+  test('drops grading when converting to an incompatible type (select_field "exact" -> file_upload_field "manual")', () => {
+    const selectField: FieldData = {
+      id: 'f1',
+      type: FieldType.SELECT_FIELD,
+      label: 'Q1',
+      options: ['Option A', 'Option B'],
+      grading: EXACT_GRADING,
+    };
+    const { store, getPageFields } = seedDoc([
+      { id: 'page-1', fields: [selectField] },
+    ]);
+
+    expect(getPageFields('page-1')[0].grading).toEqual(EXACT_GRADING);
+
+    store.getState().convertFieldType('page-1', 'f1', FieldType.FILE_UPLOAD_FIELD);
+
+    const fields = getPageFields('page-1');
+    expect(fields).toHaveLength(1);
+    expect(fields[0].type).toBe(FieldType.FILE_UPLOAD_FIELD);
+    expect(fields[0].grading).toBeUndefined();
+  });
+
+  test('a field with no grading converts cleanly with grading still undefined', () => {
+    const { store, getPageFields } = seedDoc([
+      { id: 'page-1', fields: [radioField('f1')] },
+    ]);
+
+    store.getState().convertFieldType('page-1', 'f1', FieldType.SELECT_FIELD);
+
+    expect(getPageFields('page-1')[0].grading).toBeUndefined();
+  });
+});

--- a/apps/form-app/src/store/slices/fieldsSlice.ts
+++ b/apps/form-app/src/store/slices/fieldsSlice.ts
@@ -8,7 +8,13 @@
 import * as Y from 'yjs';
 import { toastError } from '@dculus/ui';
 import { FieldsSlice, SliceCreator } from '../types/store.types';
-import { FieldType, FormField, FormPage } from '@dculus/types';
+import {
+  FieldType,
+  FIELD_TYPE_DEFAULT_GRADING_MODE,
+  FormField,
+  FormPage,
+  isGradableFieldType,
+} from '@dculus/types';
 import { getOrCreatePagesArray } from '../helpers/yjsHelpers';
 import {
   createFormField,
@@ -413,6 +419,18 @@ export const createFieldsSlice: SliceCreator<FieldsSlice> = (_set, get) => {
       if (oldType === FieldType.DATE_FIELD && newType === FieldType.DATE_FIELD) {
         if (oldData.minDate != null) carriedData.minDate = oldData.minDate;
         if (oldData.maxDate != null) carriedData.maxDate = oldData.maxDate;
+      }
+
+      // Carry the answer key only when the new type's default grading mode matches
+      // the grading's own mode — e.g. radio_field -> select_field (both 'exact').
+      // Otherwise drop it: a stale key on an incompatible field (e.g. select_field ->
+      // file_upload_field, 'exact' vs 'manual') is worse than no key at all.
+      if (
+        oldData.grading &&
+        isGradableFieldType(newType) &&
+        oldData.grading.mode === FIELD_TYPE_DEFAULT_GRADING_MODE[newType]
+      ) {
+        carriedData.grading = oldData.grading;
       }
 
       const newField = createFormField(newType, carriedData);


### PR DESCRIPTION
## Summary
- Gives `grading` the same explicit Y.Array/Y.Map treatment `createYJSFieldMap` already gives `options`/`allowedMimeTypes`/`validation`, so the answer key survives duplicate, copy-to-page, reorder, duplicate-page and field-type-change.
- `CollaborationManager.extractFieldData` reads the `grading` Y.Map back into a sanitized plain object, returning `undefined` (never `{}`) when absent.
- `fieldHelpers.createFormField` assigns `grading` onto the constructed field instance after construction (per Story 01, `grading` is deliberately not a constructor param).
- `fieldsSlice.convertFieldType` keeps `grading` between compatible types (matching default grading mode, e.g. `radio_field` -> `select_field`) and drops it otherwise (e.g. `select_field` -> `file_upload_field`), using `isGradableFieldType` / `FIELD_TYPE_DEFAULT_GRADING_MODE` from `@dculus/types`.
- Pure state plumbing — no UI, nothing renders.

Closes #294

## Test plan
- [x] `pnpm type-check` passes across the whole monorepo.
- [x] New unit tests: round-trip `createYJSFieldMap` -> `extractFieldData` for every grading mode (`exact`, `set`, `text`, `numeric`, `manual`) with mode-specific options, plus the no-grading case (Y.Map has no `grading` key at all).
- [x] New unit tests for all five operations: duplicate field, copy field to another page, reorder, duplicate page, and type change (both the compatible-keep and incompatible-drop cases).
- [x] All pre-existing tests under `apps/form-app/src/store/` pass unmodified (37/37, including the 2 pre-existing suites).
- [x] Pre-push hook's full test/build suite (form-viewer, backend, admin-app, form-app) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)