### PR TITLE
Native Quiz: gradebook export columns

### DIFF
--- a/apps/backend/src/graphql/resolvers/__tests__/unifiedExport.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/unifiedExport.test.ts
@@ -22,9 +22,17 @@ vi.mock('../../../services/hocuspocus.js');
 vi.mock('../../../services/responseFilterService.js');
 // Native Quiz (epic #289): defaults to no grades so every existing test in
 // this file keeps exercising the "no quiz data" path without per-test setup.
-vi.mock('../../../services/quiz/gradingService.js', () => ({
-  getGradesForForm: vi.fn().mockResolvedValue([]),
-}));
+// `questionGradeResultSchema` must be a real Zod schema — the resolver calls
+// `z.array(questionGradeResultSchema)` on it — so a permissive `z.any()`
+// stands in for the real (fully-validated) one covered by gradingService's
+// own tests.
+vi.mock('../../../services/quiz/gradingService.js', async () => {
+  const { z } = await import('zod');
+  return {
+    getGradesForResponses: vi.fn().mockResolvedValue([]),
+    questionGradeResultSchema: z.any(),
+  };
+});
 vi.mock('../../../lib/logger.js', () => ({
   logger: {
     info: vi.fn(),
@@ -1187,7 +1195,7 @@ describe('Unified Export Resolvers', () => {
         vi.mocked(hocuspocusService.getFormSchemaFromHocuspocus).mockResolvedValue(
           quizForm.formSchema as any
         );
-        vi.mocked(quizGradingService.getGradesForForm).mockResolvedValue([gradeRow as any]);
+        vi.mocked(quizGradingService.getGradesForResponses).mockResolvedValue([gradeRow as any]);
         vi.mocked(unifiedExportService.generateExportFile).mockResolvedValue(
           mockExportResult
         );
@@ -1201,7 +1209,12 @@ describe('Unified Export Resolvers', () => {
           mockContext
         );
 
-        expect(quizGradingService.getGradesForForm).toHaveBeenCalledWith('form-123');
+        // Scoped to the responses actually being exported, not every grade
+        // the form has ever accumulated.
+        expect(quizGradingService.getGradesForResponses).toHaveBeenCalledWith([
+          'response-1',
+          'response-2',
+        ]);
         expect(unifiedExportService.generateExportFile).toHaveBeenCalledWith(
           expect.objectContaining({
             quizEnabled: true,

--- a/apps/backend/src/graphql/resolvers/__tests__/unifiedExport.test.ts
+++ b/apps/backend/src/graphql/resolvers/__tests__/unifiedExport.test.ts
@@ -9,6 +9,7 @@ import * as unifiedExportService from '../../../services/unifiedExportService.js
 import * as temporaryFileService from '../../../services/temporaryFileService.js';
 import * as hocuspocusService from '../../../services/hocuspocus.js';
 import * as responseFilterService from '../../../services/responseFilterService.js';
+import * as quizGradingService from '../../../services/quiz/gradingService.js';
 
 // Mock all dependencies
 vi.mock('../../../middleware/better-auth-middleware.js');
@@ -19,6 +20,11 @@ vi.mock('../../../services/unifiedExportService.js');
 vi.mock('../../../services/temporaryFileService.js');
 vi.mock('../../../services/hocuspocus.js');
 vi.mock('../../../services/responseFilterService.js');
+// Native Quiz (epic #289): defaults to no grades so every existing test in
+// this file keeps exercising the "no quiz data" path without per-test setup.
+vi.mock('../../../services/quiz/gradingService.js', () => ({
+  getGradesForForm: vi.fn().mockResolvedValue([]),
+}));
 vi.mock('../../../lib/logger.js', () => ({
   logger: {
     info: vi.fn(),
@@ -818,6 +824,9 @@ describe('Unified Export Resolvers', () => {
           format: 'excel',
           pluginConfigs: {},
           includeRespondentEmail: false,
+          quizEnabled: false,
+          quizGrades: {},
+          includeQuizQuestionColumns: false,
         });
         expect(result.format).toBe('EXCEL');
       });
@@ -932,6 +941,9 @@ describe('Unified Export Resolvers', () => {
           format: 'csv',
           pluginConfigs: {},
           includeRespondentEmail: false,
+          quizEnabled: false,
+          quizGrades: {},
+          includeQuizQuestionColumns: false,
         });
         expect(result.format).toBe('CSV');
       });
@@ -1142,6 +1154,71 @@ describe('Unified Export Resolvers', () => {
         );
 
         expect(result.filename).toBe('Test_Form_2024-01-01.xlsx');
+      });
+    });
+
+    describe('Native Quiz (epic #289, Story 12/#301)', () => {
+      it('passes quizEnabled and the ResponseGrade map through to the export service', async () => {
+        const quizForm = {
+          ...mockForm,
+          settings: { quiz: { enabled: true } },
+        };
+        const gradeRow = {
+          responseId: 'response-1',
+          score: 8,
+          maxScore: 10,
+          percentage: 80,
+          passed: true,
+          status: 'AUTO_GRADED',
+          gradedAt: new Date('2024-01-01T00:00:00Z'),
+          detail: [],
+        };
+
+        vi.mocked(betterAuthMiddleware.requireAuth).mockReturnValue(mockContext.auth);
+        vi.mocked(formSharingResolvers.checkFormAccess).mockResolvedValue({
+          hasAccess: true,
+          permission: 'EDITOR' as any,
+          form: quizForm as any,
+        });
+        vi.mocked(formService.getFormById).mockResolvedValue(quizForm as any);
+        vi.mocked(responseService.getAllResponsesByFormId).mockResolvedValue(
+          mockResponses as any
+        );
+        vi.mocked(hocuspocusService.getFormSchemaFromHocuspocus).mockResolvedValue(
+          quizForm.formSchema as any
+        );
+        vi.mocked(quizGradingService.getGradesForForm).mockResolvedValue([gradeRow as any]);
+        vi.mocked(unifiedExportService.generateExportFile).mockResolvedValue(
+          mockExportResult
+        );
+        vi.mocked(temporaryFileService.uploadTemporaryFile).mockResolvedValue(
+          mockTemporaryFile as any
+        );
+
+        await unifiedExportResolvers.Mutation.generateFormResponseReport(
+          {},
+          { formId: 'form-123', format: 'EXCEL', includeQuizQuestionColumns: true },
+          mockContext
+        );
+
+        expect(quizGradingService.getGradesForForm).toHaveBeenCalledWith('form-123');
+        expect(unifiedExportService.generateExportFile).toHaveBeenCalledWith(
+          expect.objectContaining({
+            quizEnabled: true,
+            includeQuizQuestionColumns: true,
+            quizGrades: {
+              'response-1': {
+                score: 8,
+                maxScore: 10,
+                percentage: 80,
+                passed: true,
+                status: 'AUTO_GRADED',
+                gradedAt: gradeRow.gradedAt,
+                detail: [],
+              },
+            },
+          })
+        );
       });
     });
 

--- a/apps/backend/src/graphql/resolvers/unifiedExport.ts
+++ b/apps/backend/src/graphql/resolvers/unifiedExport.ts
@@ -6,12 +6,13 @@ import { getAllResponsesByFormId } from '../../services/responseService.js';
 import { generateExportFile, ExportFormat, QuizGradeExportRow } from '../../services/unifiedExportService.js';
 import { uploadTemporaryFile } from '../../services/temporaryFileService.js';
 import { getFormSchemaFromHocuspocus } from '../../services/hocuspocus.js';
-import { deserializeFormSchema } from '@dculus/types';
+import { deserializeFormSchema, QuestionGradeResult } from '@dculus/types';
 import { ResponseFilter, applyResponseFilters } from '../../services/responseFilterService.js';
 import { checkFormAccess, PermissionLevel } from './formSharing.js';
 import { logger } from '../../lib/logger.js';
 import * as pluginService from '../../services/pluginService.js';
-import { getGradesForForm } from '../../services/quiz/gradingService.js';
+import { getGradesForResponses, questionGradeResultSchema } from '../../services/quiz/gradingService.js';
+import { z } from 'zod';
 
 
 export const unifiedExportResolvers = {
@@ -120,14 +121,20 @@ export const unifiedExportResolvers = {
           form.settings?.accessControl?.enabled || form.settings?.collectRespondentEmail
         );
 
-        // Native Quiz (epic #289): fetch persisted ResponseGrade rows so the
-        // export service can build the native gradebook columns. Cheap
-        // indexed lookup by formId — a no-op for the vast majority of forms
-        // that have never used quiz mode.
+        // Native Quiz (epic #289): fetch persisted ResponseGrade rows for
+        // exactly the responses being exported (after ids/filters have
+        // narrowed the set) so a selected or filtered export never loads
+        // grade details for responses it isn't going to render.
         const quizEnabled = !!form.settings?.quiz?.enabled;
-        const grades = await getGradesForForm(formId);
+        const grades = await getGradesForResponses(responses.map((r) => r.id));
         const quizGrades: Record<string, QuizGradeExportRow> = {};
+        const questionGradeResultArraySchema = z.array(questionGradeResultSchema);
         for (const grade of grades) {
+          // `detail` is persisted Json — validate it against the same schema
+          // saveGrade wrote it with, rather than trusting the cast. Malformed
+          // rows fall back to an empty question list instead of poisoning
+          // the per-question export columns.
+          const parsedDetail = questionGradeResultArraySchema.safeParse(grade.detail);
           quizGrades[grade.responseId] = {
             score: grade.score,
             maxScore: grade.maxScore,
@@ -135,7 +142,11 @@ export const unifiedExportResolvers = {
             passed: grade.passed,
             status: grade.status,
             gradedAt: grade.gradedAt,
-            detail: Array.isArray(grade.detail) ? (grade.detail as any) : [],
+            // `fieldType` is validated as a non-empty string by the shared
+            // schema (it's persisted from the FieldType enum by saveGrade,
+            // never authored freehand), so this narrows a runtime-checked
+            // string back to the enum type the export contract expects.
+            detail: parsedDetail.success ? (parsedDetail.data as unknown as QuestionGradeResult[]) : [],
           };
         }
 

--- a/apps/backend/src/graphql/resolvers/unifiedExport.ts
+++ b/apps/backend/src/graphql/resolvers/unifiedExport.ts
@@ -3,7 +3,7 @@ import { GRAPHQL_ERROR_CODES } from '@dculus/types/graphql.js';
 import { BetterAuthContext, requireAuth } from '../../middleware/better-auth-middleware.js';
 import { getFormById } from '../../services/formService.js';
 import { getAllResponsesByFormId } from '../../services/responseService.js';
-import { generateExportFile, ExportFormat } from '../../services/unifiedExportService.js';
+import { generateExportFile, ExportFormat, QuizGradeExportRow } from '../../services/unifiedExportService.js';
 import { uploadTemporaryFile } from '../../services/temporaryFileService.js';
 import { getFormSchemaFromHocuspocus } from '../../services/hocuspocus.js';
 import { deserializeFormSchema } from '@dculus/types';
@@ -11,18 +11,20 @@ import { ResponseFilter, applyResponseFilters } from '../../services/responseFil
 import { checkFormAccess, PermissionLevel } from './formSharing.js';
 import { logger } from '../../lib/logger.js';
 import * as pluginService from '../../services/pluginService.js';
+import { getGradesForForm } from '../../services/quiz/gradingService.js';
 
 
 export const unifiedExportResolvers = {
   Mutation: {
     generateFormResponseReport: async (
       _: any,
-      { formId, format, filters = [], filterLogic = 'AND', ids }: {
+      { formId, format, filters = [], filterLogic = 'AND', ids, includeQuizQuestionColumns = false }: {
         formId: string;
         format: 'EXCEL' | 'CSV';
         filters?: ResponseFilter[];
         filterLogic?: 'AND' | 'OR';
         ids?: string[];
+        includeQuizQuestionColumns?: boolean;
       },
       context: { auth: BetterAuthContext }
     ) => {
@@ -118,6 +120,25 @@ export const unifiedExportResolvers = {
           form.settings?.accessControl?.enabled || form.settings?.collectRespondentEmail
         );
 
+        // Native Quiz (epic #289): fetch persisted ResponseGrade rows so the
+        // export service can build the native gradebook columns. Cheap
+        // indexed lookup by formId — a no-op for the vast majority of forms
+        // that have never used quiz mode.
+        const quizEnabled = !!form.settings?.quiz?.enabled;
+        const grades = await getGradesForForm(formId);
+        const quizGrades: Record<string, QuizGradeExportRow> = {};
+        for (const grade of grades) {
+          quizGrades[grade.responseId] = {
+            score: grade.score,
+            maxScore: grade.maxScore,
+            percentage: grade.percentage,
+            passed: grade.passed,
+            status: grade.status,
+            gradedAt: grade.gradedAt,
+            detail: Array.isArray(grade.detail) ? (grade.detail as any) : [],
+          };
+        }
+
         // Generate export file using unified service
         const exportResult = await generateExportFile({
           formTitle: form.title,
@@ -126,6 +147,9 @@ export const unifiedExportResolvers = {
           format: exportFormat,
           pluginConfigs,
           includeRespondentEmail,
+          quizEnabled,
+          quizGrades,
+          includeQuizQuestionColumns,
         });
 
         logger.info(`${exportFormat.toUpperCase()} file generated, size: ${exportResult.buffer.length} bytes`);

--- a/apps/backend/src/graphql/schema.ts
+++ b/apps/backend/src/graphql/schema.ts
@@ -1584,6 +1584,9 @@ export const typeDefs = gql`
       filters: [ResponseFilterInput!]
       filterLogic: FilterLogic = AND
       ids: [ID!]
+      # Native Quiz (epic #289): emit one export column per graded question,
+      # headed by the question label. Ignored for non-quiz forms.
+      includeQuizQuestionColumns: Boolean = false
     ): ExportResult!
 
     # Analytics Mutations

--- a/apps/backend/src/services/__tests__/unifiedExportService.test.ts
+++ b/apps/backend/src/services/__tests__/unifiedExportService.test.ts
@@ -12,6 +12,9 @@ import {
   SpacingType,
   PageModeType,
   DEFAULT_THANK_YOU_CONTENT,
+  RadioField,
+  FillableFormFieldValidation,
+  type FieldGrading,
   type QuestionGradeResult,
 } from '@dculus/types';
 // Exposed by the exceljs mock above so tests can inspect exactly what was
@@ -590,7 +593,9 @@ describe('Unified Export Service', () => {
         'Score', 'Max Score', 'Percentage', 'Result', 'Grading Status', 'Graded At',
       ]);
       expect(dataRow.slice(3, 8)).toEqual(['7.5/10', '10', '75.0%', 'Pass', 'AUTO_GRADED']);
-      expect(dataRow[8]).toContain('2024');
+      // en-US, UTC — matches the explicit `timeZone: 'UTC'` in formatQuizGradedAt,
+      // so this is deterministic regardless of the host machine's local zone.
+      expect(dataRow[8]).toBe('01/01/2024, 12:34:56');
     });
 
     it('emits blank quiz cells for a quiz-enabled form when a response has no grade yet', async () => {
@@ -658,6 +663,19 @@ describe('Unified Export Service', () => {
     });
 
     describe('per-question columns', () => {
+      // Real @dculus/types field-class instances (mirroring
+      // deserializeFormField's pattern of assigning `grading` post-construction)
+      // rather than plain object literals cast with `as any`.
+      const radioFieldWithGrading = (
+        id: string,
+        label: string,
+        grading: FieldGrading
+      ): FormSchema['pages'][number]['fields'][number] => {
+        const field = new RadioField(id, label, '', '', '', new FillableFormFieldValidation(false), []);
+        (field as typeof field & { grading?: FieldGrading }).grading = grading;
+        return field;
+      };
+
       const quizSchema: FormSchema = {
         ...mockFormSchema,
         pages: [
@@ -666,24 +684,22 @@ describe('Unified Export Service', () => {
             title: 'Page 1',
             order: 0,
             fields: [
-              {
-                id: 'q1',
-                type: FieldType.RADIO_FIELD,
-                label: 'Capital of France?',
-                grading: { mode: 'exact', pointValue: 5, acceptedAnswers: ['Paris'] },
-              } as any,
-              {
-                id: 'q2',
-                type: FieldType.RADIO_FIELD,
-                label: 'Question 1',
-                grading: { mode: 'exact', pointValue: 5, acceptedAnswers: ['A'] },
-              } as any,
-              {
-                id: 'q3',
-                type: FieldType.RADIO_FIELD,
-                label: 'Question 1', // duplicate label — must not collide with q2's column
-                grading: { mode: 'exact', pointValue: 5, acceptedAnswers: ['B'] },
-              } as any,
+              radioFieldWithGrading('q1', 'Capital of France?', {
+                mode: 'exact',
+                pointValue: 5,
+                acceptedAnswers: ['Paris'],
+              }),
+              radioFieldWithGrading('q2', 'Question 1', {
+                mode: 'exact',
+                pointValue: 5,
+                acceptedAnswers: ['A'],
+              }),
+              radioFieldWithGrading('q3', 'Question 1', {
+                // duplicate label — must not collide with q2's column
+                mode: 'exact',
+                pointValue: 5,
+                acceptedAnswers: ['B'],
+              }),
             ],
           },
         ],
@@ -789,6 +805,81 @@ describe('Unified Export Service', () => {
           'Response ID', 'Submitted At', 'Tags',
           'Score', 'Max Score', 'Percentage', 'Result', 'Grading Status', 'Graded At',
         ]);
+      });
+
+      it('blanks the cell for a schema question the response grade has no detail entry for', async () => {
+        const quizGrades: Record<string, QuizGradeExportRow> = {
+          'resp-1': {
+            score: 5,
+            maxScore: 15,
+            percentage: 33.3,
+            passed: false,
+            status: 'AUTO_GRADED',
+            gradedAt: null,
+            // Only q1 graded — q2/q3 might have been added to the schema
+            // after this response was submitted.
+            detail: [buildDetail('q1', 'Capital of France?', 5, 5)],
+          },
+        };
+
+        await generateExportFile({
+          formTitle: 'Quiz Form',
+          responses: [quizResponse] as any,
+          formSchema: quizSchema,
+          format: 'excel',
+          quizEnabled: true,
+          quizGrades,
+          includeQuizQuestionColumns: true,
+        });
+
+        const worksheet = getLastWorkbook().worksheets[0];
+        const [dataRow] = worksheet.addRow.mock.calls[1];
+
+        expect(dataRow.slice(9, 12)).toEqual(['5/5', '', '']);
+      });
+
+      it('appends a trailing column, sorted by fieldId, for a graded question the schema does not contain', async () => {
+        const quizGrades: Record<string, QuizGradeExportRow> = {
+          'resp-1': {
+            score: 15,
+            maxScore: 25,
+            percentage: 60,
+            passed: true,
+            status: 'AUTO_GRADED',
+            gradedAt: null,
+            detail: [
+              buildDetail('q1', 'Capital of France?', 5, 5),
+              buildDetail('q2', 'Question 1', 5, 5),
+              buildDetail('q3', 'Question 1', 0, 5),
+              // Deleted/legacy field, absent from quizSchema entirely.
+              buildDetail('z-deleted-field', 'Old Removed Question', 5, 10),
+            ],
+          },
+        };
+
+        await generateExportFile({
+          formTitle: 'Quiz Form',
+          responses: [quizResponse] as any,
+          formSchema: quizSchema,
+          format: 'excel',
+          quizEnabled: true,
+          quizGrades,
+          includeQuizQuestionColumns: true,
+        });
+
+        const worksheet = getLastWorkbook().worksheets[0];
+        const [headerRow] = worksheet.addRow.mock.calls[0];
+        const [dataRow] = worksheet.addRow.mock.calls[1];
+
+        // Schema fields (q1, q2, q3) keep their order; the schema-unknown
+        // field is appended last regardless of its position in `detail`.
+        expect(headerRow.slice(9, 13)).toEqual([
+          'Capital of France?',
+          'Question 1',
+          'Question 1 (2)',
+          'Old Removed Question',
+        ]);
+        expect(dataRow.slice(9, 13)).toEqual(['5/5', '5/5', '0/5', '5/10']);
       });
     });
   });

--- a/apps/backend/src/services/__tests__/unifiedExportService.test.ts
+++ b/apps/backend/src/services/__tests__/unifiedExportService.test.ts
@@ -3,14 +3,37 @@ import {
   generateExportFile,
   generateExcelFilename,
   generateCsvFilename,
+  type QuizGradeExportRow,
 } from '../unifiedExportService.js';
-import { FormSchema, FieldType, ThemeType, SpacingType, PageModeType, DEFAULT_THANK_YOU_CONTENT } from '@dculus/types';
+import {
+  FormSchema,
+  FieldType,
+  ThemeType,
+  SpacingType,
+  PageModeType,
+  DEFAULT_THANK_YOU_CONTENT,
+  type QuestionGradeResult,
+} from '@dculus/types';
+// Exposed by the exceljs mock above so tests can inspect exactly what was
+// written to the workbook (see `__mockWorkbooks`).
+import * as ExcelJSMock from 'exceljs';
+const getLastWorkbook = () => (ExcelJSMock as any).__mockWorkbooks.at(-1);
 
 // Mock dependencies
+// `__mockWorkbooks` records every constructed workbook so tests can inspect
+// the exact header/row arrays passed to `worksheet.addRow` — needed for the
+// "byte-identical" acceptance test, which must assert on the generated
+// workbook rather than a buffer-size summary.
 vi.mock('exceljs', () => {
+  const mockWorkbooks: any[] = [];
+
   // Create a mock class for Workbook
   class MockWorkbook {
     worksheets: any[] = [];
+
+    constructor() {
+      mockWorkbooks.push(this);
+    }
 
     addWorksheet(name: string) {
       const mockWorksheet = {
@@ -36,6 +59,7 @@ vi.mock('exceljs', () => {
     default: {
       Workbook: MockWorkbook,
     },
+    __mockWorkbooks: mockWorkbooks,
   };
 });
 vi.mock('../plugins/exportRegistry.js', () => ({
@@ -132,6 +156,7 @@ describe('Unified Export Service', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    (ExcelJSMock as any).__mockWorkbooks.length = 0;
   });
 
   afterEach(() => {
@@ -294,7 +319,9 @@ describe('Unified Export Service', () => {
       expect(csvContent).toContain('option1; option2; option3');
     });
 
-    it('should include plugin data in CSV', async () => {
+    it('should export legacy quiz-grading metadata through the native quiz columns', async () => {
+      // Story 12/#301: legacy plugin metadata (no ResponseGrade row) must
+      // populate the SAME six native columns, not the old plugin's own set.
       const result = await generateExportFile({
         formTitle: 'Quiz Form',
         responses: mockResponses as any,
@@ -303,8 +330,10 @@ describe('Unified Export Service', () => {
       });
 
       const csvContent = result.buffer.toString('utf-8');
-      expect(csvContent).toContain('Quiz Score,Quiz Percentage,Quiz Status,Quiz Pass Threshold');
-      expect(csvContent).toContain('8/10,80.0,Pass,60%');
+      expect(csvContent).toContain('Score,Max Score,Percentage,Result,Grading Status,Graded At');
+      expect(csvContent).not.toContain('Quiz Score');
+      expect(csvContent).not.toContain('Quiz Pass Threshold');
+      expect(csvContent).toContain('8/10,10,80.0%,Pass,AUTO_GRADED,,John Doe');
     });
 
     it('should handle newlines in field values', async () => {
@@ -484,6 +513,283 @@ describe('Unified Export Service', () => {
       });
 
       expect(result.buffer).toBeInstanceOf(Buffer);
+    });
+  });
+
+  describe('Native Quiz gradebook columns (epic #289, Story 12/#301)', () => {
+    const plainResponses = [
+      {
+        id: 'resp-1',
+        data: { 'field-1': 'John Doe', 'field-2': 'john@example.com' },
+        submittedAt: 1704067200000,
+        metadata: {},
+      },
+      {
+        id: 'resp-2',
+        data: { 'field-1': 'Jane Smith', 'field-2': 'jane@example.com' },
+        submittedAt: '1706745600000',
+        metadata: {},
+      },
+    ];
+
+    it('CRITICAL: a non-quiz form export is byte-identical to before (CSV)', async () => {
+      const result = await generateExportFile({
+        formTitle: 'Plain Form',
+        responses: plainResponses as any,
+        formSchema: mockFormSchema,
+        format: 'csv',
+      });
+
+      const lines = result.buffer.toString('utf-8').split('\n');
+      expect(lines[0]).toBe('Response ID,Submitted At,Tags,Name,Email');
+      expect(lines).toHaveLength(3);
+    });
+
+    it('CRITICAL: a non-quiz form export is byte-identical to before (Excel workbook)', async () => {
+      await generateExportFile({
+        formTitle: 'Plain Form',
+        responses: plainResponses as any,
+        formSchema: mockFormSchema,
+        format: 'excel',
+      });
+
+      const worksheet = getLastWorkbook().worksheets[0];
+      const [headerRow] = worksheet.addRow.mock.calls[0];
+      expect(headerRow).toEqual(['Response ID', 'Submitted At', 'Tags', 'Name', 'Email']);
+      expect(worksheet.addRow.mock.calls).toHaveLength(3); // header + 2 responses
+    });
+
+    it('emits the six native columns for a quiz-enabled form using ResponseGrade data', async () => {
+      const quizGrades: Record<string, QuizGradeExportRow> = {
+        'resp-1': {
+          score: 7.5,
+          maxScore: 10,
+          percentage: 75,
+          passed: true,
+          status: 'AUTO_GRADED',
+          gradedAt: new Date('2024-01-01T12:34:56Z'),
+          detail: [],
+        },
+      };
+
+      await generateExportFile({
+        formTitle: 'Quiz Form',
+        responses: [plainResponses[0]] as any,
+        formSchema: mockFormSchema,
+        format: 'excel',
+        quizEnabled: true,
+        quizGrades,
+      });
+
+      const worksheet = getLastWorkbook().worksheets[0];
+      const [headerRow] = worksheet.addRow.mock.calls[0];
+      const [dataRow] = worksheet.addRow.mock.calls[1];
+
+      expect(headerRow.slice(0, 9)).toEqual([
+        'Response ID', 'Submitted At', 'Tags',
+        'Score', 'Max Score', 'Percentage', 'Result', 'Grading Status', 'Graded At',
+      ]);
+      expect(dataRow.slice(3, 8)).toEqual(['7.5/10', '10', '75.0%', 'Pass', 'AUTO_GRADED']);
+      expect(dataRow[8]).toContain('2024');
+    });
+
+    it('emits blank quiz cells for a quiz-enabled form when a response has no grade yet', async () => {
+      await generateExportFile({
+        formTitle: 'Quiz Form',
+        responses: plainResponses as any,
+        formSchema: mockFormSchema,
+        format: 'excel',
+        quizEnabled: true,
+      });
+
+      const worksheet = getLastWorkbook().worksheets[0];
+      const [dataRow1] = worksheet.addRow.mock.calls[1];
+      expect(dataRow1.slice(3, 9)).toEqual(['', '', '', '', '', '']);
+    });
+
+    it('never emits two parallel sets of quiz columns when both a ResponseGrade row and legacy metadata exist', async () => {
+      const responseWithBoth = [
+        {
+          ...plainResponses[0],
+          metadata: {
+            'quiz-grading': {
+              quizScore: 2,
+              totalMarks: 10,
+              percentage: 20,
+              gradedAt: '2023-01-01T00:00:00Z',
+              gradedBy: 'plugin',
+            },
+          },
+        },
+      ];
+      const quizGrades: Record<string, QuizGradeExportRow> = {
+        'resp-1': {
+          score: 9,
+          maxScore: 10,
+          percentage: 90,
+          passed: true,
+          status: 'RELEASED',
+          gradedAt: new Date('2024-06-01T00:00:00Z'),
+          detail: [],
+        },
+      };
+
+      const result = await generateExportFile({
+        formTitle: 'Quiz Form',
+        responses: responseWithBoth as any,
+        formSchema: mockFormSchema,
+        format: 'csv',
+        quizEnabled: true,
+        quizGrades,
+      });
+
+      const csvContent = result.buffer.toString('utf-8');
+      // The native ResponseGrade row wins outright — the legacy plugin
+      // metadata's 2/10 must never show up, and the old plugin's own
+      // 'Quiz Score' header must never appear alongside the native one.
+      const headerOccurrences = csvContent.split(
+        'Score,Max Score,Percentage,Result,Grading Status,Graded At'
+      ).length - 1;
+      expect(headerOccurrences).toBe(1);
+      expect(csvContent).toContain('9/10,10,90.0%,Pass,RELEASED');
+      expect(csvContent).not.toContain('2/10');
+      expect(csvContent).not.toContain('Quiz Score');
+      expect(csvContent).not.toContain('Quiz Pass Threshold');
+    });
+
+    describe('per-question columns', () => {
+      const quizSchema: FormSchema = {
+        ...mockFormSchema,
+        pages: [
+          {
+            id: 'page-1',
+            title: 'Page 1',
+            order: 0,
+            fields: [
+              {
+                id: 'q1',
+                type: FieldType.RADIO_FIELD,
+                label: 'Capital of France?',
+                grading: { mode: 'exact', pointValue: 5, acceptedAnswers: ['Paris'] },
+              } as any,
+              {
+                id: 'q2',
+                type: FieldType.RADIO_FIELD,
+                label: 'Question 1',
+                grading: { mode: 'exact', pointValue: 5, acceptedAnswers: ['A'] },
+              } as any,
+              {
+                id: 'q3',
+                type: FieldType.RADIO_FIELD,
+                label: 'Question 1', // duplicate label — must not collide with q2's column
+                grading: { mode: 'exact', pointValue: 5, acceptedAnswers: ['B'] },
+              } as any,
+            ],
+          },
+        ],
+      };
+
+      // Keyed to q1/q2/q3 (not field-1/field-2) so extractFieldInfo doesn't
+      // treat plainResponses' fields as orphan "Unknown field (deleted)"
+      // columns, which would throw off the column-count assertions below.
+      const quizResponse = {
+        id: 'resp-1',
+        data: { q1: 'Paris', q2: 'A', q3: 'B' },
+        submittedAt: 1704067200000,
+        metadata: {},
+      };
+
+      const buildDetail = (
+        fieldId: string,
+        fieldLabel: string,
+        pointsAwarded: number,
+        pointValue: number
+      ): QuestionGradeResult => ({
+        fieldId,
+        fieldLabel,
+        fieldType: FieldType.RADIO_FIELD,
+        mode: 'exact',
+        submittedValue: 'x',
+        acceptedAnswers: ['x'],
+        correct: pointsAwarded === pointValue,
+        pointsAwarded,
+        pointValue,
+        autoPointsAwarded: pointsAwarded,
+      });
+
+      it('emits one column per graded question headed by the question label, deduping collisions', async () => {
+        const quizGrades: Record<string, QuizGradeExportRow> = {
+          'resp-1': {
+            score: 10,
+            maxScore: 15,
+            percentage: 66.7,
+            passed: true,
+            status: 'AUTO_GRADED',
+            gradedAt: new Date('2024-01-01T00:00:00Z'),
+            detail: [
+              buildDetail('q1', 'Capital of France?', 5, 5),
+              buildDetail('q2', 'Question 1', 5, 5),
+              buildDetail('q3', 'Question 1', 0, 5),
+            ],
+          },
+        };
+
+        await generateExportFile({
+          formTitle: 'Quiz Form',
+          responses: [quizResponse] as any,
+          formSchema: quizSchema,
+          format: 'excel',
+          quizEnabled: true,
+          quizGrades,
+          includeQuizQuestionColumns: true,
+        });
+
+        const worksheet = getLastWorkbook().worksheets[0];
+        const [headerRow] = worksheet.addRow.mock.calls[0];
+        const [dataRow] = worksheet.addRow.mock.calls[1];
+
+        // 3 base + 6 quiz + 3 per-question columns before the plain form-field columns
+        expect(headerRow).toHaveLength(15);
+        expect(headerRow.slice(9, 12)).toEqual([
+          'Capital of France?',
+          'Question 1',
+          'Question 1 (2)',
+        ]);
+        expect(dataRow.slice(9, 12)).toEqual(['5/5', '5/5', '0/5']);
+      });
+
+      it('omits per-question columns when the toggle is off', async () => {
+        const quizGrades: Record<string, QuizGradeExportRow> = {
+          'resp-1': {
+            score: 5,
+            maxScore: 5,
+            percentage: 100,
+            passed: true,
+            status: 'AUTO_GRADED',
+            gradedAt: null,
+            detail: [buildDetail('q1', 'Capital of France?', 5, 5)],
+          },
+        };
+
+        await generateExportFile({
+          formTitle: 'Quiz Form',
+          responses: [quizResponse] as any,
+          formSchema: quizSchema,
+          format: 'excel',
+          quizEnabled: true,
+          quizGrades,
+        });
+
+        const worksheet = getLastWorkbook().worksheets[0];
+        const [headerRow] = worksheet.addRow.mock.calls[0];
+
+        // 3 base + 6 quiz + 3 plain form-field columns — no per-question block
+        expect(headerRow).toHaveLength(12);
+        expect(headerRow.slice(0, 9)).toEqual([
+          'Response ID', 'Submitted At', 'Tags',
+          'Score', 'Max Score', 'Percentage', 'Result', 'Grading Status', 'Graded At',
+        ]);
+      });
     });
   });
 });

--- a/apps/backend/src/services/quiz/gradingService.ts
+++ b/apps/backend/src/services/quiz/gradingService.ts
@@ -25,7 +25,7 @@ const jsonSubmittedValueSchema = z.preprocess(
   z.json()
 );
 
-const questionGradeResultSchema = z.object({
+export const questionGradeResultSchema = z.object({
   fieldId: z.string().min(1),
   fieldLabel: z.string(),
   fieldType: z.string(),
@@ -135,6 +135,19 @@ export const getGradesForForm = async (
   formId: string,
   opts?: { status?: GradeStatus }
 ): Promise<ResponseGradeRow[]> => responseGradeRepository.findManyByFormId(formId, opts);
+
+/**
+ * Grades for a specific set of responses (e.g. the final, filtered/selected
+ * response set an export is about to render) rather than every grade a form
+ * has ever accumulated. Empty input short-circuits to avoid an unbounded
+ * `IN ()` query.
+ */
+export const getGradesForResponses = async (
+  responseIds: string[]
+): Promise<ResponseGradeRow[]> => {
+  if (responseIds.length === 0) return [];
+  return responseGradeRepository.findMany({ where: { responseId: { in: responseIds } } });
+};
 
 /**
  * Read `detail` back out as `QuestionGradeResult[]`. Storage is `Json`, so

--- a/apps/backend/src/services/unifiedExportService.ts
+++ b/apps/backend/src/services/unifiedExportService.ts
@@ -1,16 +1,39 @@
 import ExcelJS from 'exceljs';
 import { parsePhoneNumberFromString } from 'libphonenumber-js/max';
-import { FormResponse, FormSchema, FieldType } from '@dculus/types';
+import { FormResponse, FormSchema, FieldType, QuestionGradeResult } from '@dculus/types';
 import {
   getPluginTypesWithData,
   getPluginExport,
   pluginTypeFromMetadataKey,
 } from '../plugins/core/exportRegistry.js';
 
+// TODO(#289): remove once Story 14 (#303, plugin deprecation) lands. Native
+// quiz columns are now built directly below from ResponseGrade / legacy
+// metadata, and the quiz-grading key is explicitly excluded from the generic
+// plugin-column loop (see LEGACY_QUIZ_METADATA_KEY) — this import no longer
+// contributes any export columns. It stays only so other code that still
+// expects the quiz plugin type to be registered keeps working until #303
+// removes it at the source.
 import '../plugins/quiz/index.js';
 import { logger } from '../lib/logger.js';
 
 export type ExportFormat = 'excel' | 'csv';
+
+/**
+ * Native Quiz (epic #289, Story 12/#301): a response's persisted grade,
+ * trimmed to exactly what the export needs. Build this from `ResponseGrade`
+ * rows (see `services/quiz/gradingService.getGradesForForm`) keyed by
+ * `responseId`.
+ */
+export interface QuizGradeExportRow {
+  score: number;
+  maxScore: number;
+  percentage: number;
+  passed: boolean;
+  status: string;
+  gradedAt: Date | string | null;
+  detail: QuestionGradeResult[];
+}
 
 export interface UnifiedExportData {
   formTitle: string;
@@ -30,6 +53,19 @@ export interface UnifiedExportData {
    * forms are anonymous and `response.respondentEmail` is always null there.
    */
   includeRespondentEmail?: boolean;
+  /**
+   * Native Quiz (epic #289): whether `form.settings.quiz?.enabled` is true.
+   * Native gradebook columns are emitted when this is true OR when any
+   * response carries a `quizGrades` entry or legacy quiz-grading plugin
+   * metadata — see `buildQuizExportPlan`. Absent/false with no quiz data
+   * anywhere in the responses means zero quiz columns, byte-identical to a
+   * form that never had quiz mode at all.
+   */
+  quizEnabled?: boolean;
+  /** responseId -> persisted ResponseGrade row, for quiz-enabled forms. */
+  quizGrades?: Record<string, QuizGradeExportRow>;
+  /** Emit one column per graded question, headed by the question label. */
+  includeQuizQuestionColumns?: boolean;
 }
 
 export interface ExportResult {
@@ -123,6 +159,247 @@ const escapeCsvFieldName = (fieldName: string): string => {
   return fieldName;
 };
 
+// ---------------------------------------------------------------------------
+// Native Quiz gradebook columns (epic #289, Story 12/#301)
+// ---------------------------------------------------------------------------
+
+// The quiz-grading plugin stored its metadata under this bare key, or
+// `${LEGACY_QUIZ_METADATA_KEY}:${pluginId}` for instance-scoped configs (see
+// apps/backend/src/plugins/quiz/types.ts). Excluded from the generic
+// plugin-column loop below so legacy data never produces a second set of
+// quiz columns alongside the native ones.
+const LEGACY_QUIZ_METADATA_KEY = 'quiz-grading';
+
+const isLegacyQuizMetadataKey = (key: string): boolean =>
+  key === LEGACY_QUIZ_METADATA_KEY || key.startsWith(`${LEGACY_QUIZ_METADATA_KEY}:`);
+
+const hasLegacyQuizMetadata = (responses: FormResponse[]): boolean =>
+  responses.some(
+    (r) => r.metadata && Object.keys(r.metadata).some(isLegacyQuizMetadataKey)
+  );
+
+interface NormalizedQuizQuestion {
+  fieldId: string;
+  label: string;
+  pointsAwarded: number;
+  pointValue: number;
+}
+
+interface NormalizedQuizGrade {
+  score: number;
+  maxScore: number;
+  percentage: number;
+  passed: boolean;
+  status: string;
+  gradedAt: Date | string | null;
+  questions: NormalizedQuizQuestion[];
+}
+
+const normalizeNativeGrade = (row: QuizGradeExportRow): NormalizedQuizGrade => ({
+  score: row.score,
+  maxScore: row.maxScore,
+  percentage: row.percentage,
+  passed: row.passed,
+  status: row.status,
+  gradedAt: row.gradedAt,
+  questions: (row.detail ?? []).map((q) => ({
+    fieldId: q.fieldId,
+    label: q.fieldLabel,
+    pointsAwarded: q.pointsAwarded,
+    pointValue: q.pointValue,
+  })),
+});
+
+// Legacy plugin metadata (QuizGradingMetadata, @dculus/types) predates
+// ResponseGrade and uses a different shape/status vocabulary — map it onto
+// the same fields the native path produces so a single set of columns
+// covers both. 'plugin' grading was always fully automatic; 'manual' meant
+// a human had entered the score, closest today to REVIEWED.
+const normalizeLegacyQuizMetadata = (raw: any): NormalizedQuizGrade => {
+  const passThreshold = typeof raw?.passThreshold === 'number' ? raw.passThreshold : 60;
+  const percentage = typeof raw?.percentage === 'number' ? raw.percentage : 0;
+  return {
+    score: typeof raw?.quizScore === 'number' ? raw.quizScore : 0,
+    maxScore: typeof raw?.totalMarks === 'number' ? raw.totalMarks : 0,
+    percentage,
+    passed: percentage >= passThreshold,
+    status: raw?.gradedBy === 'manual' ? 'REVIEWED' : 'AUTO_GRADED',
+    gradedAt: raw?.gradedAt ?? null,
+    questions: Array.isArray(raw?.fieldResults)
+      ? raw.fieldResults.map((fr: any) => ({
+          fieldId: fr.fieldId,
+          label: fr.fieldLabel || fr.fieldId,
+          pointsAwarded: typeof fr.marksAwarded === 'number' ? fr.marksAwarded : 0,
+          pointValue: typeof fr.maxMarks === 'number' ? fr.maxMarks : 0,
+        }))
+      : [],
+  };
+};
+
+/**
+ * Resolve the single grade a response should be exported with. A
+ * ResponseGrade row always wins over legacy metadata — once a response has
+ * a native grade it owns the export row, and the two are never combined.
+ */
+const resolveQuizGrade = (
+  response: FormResponse,
+  quizGrades: Record<string, QuizGradeExportRow>
+): NormalizedQuizGrade | null => {
+  const native = quizGrades[response.id];
+  if (native) return normalizeNativeGrade(native);
+
+  const metadata = response.metadata;
+  if (!metadata) return null;
+  const legacyKey = Object.keys(metadata).filter(isLegacyQuizMetadataKey).sort()[0];
+  if (!legacyKey || !metadata[legacyKey]) return null;
+  return normalizeLegacyQuizMetadata(metadata[legacyKey]);
+};
+
+const QUIZ_BASE_HEADERS = [
+  'Score',
+  'Max Score',
+  'Percentage',
+  'Result',
+  'Grading Status',
+  'Graded At',
+];
+
+const formatQuizGradedAt = (value: Date | string | null): string => {
+  if (!value) return '';
+  const date = value instanceof Date ? value : new Date(value);
+  if (isNaN(date.getTime())) return '';
+  return date.toLocaleString('en-US', {
+    timeZone: 'UTC',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+};
+
+const quizBaseValues = (grade: NormalizedQuizGrade | null): string[] => {
+  if (!grade) return ['', '', '', '', '', ''];
+  return [
+    `${grade.score}/${grade.maxScore}`,
+    `${grade.maxScore}`,
+    `${grade.percentage.toFixed(1)}%`,
+    grade.passed ? 'Pass' : 'Fail',
+    grade.status,
+    formatQuizGradedAt(grade.gradedAt),
+  ];
+};
+
+/** Disambiguates repeated question labels: first occurrence unchanged, then " (2)", " (3)", ... */
+const dedupeLabel = (label: string, seen: Map<string, number>): string => {
+  const count = (seen.get(label) ?? 0) + 1;
+  seen.set(label, count);
+  return count === 1 ? label : `${label} (${count})`;
+};
+
+/**
+ * Stable per-question column order: schema field order first (so re-running
+ * an export keeps columns in place as new responses arrive), then any
+ * graded fieldId the schema doesn't know about (deleted fields, or legacy
+ * plugin data for a field that's since been removed).
+ */
+const buildQuizQuestionColumns = (
+  formSchema: FormSchema,
+  grades: NormalizedQuizGrade[]
+): Array<{ fieldId: string; header: string }> => {
+  const ordered: Array<{ fieldId: string; label: string }> = [];
+  const seenIds = new Set<string>();
+
+  formSchema.pages.forEach((page) => {
+    page.fields.forEach((field) => {
+      const grading = (field as any).grading;
+      if (grading && field.id && 'label' in field && (field as any).label) {
+        ordered.push({ fieldId: field.id, label: (field as any).label });
+        seenIds.add(field.id);
+      }
+    });
+  });
+
+  grades.forEach((grade) => {
+    grade.questions.forEach((q) => {
+      if (!seenIds.has(q.fieldId)) {
+        ordered.push({ fieldId: q.fieldId, label: q.label });
+        seenIds.add(q.fieldId);
+      }
+    });
+  });
+
+  const seenLabels = new Map<string, number>();
+  return ordered.map(({ fieldId, label }) => ({
+    fieldId,
+    header: dedupeLabel(label, seenLabels),
+  }));
+};
+
+const quizQuestionValues = (
+  grade: NormalizedQuizGrade | null,
+  columns: Array<{ fieldId: string }>
+): string[] =>
+  columns.map(({ fieldId }) => {
+    const q = grade?.questions.find((question) => question.fieldId === fieldId);
+    return q ? `${q.pointsAwarded}/${q.pointValue}` : '';
+  });
+
+interface QuizExportPlan {
+  emit: boolean;
+  headers: string[];
+  questionColumns: Array<{ fieldId: string; header: string }>;
+  gradesByResponseId: Map<string, NormalizedQuizGrade | null>;
+}
+
+/**
+ * Decides whether this export gets native quiz columns at all, and if so
+ * builds the header list and a per-response lookup of the normalized grade
+ * to render. Emission is gated on `quizEnabled` OR the presence of actual
+ * quiz data (native or legacy) in the given responses, so a plugin-graded
+ * form keeps exporting its (now-native-shaped) columns even if
+ * `form.settings.quiz` was never turned on.
+ */
+const buildQuizExportPlan = (
+  formSchema: FormSchema,
+  responses: FormResponse[],
+  data: Pick<UnifiedExportData, 'quizEnabled' | 'quizGrades' | 'includeQuizQuestionColumns'>
+): QuizExportPlan => {
+  const quizGrades = data.quizGrades ?? {};
+  const emit =
+    !!data.quizEnabled || Object.keys(quizGrades).length > 0 || hasLegacyQuizMetadata(responses);
+
+  if (!emit) {
+    return { emit: false, headers: [], questionColumns: [], gradesByResponseId: new Map() };
+  }
+
+  const gradesByResponseId = new Map<string, NormalizedQuizGrade | null>();
+  responses.forEach((r) => gradesByResponseId.set(r.id, resolveQuizGrade(r, quizGrades)));
+
+  const questionColumns = data.includeQuizQuestionColumns
+    ? buildQuizQuestionColumns(
+        formSchema,
+        Array.from(gradesByResponseId.values()).filter(
+          (g): g is NormalizedQuizGrade => !!g
+        )
+      )
+    : [];
+
+  return {
+    emit: true,
+    headers: [...QUIZ_BASE_HEADERS, ...questionColumns.map((c) => c.header)],
+    questionColumns,
+    gradesByResponseId,
+  };
+};
+
+const quizRowValues = (plan: QuizExportPlan, responseId: string): string[] => {
+  const grade = plan.gradesByResponseId.get(responseId) ?? null;
+  return [...quizBaseValues(grade), ...quizQuestionValues(grade, plan.questionColumns)];
+};
+
 // Extract field information from responses or schema
 const extractFieldInfo = (
   formSchema: FormSchema,
@@ -207,12 +484,19 @@ const generateCsvContent = (data: UnifiedExportData): string => {
     responses
   );
 
-  // Get plugin types that have data in any response
-  const activePluginTypes = getPluginTypesWithData(responses);
+  const quizPlan = buildQuizExportPlan(formSchema, responses, data);
+
+  // Get plugin types that have data in any response — quiz-grading is
+  // handled natively above (quizPlan) and excluded here so it never
+  // produces a second set of quiz columns.
+  const activePluginTypes = getPluginTypesWithData(responses).filter(
+    (key) => pluginTypeFromMetadataKey(key) !== LEGACY_QUIZ_METADATA_KEY
+  );
 
   // Build CSV header
   const headers = ['Response ID', 'Submitted At', 'Tags'];
   if (includeRespondentEmail) headers.push('Respondent Email');
+  quizPlan.headers.forEach((h) => headers.push(escapeCsvFieldName(h)));
 
   // Add plugin columns — use getColumnsWithConfig when available and config is present
   // activePluginTypes is now a list of metadata keys (e.g. 'quiz-grading:pluginId')
@@ -267,6 +551,12 @@ const generateCsvContent = (data: UnifiedExportData): string => {
     row.push(escapeCsvFieldName((response.tags ?? []).map((t) => t.name).join(', ')));
     if (includeRespondentEmail) row.push(escapeCsvFieldName(response.respondentEmail || ''));
 
+    if (quizPlan.emit) {
+      quizRowValues(quizPlan, response.id).forEach((value) => {
+        row.push(escapeCsvFieldName(value));
+      });
+    }
+
     // Add plugin data
     activePluginTypes.forEach((metadataKey) => {
       const pluginType = pluginTypeFromMetadataKey(metadataKey);
@@ -319,7 +609,7 @@ const generateCsvContent = (data: UnifiedExportData): string => {
   }, 0);
 
   logger.info(
-    `Unified Export - Generated CSV with ${responses.length} rows and ${headers.length} columns (${pluginColumnCount} plugin columns)`
+    `Unified Export - Generated CSV with ${responses.length} rows and ${headers.length} columns (${pluginColumnCount} plugin columns, ${quizPlan.headers.length} quiz columns)`
   );
   return rows.join('\n');
 };
@@ -334,8 +624,14 @@ const generateExcelContent = async (
     responses
   );
 
-  // Get plugin types that have data in any response
-  const activePluginTypes = getPluginTypesWithData(responses);
+  const quizPlan = buildQuizExportPlan(formSchema, responses, data);
+
+  // Get plugin types that have data in any response — quiz-grading is
+  // handled natively above (quizPlan) and excluded here so it never
+  // produces a second set of quiz columns.
+  const activePluginTypes = getPluginTypesWithData(responses).filter(
+    (key) => pluginTypeFromMetadataKey(key) !== LEGACY_QUIZ_METADATA_KEY
+  );
 
   // Create workbook and worksheet
   const workbook = new ExcelJS.Workbook();
@@ -344,6 +640,7 @@ const generateExcelContent = async (
   // Build headers
   const headers = ['Response ID', 'Submitted At', 'Tags'];
   if (includeRespondentEmail) headers.push('Respondent Email');
+  headers.push(...quizPlan.headers);
 
   // Add plugin columns to headers — use getColumnsWithConfig when available and config is present
   activePluginTypes.forEach((metadataKey) => {
@@ -399,6 +696,10 @@ const generateExcelContent = async (
     );
     rowData.push((response.tags ?? []).map((t) => t.name).join(', '));
     if (includeRespondentEmail) rowData.push(response.respondentEmail || '');
+
+    if (quizPlan.emit) {
+      rowData.push(...quizRowValues(quizPlan, response.id));
+    }
 
     // Add plugin data
     activePluginTypes.forEach((metadataKey) => {
@@ -458,10 +759,10 @@ const generateExcelContent = async (
         : pluginExport.getColumns();
     return count + cols.length;
   }, 0);
-  const totalColumns = 3 + pluginColumnCount + orderedFieldIds.length; // 3 for Response ID + Submitted At + Tags
+  const totalColumns = 3 + pluginColumnCount + quizPlan.headers.length + orderedFieldIds.length; // 3 for Response ID + Submitted At + Tags
 
   logger.info(
-    `Unified Export - Generated Excel with ${responses.length} rows and ${totalColumns} columns (${pluginColumnCount} plugin columns)`
+    `Unified Export - Generated Excel with ${responses.length} rows and ${totalColumns} columns (${pluginColumnCount} plugin columns, ${quizPlan.headers.length} quiz columns)`
   );
 
   // Generate buffer

--- a/apps/backend/src/services/unifiedExportService.ts
+++ b/apps/backend/src/services/unifiedExportService.ts
@@ -1,5 +1,6 @@
 import ExcelJS from 'exceljs';
 import { parsePhoneNumberFromString } from 'libphonenumber-js/max';
+import { z } from 'zod';
 import { FormResponse, FormSchema, FieldType, QuestionGradeResult } from '@dculus/types';
 import {
   getPluginTypesWithData,
@@ -210,29 +211,48 @@ const normalizeNativeGrade = (row: QuizGradeExportRow): NormalizedQuizGrade => (
   })),
 });
 
-// Legacy plugin metadata (QuizGradingMetadata, @dculus/types) predates
-// ResponseGrade and uses a different shape/status vocabulary — map it onto
-// the same fields the native path produces so a single set of columns
-// covers both. 'plugin' grading was always fully automatic; 'manual' meant
-// a human had entered the score, closest today to REVIEWED.
-const normalizeLegacyQuizMetadata = (raw: any): NormalizedQuizGrade => {
-  const passThreshold = typeof raw?.passThreshold === 'number' ? raw.passThreshold : 60;
-  const percentage = typeof raw?.percentage === 'number' ? raw.percentage : 0;
+// Legacy plugin metadata (QuizGradingMetadata, @dculus/types) is untrusted
+// persisted JSON — validate it with Zod rather than trusting an `any` cast.
+// Invalid/missing fields fall back to safe defaults instead of throwing, the
+// same "drop, don't crash" posture as sanitizeFieldGrading in @dculus/types.
+const legacyQuizFieldResultSchema = z.object({
+  fieldId: z.string(),
+  fieldLabel: z.string().optional(),
+  marksAwarded: z.number().default(0),
+  maxMarks: z.number().default(0),
+});
+
+const legacyQuizMetadataSchema = z.object({
+  quizScore: z.number().default(0),
+  totalMarks: z.number().default(0),
+  percentage: z.number().default(0),
+  passThreshold: z.number().default(60),
+  gradedAt: z.union([z.string(), z.date()]).nullish(),
+  gradedBy: z.enum(['plugin', 'manual']).optional(),
+  fieldResults: z.array(legacyQuizFieldResultSchema).default([]),
+});
+
+// Legacy plugin metadata predates ResponseGrade and uses a different
+// shape/status vocabulary — map it onto the same fields the native path
+// produces so a single set of columns covers both. 'plugin' grading was
+// always fully automatic; 'manual' meant a human had entered the score,
+// closest today to REVIEWED.
+const normalizeLegacyQuizMetadata = (raw: unknown): NormalizedQuizGrade => {
+  const parsed = legacyQuizMetadataSchema.safeParse(raw);
+  const data = parsed.success ? parsed.data : legacyQuizMetadataSchema.parse({});
   return {
-    score: typeof raw?.quizScore === 'number' ? raw.quizScore : 0,
-    maxScore: typeof raw?.totalMarks === 'number' ? raw.totalMarks : 0,
-    percentage,
-    passed: percentage >= passThreshold,
-    status: raw?.gradedBy === 'manual' ? 'REVIEWED' : 'AUTO_GRADED',
-    gradedAt: raw?.gradedAt ?? null,
-    questions: Array.isArray(raw?.fieldResults)
-      ? raw.fieldResults.map((fr: any) => ({
-          fieldId: fr.fieldId,
-          label: fr.fieldLabel || fr.fieldId,
-          pointsAwarded: typeof fr.marksAwarded === 'number' ? fr.marksAwarded : 0,
-          pointValue: typeof fr.maxMarks === 'number' ? fr.maxMarks : 0,
-        }))
-      : [],
+    score: data.quizScore,
+    maxScore: data.totalMarks,
+    percentage: data.percentage,
+    passed: data.percentage >= data.passThreshold,
+    status: data.gradedBy === 'manual' ? 'REVIEWED' : 'AUTO_GRADED',
+    gradedAt: data.gradedAt ?? null,
+    questions: data.fieldResults.map((fr) => ({
+      fieldId: fr.fieldId,
+      label: fr.fieldLabel || fr.fieldId,
+      pointsAwarded: fr.marksAwarded,
+      pointValue: fr.maxMarks,
+    })),
   };
 };
 
@@ -281,7 +301,7 @@ const formatQuizGradedAt = (value: Date | string | null): string => {
 };
 
 const quizBaseValues = (grade: NormalizedQuizGrade | null): string[] => {
-  if (!grade) return ['', '', '', '', '', ''];
+  if (!grade) return QUIZ_BASE_HEADERS.map(() => '');
   return [
     `${grade.score}/${grade.maxScore}`,
     `${grade.maxScore}`,
@@ -322,14 +342,21 @@ const buildQuizQuestionColumns = (
     });
   });
 
+  // Fields the schema doesn't know about (deleted fields, or legacy data for
+  // a field that's since been removed) — sorted by fieldId so their column
+  // order is deterministic regardless of response/grade iteration order,
+  // which changes between a full export and a filtered/selected one.
+  const unknown: Array<{ fieldId: string; label: string }> = [];
   grades.forEach((grade) => {
     grade.questions.forEach((q) => {
       if (!seenIds.has(q.fieldId)) {
-        ordered.push({ fieldId: q.fieldId, label: q.label });
+        unknown.push({ fieldId: q.fieldId, label: q.label });
         seenIds.add(q.fieldId);
       }
     });
   });
+  unknown.sort((a, b) => a.fieldId.localeCompare(b.fieldId));
+  ordered.push(...unknown);
 
   const seenLabels = new Map<string, number>();
   return ordered.map(({ fieldId, label }) => ({
@@ -341,11 +368,17 @@ const buildQuizQuestionColumns = (
 const quizQuestionValues = (
   grade: NormalizedQuizGrade | null,
   columns: Array<{ fieldId: string }>
-): string[] =>
-  columns.map(({ fieldId }) => {
-    const q = grade?.questions.find((question) => question.fieldId === fieldId);
+): string[] => {
+  if (!grade) return columns.map(() => '');
+  // Indexed once per response rather than re-scanning `questions` for every
+  // column — matters once a quiz has many graded questions and exports can
+  // run to tens of thousands of responses.
+  const byFieldId = new Map(grade.questions.map((q) => [q.fieldId, q]));
+  return columns.map(({ fieldId }) => {
+    const q = byFieldId.get(fieldId);
     return q ? `${q.pointsAwarded}/${q.pointValue}` : '';
   });
+};
 
 interface QuizExportPlan {
   emit: boolean;
@@ -759,10 +792,8 @@ const generateExcelContent = async (
         : pluginExport.getColumns();
     return count + cols.length;
   }, 0);
-  const totalColumns = 3 + pluginColumnCount + quizPlan.headers.length + orderedFieldIds.length; // 3 for Response ID + Submitted At + Tags
-
   logger.info(
-    `Unified Export - Generated Excel with ${responses.length} rows and ${totalColumns} columns (${pluginColumnCount} plugin columns, ${quizPlan.headers.length} quiz columns)`
+    `Unified Export - Generated Excel with ${responses.length} rows and ${headers.length} columns (${pluginColumnCount} plugin columns, ${quizPlan.headers.length} quiz columns)`
   );
 
   // Generate buffer


### PR DESCRIPTION
Closes #301

## Summary
- Native gradebook columns in Excel/CSV export, sourced from `ResponseGrade` instead of the `quiz-grading` plugin's export registry: **Score** (`8/10`), **Max Score**, **Percentage**, **Result** (Pass/Fail), **Grading Status**, **Graded At**.
- Optional per-question points column set behind an `includeQuizQuestionColumns` toggle — one column per graded question headed by the question label, with duplicate labels disambiguated (`Question 1`, `Question 1 (2)`, ...).
- Columns are emitted only when the form has quiz mode enabled (`form.settings.quiz.enabled`) or the responses being exported actually carry quiz data (native `ResponseGrade` rows or legacy plugin metadata) — a non-quiz form's export is byte-identical to before.
- Responses graded by the old plugin (no `ResponseGrade` row) are read from legacy `metadata['quiz-grading'...]` and rendered through the **same** six columns — never a second parallel set. The plugin's own `quiz-grading` export columns are explicitly excluded from the generic plugin-column loop to guarantee this.
- `import '../plugins/quiz/index.js'` stays in `unifiedExportService.ts` with a `TODO(#289)` — Story 14 (#303, plugin deprecation) hasn't landed yet, so removing it now would be premature.

## Test plan
- [x] `pnpm --filter backend exec tsc --noEmit`
- [x] `pnpm type-check` (all workspaces)
- [x] `pnpm test:unit` (3143 backend tests pass)
- [x] New tests in `unifiedExportService.test.ts`: byte-identical non-quiz export (CSV + inspected Excel workbook), native ResponseGrade columns, legacy-metadata fallback through the same columns, no-double-columns when both a grade row and legacy metadata exist, per-question toggle with duplicate-label dedup
- [x] Resolver test updated/added in `unifiedExport.test.ts` to verify `quizEnabled`/`quizGrades`/`includeQuizQuestionColumns` wiring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added native quiz grading details to CSV and Excel response exports.
  - Quiz exports now include scores, percentages, pass status, grading dates, and related details.
  - Added an option to include one export column for each graded quiz question.
  - Quiz question columns maintain consistent ordering and distinguish duplicate question labels.
  - Native quiz grades take precedence when legacy quiz data is also present.
  - Non-quiz exports remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->