### PR TITLE
Native Quiz: synchronous grading in submitResponse

### DIFF
--- a/apps/backend/src/graphql/resolvers/__tests__/responses.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/responses.test.ts
@@ -4,7 +4,9 @@ import { GraphQLError } from '#graphql-errors';
 import {
   DEFAULT_THANK_YOU_CONTENT,
   RadioField,
+  TextInputField,
   FillableFormFieldValidation,
+  TextFieldValidation,
   serializeFormSchema,
   type FormSchema,
   type QuizSettings,
@@ -1077,30 +1079,30 @@ describe('Responses Resolvers', () => {
       );
 
       it('excludes a conditionally-hidden graded question from maxScore', async () => {
-        const bonusField = {
-          id: 'bonus',
-          type: 'text_input_field',
-          label: 'Bonus',
-          validation: { required: false, type: 'text_field_validation' },
-          grading: { mode: 'text', pointValue: 5, acceptedAnswers: ['42'] },
-        };
-        const schemaWithCondition = {
-          ...rawQuizSchema,
+        const triggerField = new RadioField(
+          'trigger',
+          'Trigger',
+          '',
+          '',
+          '',
+          new FillableFormFieldValidation(false),
+          ['Yes', 'No']
+        );
+        const bonusField = new TextInputField(
+          'bonus',
+          'Bonus',
+          '',
+          '',
+          '',
+          '',
+          new TextFieldValidation(false)
+        );
+        bonusField.grading = { mode: 'text', pointValue: 5, acceptedAnswers: ['42'] };
+
+        const schemaWithConditionObj: FormSchema = {
+          ...quizSchema,
           pages: [
-            {
-              ...rawQuizSchema.pages[0],
-              fields: [
-                ...rawQuizSchema.pages[0].fields,
-                {
-                  id: 'trigger',
-                  type: 'radio_field',
-                  label: 'Trigger',
-                  options: ['Yes', 'No'],
-                  validation: { required: false, type: 'fillable_form_field' },
-                },
-                bonusField,
-              ],
-            },
+            { ...quizSchema.pages[0], fields: [gradedField, triggerField, bonusField] },
           ],
           conditions: [
             {
@@ -1112,6 +1114,7 @@ describe('Responses Resolvers', () => {
             },
           ],
         };
+        const schemaWithCondition = serializeFormSchema(schemaWithConditionObj);
         const quiz: QuizSettings = {
           enabled: true,
           passThresholdPercent: 60,
@@ -1139,7 +1142,7 @@ describe('Responses Resolvers', () => {
         ).toBe(false);
       });
 
-      it('lets the submission succeed and saves a NEEDS_REVIEW fallback when grading throws', async () => {
+      it('lets the submission succeed when grading and the NEEDS_REVIEW fallback both fail', async () => {
         const quiz: QuizSettings = {
           enabled: true,
           passThresholdPercent: 60,
@@ -1161,6 +1164,42 @@ describe('Responses Resolvers', () => {
         expect(result).toMatchObject({ id: mockResponse.id, formId: mockResponse.formId });
         expect(result).not.toHaveProperty('grade');
         expect(responseGradeRepository.upsertForResponse).not.toHaveBeenCalled();
+      });
+
+      it('persists a NEEDS_REVIEW fallback when grading throws, but never surfaces it to the respondent or automations', async () => {
+        const quiz: QuizSettings = {
+          enabled: true,
+          passThresholdPercent: 60,
+          gradeRelease: 'immediate',
+          respondentVisibility: baseVisibility,
+        };
+        // `pages: 'not-a-schema'` makes deserializeFormSchema throw (a bare
+        // string has no .map), exercising the branch where grading itself
+        // fails but the NEEDS_REVIEW fallback save succeeds.
+        vi.mocked(formService.getFormById).mockResolvedValue(
+          buildFormWithQuiz(quiz, { pages: 'not-a-schema' }) as any
+        );
+        stubGradeUpsert();
+
+        const result = await responsesResolvers.Mutation.submitResponse(
+          {},
+          { input: { formId: 'form-123', data: { q1: 'Paris' } } },
+          mockContext
+        );
+
+        expect(responseGradeRepository.upsertForResponse).toHaveBeenCalledWith(
+          'response-123',
+          expect.objectContaining({ status: 'NEEDS_REVIEW', score: 0, maxScore: 0 })
+        );
+        // isReleased() ignores grade status under 'immediate' release, so this
+        // placeholder must never be projected — it would read as a genuine
+        // "you scored 0%" to the respondent instead of silence.
+        expect(result).not.toHaveProperty('grade');
+        expect(pluginEvents.emitFormSubmitted).toHaveBeenCalledWith(
+          'form-123',
+          'org-123',
+          expect.not.objectContaining({ quizScore: expect.anything() })
+        );
       });
     });
   });

--- a/apps/backend/src/graphql/resolvers/__tests__/responses.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/responses.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { responsesResolvers, extendedResponsesResolvers } from '../responses.js';
 import { GraphQLError } from '#graphql-errors';
-import { DEFAULT_THANK_YOU_CONTENT } from '@dculus/types';
+import {
+  DEFAULT_THANK_YOU_CONTENT,
+  RadioField,
+  FillableFormFieldValidation,
+  serializeFormSchema,
+  type FormSchema,
+  type QuizSettings,
+} from '@dculus/types';
 import * as responseService from '../../../services/responseService.js';
 import * as formService from '../../../services/formService.js';
 import * as betterAuthMiddleware from '../../../middleware/better-auth-middleware.js';
@@ -13,6 +20,8 @@ import * as subscriptionEvents from '../../../subscriptions/events.js';
 import * as editTrackingService from '../../../services/responseEditTrackingService.js';
 import * as tagService from '../../../services/tagService.js';
 import * as responseCopyService from '../../../services/responseCopyService.js';
+import * as hocuspocusService from '../../../services/hocuspocus.js';
+import { responseRepository, responseGradeRepository } from '../../../repositories/index.js';
 
 // Mock all dependencies
 vi.mock('../../../services/responseService.js');
@@ -23,6 +32,11 @@ vi.mock('../../../services/analyticsService.js');
 vi.mock('../../../plugins/core/events.js');
 vi.mock('../../../subscriptions/usageService.js');
 vi.mock('../../../subscriptions/events.js');
+vi.mock('../../../services/hocuspocus.js');
+// Native Quiz (issue #295): only the DB boundary is mocked here — gradingEngine
+// and gradingService run for real, so these tests exercise the actual grading
+// and release/visibility projection logic, not a stand-in for it.
+vi.mock('../../../repositories/index.js');
 vi.mock('../../../lib/logger.js', () => ({
   logger: {
     info: vi.fn(),
@@ -105,6 +119,10 @@ describe('Responses Resolvers', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Matches the pre-existing effective behavior in this suite: no real DB,
+    // so the internal try/catch in getFormSchemaFromHocuspocus always
+    // resolved to null and every schema fell back to form.formSchema.
+    vi.mocked(hocuspocusService.getFormSchemaFromHocuspocus).mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -916,6 +934,233 @@ describe('Responses Resolvers', () => {
         expect(responseCopyService.sendResponseCopyIfEnabled).toHaveBeenCalledWith(
           expect.objectContaining({ form: formWithResponseCopyEnabled })
         );
+      });
+    });
+
+    describe('Native Quiz grading (issue #295)', () => {
+      const baseVisibility = {
+        totalScore: true,
+        perQuestionCorrectness: true,
+        correctAnswers: true,
+        pointValues: true,
+        feedback: true,
+        passFailBadge: true,
+      };
+
+      const gradedField = new RadioField(
+        'q1',
+        'Capital of France',
+        '',
+        '',
+        '',
+        new FillableFormFieldValidation(false),
+        ['Paris', 'London', 'Berlin']
+      );
+      gradedField.grading = { mode: 'exact', pointValue: 10, acceptedAnswers: ['Paris'] };
+
+      const quizSchema: FormSchema = {
+        pages: [{ id: 'page-1', title: 'Page 1', fields: [gradedField], order: 0 }],
+        layout: { theme: 'light', backgroundImageKey: '' } as any,
+        isShuffleEnabled: false,
+      };
+      const rawQuizSchema = serializeFormSchema(quizSchema);
+
+      const buildFormWithQuiz = (quiz: QuizSettings, schema: unknown = rawQuizSchema) => ({
+        ...mockForm,
+        settings: { quiz },
+        formSchema: schema,
+      });
+
+      const stubGradeUpsert = () => {
+        vi.mocked(responseRepository.findUnique).mockResolvedValue({ formId: 'form-123' } as any);
+        vi.mocked(responseGradeRepository.upsertForResponse).mockImplementation(
+          async (responseId: string, data: any) =>
+            ({
+              id: 'grade-1',
+              responseId,
+              gradedAt: new Date('2026-01-01T00:00:00Z'),
+              gradedById: null,
+              releasedAt: null,
+              schemaVersion: 1,
+              attemptNumber: 1,
+              integrity: null,
+              ...data,
+            }) as any
+        );
+      };
+
+      it('performs zero extra work for a form with settings.quiz absent (additive guarantee)', async () => {
+        // mockForm.settings is null — quiz absent, exactly the pre-existing fixture.
+        const result = await responsesResolvers.Mutation.submitResponse(
+          {},
+          { input: mockInput },
+          mockContext
+        );
+
+        expect(result).toEqual({ ...mockResponse, thankYouMessage: DEFAULT_THANK_YOU_CONTENT });
+        expect(result).not.toHaveProperty('grade');
+        expect(responseGradeRepository.upsertForResponse).not.toHaveBeenCalled();
+        expect(responseRepository.findUnique).not.toHaveBeenCalled();
+        // Unchanged from before this change: one Hocuspocus lookup for the
+        // conditional-strip pass, one for the thank-you mention substitution.
+        expect(hocuspocusService.getFormSchemaFromHocuspocus).toHaveBeenCalledTimes(2);
+      });
+
+      it('returns a populated, released grade under gradeRelease: immediate', async () => {
+        const quiz: QuizSettings = {
+          enabled: true,
+          passThresholdPercent: 60,
+          gradeRelease: 'immediate',
+          respondentVisibility: baseVisibility,
+        };
+        vi.mocked(formService.getFormById).mockResolvedValue(buildFormWithQuiz(quiz) as any);
+        stubGradeUpsert();
+
+        const result = await responsesResolvers.Mutation.submitResponse(
+          {},
+          { input: { formId: 'form-123', data: { q1: 'Paris' } } },
+          mockContext
+        );
+
+        expect(result.grade).toEqual({
+          released: true,
+          score: 10,
+          maxScore: 10,
+          percentage: 100,
+          passed: true,
+          questions: [
+            {
+              fieldId: 'q1',
+              label: 'Capital of France',
+              yourAnswer: 'Paris',
+              correct: true,
+              pointsAwarded: 10,
+              pointValue: 10,
+              correctAnswer: ['Paris'],
+            },
+          ],
+        });
+        expect(responseGradeRepository.upsertForResponse).toHaveBeenCalledWith(
+          'response-123',
+          expect.objectContaining({
+            score: 10,
+            maxScore: 10,
+            percentage: 100,
+            passed: true,
+            status: 'AUTO_GRADED',
+          })
+        );
+      });
+
+      it.each(['afterReview', 'never'] as const)(
+        'returns only { released: false } under gradeRelease: %s',
+        async (gradeRelease) => {
+          const quiz: QuizSettings = {
+            enabled: true,
+            passThresholdPercent: 60,
+            gradeRelease,
+            respondentVisibility: baseVisibility,
+          };
+          vi.mocked(formService.getFormById).mockResolvedValue(buildFormWithQuiz(quiz) as any);
+          stubGradeUpsert();
+
+          const result = await responsesResolvers.Mutation.submitResponse(
+            {},
+            { input: { formId: 'form-123', data: { q1: 'Paris' } } },
+            mockContext
+          );
+
+          expect(result.grade).toEqual({ released: false });
+          expect(Object.keys(result.grade!)).toEqual(['released']);
+          expect(JSON.stringify(result.grade)).not.toMatch(/score|percentage|pointsAwarded|Paris/);
+        }
+      );
+
+      it('excludes a conditionally-hidden graded question from maxScore', async () => {
+        const bonusField = {
+          id: 'bonus',
+          type: 'text_input_field',
+          label: 'Bonus',
+          validation: { required: false, type: 'text_field_validation' },
+          grading: { mode: 'text', pointValue: 5, acceptedAnswers: ['42'] },
+        };
+        const schemaWithCondition = {
+          ...rawQuizSchema,
+          pages: [
+            {
+              ...rawQuizSchema.pages[0],
+              fields: [
+                ...rawQuizSchema.pages[0].fields,
+                {
+                  id: 'trigger',
+                  type: 'radio_field',
+                  label: 'Trigger',
+                  options: ['Yes', 'No'],
+                  validation: { required: false, type: 'fillable_form_field' },
+                },
+                bonusField,
+              ],
+            },
+          ],
+          conditions: [
+            {
+              id: 'r-show-bonus',
+              enabled: true,
+              combinator: 'all',
+              terms: [{ fieldId: 'trigger', operator: 'equals', value: 'Yes' }],
+              actions: [{ type: 'showField', fieldIds: ['bonus'] }],
+            },
+          ],
+        };
+        const quiz: QuizSettings = {
+          enabled: true,
+          passThresholdPercent: 60,
+          gradeRelease: 'immediate',
+          respondentVisibility: baseVisibility,
+        };
+        vi.mocked(formService.getFormById).mockResolvedValue(
+          buildFormWithQuiz(quiz, schemaWithCondition) as any
+        );
+        stubGradeUpsert();
+
+        // trigger === 'No' hides `bonus` — stripConditionallyHiddenValues removes it
+        // from input.data before grading ever sees it.
+        const result = await responsesResolvers.Mutation.submitResponse(
+          {},
+          { input: { formId: 'form-123', data: { q1: 'Paris', trigger: 'No', bonus: 'sneaky' } } },
+          mockContext
+        );
+
+        // Only q1 (10 pts) counts toward maxScore — bonus (5 pts) never saw the
+        // respondent, so it's excluded from the denominator, not scored wrong.
+        expect(result.grade).toMatchObject({ maxScore: 10, score: 10 });
+        expect(
+          (result.grade as any).questions.some((q: any) => q.fieldId === 'bonus')
+        ).toBe(false);
+      });
+
+      it('lets the submission succeed and saves a NEEDS_REVIEW fallback when grading throws', async () => {
+        const quiz: QuizSettings = {
+          enabled: true,
+          passThresholdPercent: 60,
+          gradeRelease: 'immediate',
+          respondentVisibility: baseVisibility,
+        };
+        vi.mocked(formService.getFormById).mockResolvedValue(buildFormWithQuiz(quiz) as any);
+        // Forces saveGrade to throw for both the primary and the NEEDS_REVIEW
+        // fallback attempt — simulates a grading-path failure end to end.
+        vi.mocked(responseRepository.findUnique).mockRejectedValue(new Error('DB is down'));
+
+        const result = await responsesResolvers.Mutation.submitResponse(
+          {},
+          { input: { formId: 'form-123', data: { q1: 'Paris' } } },
+          mockContext
+        );
+
+        expect(responseService.submitResponse).toHaveBeenCalled();
+        expect(result).toMatchObject({ id: mockResponse.id, formId: mockResponse.formId });
+        expect(result).not.toHaveProperty('grade');
+        expect(responseGradeRepository.upsertForResponse).not.toHaveBeenCalled();
       });
     });
   });

--- a/apps/backend/src/graphql/resolvers/__tests__/responses.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/responses.test.ts
@@ -1198,8 +1198,13 @@ describe('Responses Resolvers', () => {
         expect(pluginEvents.emitFormSubmitted).toHaveBeenCalledWith(
           'form-123',
           'org-123',
-          expect.not.objectContaining({ quizScore: expect.anything() })
+          expect.objectContaining({ responseId: 'response-123' })
         );
+        const emittedPayload = vi.mocked(pluginEvents.emitFormSubmitted).mock.calls[0][2];
+        expect(emittedPayload).not.toHaveProperty('quizScore');
+        expect(emittedPayload).not.toHaveProperty('quizMaxScore');
+        expect(emittedPayload).not.toHaveProperty('quizPercentage');
+        expect(emittedPayload).not.toHaveProperty('quizPassed');
       });
     });
   });

--- a/apps/backend/src/graphql/resolvers/responses.ts
+++ b/apps/backend/src/graphql/resolvers/responses.ts
@@ -204,17 +204,31 @@ export const responsesResolvers = {
         }
       }
 
+      // Live schema for form.id (Hocuspocus, falling back to the DB column),
+      // resolved at most once and shared by conditional stripping below and
+      // quiz grading further down — both need the exact same schema, and
+      // getFormSchemaFromHocuspocus is a DB read plus a full Y.Doc rebuild,
+      // not a cheap call to repeat.
+      let liveSchema: unknown;
+      let liveSchemaResolved = false;
+      const resolveLiveSchema = async () => {
+        if (!liveSchemaResolved) {
+          liveSchema = (await getFormSchemaFromHocuspocus(form.id)) ?? form.formSchema;
+          liveSchemaResolved = true;
+        }
+        return liveSchema;
+      };
+
       // Server-side conditional-logic enforcement (defense in depth): strip
       // values of fields/pages the form's rules hide, evaluated against the
-      // same live schema the viewer was served (Hocuspocus, falling back to
-      // the DB column). The client strips too, but this mutation is public
-      // and callable directly. Runs before BOTH insert paths below.
+      // same live schema the viewer was served. The client strips too, but
+      // this mutation is public and callable directly. Runs before BOTH
+      // insert paths below.
       if (input.data && typeof input.data === 'object') {
-        const liveSchema =
-          (await getFormSchemaFromHocuspocus(form.id)) ?? form.formSchema;
-        if (liveSchema) {
+        const schema = await resolveLiveSchema();
+        if (schema) {
           input.data = stripConditionallyHiddenValues(
-            liveSchema,
+            schema,
             input.data as Record<string, unknown>
           );
         }
@@ -294,10 +308,9 @@ export const responsesResolvers = {
       const quizSettings = form.settings?.quiz;
       if (quizSettings?.enabled) {
         try {
-          const liveSchema =
-            (await getFormSchemaFromHocuspocus(form.id)) ?? form.formSchema;
-          if (liveSchema) {
-            const deserializedSchema = deserializeFormSchema(liveSchema);
+          const schema = await resolveLiveSchema();
+          if (schema) {
+            const deserializedSchema = deserializeFormSchema(schema);
             const gradeResult = gradeResponse(
               deserializedSchema,
               quizSettings,
@@ -327,7 +340,13 @@ export const responsesResolvers = {
           // let the submission succeed either way.
           logger.error('Error grading quiz response:', error);
           try {
-            const fallbackGrade = await saveGrade({
+            // Persisted for a human reviewer, but deliberately not assigned to
+            // `grade`/`quizFanout`: under gradeRelease 'immediate' (and a
+            // past-due 'scheduled' release), toRespondentView.isReleased()
+            // ignores grade status entirely, so surfacing this placeholder
+            // would show the respondent — and automations via quizPassed —
+            // a false "you scored 0%" instead of just staying silent.
+            await saveGrade({
               responseId: savedResponse.id,
               score: 0,
               maxScore: 0,
@@ -337,13 +356,6 @@ export const responsesResolvers = {
               autoScore: 0,
               detail: [],
             });
-            grade = toRespondentView(fallbackGrade, quizSettings);
-            quizFanout = {
-              quizScore: fallbackGrade.score,
-              quizMaxScore: fallbackGrade.maxScore,
-              quizPercentage: fallbackGrade.percentage,
-              quizPassed: fallbackGrade.passed,
-            };
           } catch (persistError) {
             logger.error(
               'Error persisting NEEDS_REVIEW grade after grading failure:',

--- a/apps/backend/src/graphql/resolvers/responses.ts
+++ b/apps/backend/src/graphql/resolvers/responses.ts
@@ -22,8 +22,11 @@ import {
   substituteMentions,
 } from '@dculus/utils';
 import { deserializeFormSchema, DEFAULT_THANK_YOU_CONTENT } from '@dculus/types';
+import type { RespondentGradeView } from '@dculus/types';
 import { stripConditionallyHiddenValues } from '../../lib/conditionalStrip.js';
 import { getFormSchemaFromHocuspocus } from '../../services/hocuspocus.js';
+import { gradeResponse } from '../../services/quiz/gradingEngine.js';
+import { saveGrade, toRespondentView } from '../../services/quiz/gradingService.js';
 import { analyticsService } from '../../services/analyticsService.js';
 import { emitFormSubmitted } from '../../plugins/core/events.js';
 import { checkUsageExceeded } from '../../subscriptions/usageService.js';
@@ -273,6 +276,83 @@ export const responsesResolvers = {
       // At this point response is guaranteed non-null — both branches above set it.
       const savedResponse = response!;
 
+      // Native Quiz (D3, epic #289): grade synchronously, here, so the score
+      // can be included in this mutation's payload — emitFormSubmitted below
+      // fires after this resolver returns and structurally cannot do that.
+      // Grades against input.data AFTER stripConditionallyHiddenValues ran
+      // above (~line 209), so a question hidden by conditional logic is
+      // excluded from maxScore rather than scored wrong — two respondents
+      // can legitimately face different denominators.
+      // Additive guarantee: settings.quiz absent/disabled is zero extra work
+      // below — no schema fetch, no grading engine call, no ResponseGrade
+      // write, and `grade` stays undefined so it is omitted from the payload.
+      let grade: RespondentGradeView | undefined;
+      let quizFanout:
+        | { quizScore: number; quizMaxScore: number; quizPercentage: number; quizPassed: boolean }
+        | undefined;
+
+      const quizSettings = form.settings?.quiz;
+      if (quizSettings?.enabled) {
+        try {
+          const liveSchema =
+            (await getFormSchemaFromHocuspocus(form.id)) ?? form.formSchema;
+          if (liveSchema) {
+            const deserializedSchema = deserializeFormSchema(liveSchema);
+            const gradeResult = gradeResponse(
+              deserializedSchema,
+              quizSettings,
+              (input.data || {}) as Record<string, unknown>
+            );
+            const savedGrade = await saveGrade({
+              responseId: savedResponse.id,
+              score: gradeResult.score,
+              maxScore: gradeResult.maxScore,
+              percentage: gradeResult.percentage,
+              passed: gradeResult.passed,
+              status: gradeResult.status,
+              autoScore: gradeResult.score,
+              detail: gradeResult.questions,
+            });
+            grade = toRespondentView(savedGrade, quizSettings);
+            quizFanout = {
+              quizScore: savedGrade.score,
+              quizMaxScore: savedGrade.maxScore,
+              quizPercentage: savedGrade.percentage,
+              quizPassed: savedGrade.passed,
+            };
+          }
+        } catch (error) {
+          // D7: losing a response to a grading bug is far worse than an
+          // ungraded one — log, best-effort persist a NEEDS_REVIEW grade, and
+          // let the submission succeed either way.
+          logger.error('Error grading quiz response:', error);
+          try {
+            const fallbackGrade = await saveGrade({
+              responseId: savedResponse.id,
+              score: 0,
+              maxScore: 0,
+              percentage: 0,
+              passed: false,
+              status: 'NEEDS_REVIEW',
+              autoScore: 0,
+              detail: [],
+            });
+            grade = toRespondentView(fallbackGrade, quizSettings);
+            quizFanout = {
+              quizScore: fallbackGrade.score,
+              quizMaxScore: fallbackGrade.maxScore,
+              quizPercentage: fallbackGrade.percentage,
+              quizPassed: fallbackGrade.passed,
+            };
+          } catch (persistError) {
+            logger.error(
+              'Error persisting NEEDS_REVIEW grade after grading failure:',
+              persistError
+            );
+          }
+        }
+      }
+
       // Auto-assign __preview__ system tag when submitted from the builder preview panel
       if (input.isPreview) {
         try {
@@ -362,12 +442,15 @@ export const responsesResolvers = {
         emitFormSubmitted(input.formId, form.organizationId, {
           // input.data is user-submitted field values; spreading it first (and the
           // control fields after) keeps a form field literally named "responseId"/
-          // "isPreview" from spoofing these — isPreview in particular now gates
-          // whether automations fire, so it must stay server-authoritative.
+          // "isPreview"/"quizScore" from spoofing these — isPreview in particular
+          // now gates whether automations fire, so it must stay server-authoritative.
+          // quizFanout (quizScore/quizMaxScore/quizPercentage/quizPassed) is only
+          // present when settings.quiz is enabled and grading actually ran.
           ...input.data,
           responseId: savedResponse.id,
           submittedAt: savedResponse.submittedAt.toISOString(),
           isPreview: Boolean(input.isPreview),
+          ...(quizFanout ?? {}),
         });
       } catch (error) {
         // Log error but don't fail the response submission
@@ -398,6 +481,10 @@ export const responsesResolvers = {
       return {
         ...savedResponse,
         thankYouMessage,
+        // Omitted entirely (not `grade: undefined`) when quiz grading did not
+        // run — keeps the payload byte-identical to before this change for
+        // every non-quiz form (epic #289's additive guarantee).
+        ...(grade !== undefined ? { grade } : {}),
       };
     },
     updateResponse: async (

--- a/apps/backend/src/graphql/schema.ts
+++ b/apps/backend/src/graphql/schema.ts
@@ -269,6 +269,36 @@ export const typeDefs = gql`
     lastEditedBy: User
     editHistory: [ResponseEditHistory!]!
     tags: [ResponseTag!]!
+    # Native Quiz (epic #289, D3): populated only when submitResponse graded
+    # this response synchronously — absent for every non-quiz form/response,
+    # and for queries other than submitResponse, which never compute it.
+    grade: ResponseGradeView
+  }
+
+  # Native Quiz (epic #289) — mirrors RespondentGradeView
+  # (packages/types/src/quiz.ts). This IS the release/visibility boundary
+  # (D5-adjacent): when released is false, every other field is genuinely
+  # absent, never zeroed or null-but-present. Built only via
+  # gradingService.toRespondentView — never hand-roll this projection.
+  type ResponseGradeView {
+    released: Boolean!
+    score: Float
+    maxScore: Float
+    percentage: Float
+    passed: Boolean
+    message: String
+    questions: [ResponseGradeQuestionView!]
+  }
+
+  type ResponseGradeQuestionView {
+    fieldId: ID!
+    label: String!
+    correct: Boolean
+    pointsAwarded: Float
+    pointValue: Float
+    yourAnswer: JSON
+    correctAnswer: [String!]
+    feedback: String
   }
 
   # Response Edit Tracking Types


### PR DESCRIPTION
Closes #295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added synchronous grading for Native Quiz submissions.
  * Quiz results can include scores, pass/fail status, release timing, messages, and per-question grading details.
  * Added support for hidden-question scoring and configurable grade release.
  * Grade visibility respects release settings for respondents and submission automations.

* **Bug Fixes**
  * Quiz submissions remain successful when grading fails.
  * Affected responses are marked for review without exposing fallback zero-score results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->